### PR TITLE
Fix all project warnings, specify nullability

### DIFF
--- a/lottie-ios/Classes/LAAnimationView.m
+++ b/lottie-ios/Classes/LAAnimationView.m
@@ -386,9 +386,10 @@ const NSTimeInterval singleFrameTimeValue = 1.0 / 60.0;
   newChild.childView = view;
   
   if (!layer) {
-    // TODO Throw Error
-    [self.layer addSublayer:view.layer];
-    newChild.layer = self.layer;
+    NSException* myException = [NSException exceptionWithName:@"LayerNotFoundException"
+                                                       reason:@"The required layer was not specified."
+                                                     userInfo:nil];
+    @throw myException;
   } else {
     newChild.layer = layerObject;
     [layerObject.superlayer insertSublayer:view.layer above:layerObject];

--- a/lottie-ios/Classes/LAAnimationView_Internal.h
+++ b/lottie-ios/Classes/LAAnimationView_Internal.h
@@ -14,7 +14,7 @@ typedef enum : NSUInteger {
 
 @interface LAAnimationState : NSObject
 
-- (instancetype)initWithDuration:(CGFloat)duration layer:(CALayer *)layer;
+- (_Nonnull instancetype)initWithDuration:(CGFloat)duration layer:( CALayer * _Nullable)layer;
 
 - (void)setAnimationIsPlaying:(BOOL)animationIsPlaying;
 - (void)setAnimationDoesLoop:(BOOL)loopAnimation;
@@ -29,14 +29,14 @@ typedef enum : NSUInteger {
 @property (nonatomic, readonly) CGFloat animationDuration;
 @property (nonatomic, readonly) CGFloat animationSpeed;
 
-@property (nonatomic, readonly) CALayer *layer;
+@property (nonatomic, readonly) CALayer * _Nullable layer;
 
 @end
 
 @interface LAAnimationView ()
 
-@property (nonatomic, readonly) LAComposition *sceneModel;
-@property (nonatomic, strong) LAAnimationState *animationState;
+@property (nonatomic, readonly) LAComposition * _Nonnull sceneModel;
+@property (nonatomic, strong) LAAnimationState *_Nonnull animationState;
 @property (nonatomic, copy, nullable) LAAnimationCompletionBlock completionBlock;
 
 @end

--- a/lottie-ios/Classes/PublicHeaders/LAAnimationTransitionController.h
+++ b/lottie-ios/Classes/PublicHeaders/LAAnimationTransitionController.h
@@ -22,22 +22,19 @@
 
 @interface LAAnimationTransitionController : NSObject <UIViewControllerAnimatedTransitioning>
 
-/** Initializer
+/**
+ The initializer to create a new transition animation.
  
- @param NSString *animation
-    The name of the Lottie Animation to load for the transition
+ @param animation The name of the Lottie Animation to load for the transition
  
- @param NSString *fromLayer
-    The name of the custom layer to mask the fromVC screenshot with.
-    If no layer is specified then the screenshot is added behind the Lottie Animation
+ @param fromLayer The name of the custom layer to mask the fromVC screenshot with. 
+ If no layer is specified then the screenshot is added behind the Lottie Animation
  
- @param NSString *toLayer
-    The name of the custom layer to mask the toVC screenshot with.
-    If no layer is specified then the screenshot is added behind the Lottie Animation
-    and a fade transition is performed along with the Lottie animation.
+ @param toLayer The name of the custom layer to mask the toVC screenshot with.
+ If no layer is specified then the screenshot is added behind the Lottie Animation
+ and a fade transition is performed along with the Lottie animation.
 
  */
-
 - (instancetype)initWithAnimationNamed:(NSString *)animation
                         fromLayerNamed:(NSString *)fromLayer
                           toLayerNamed:(NSString *)toLayer;


### PR DESCRIPTION
Hey guys! Thanks for accepting the first PR. Taking a deeper look into the source, I found some semantic warnings that are all resolved using this patch. Here is what's included:
- [x] Resolve docs warnings by normalizing them to the Apple docs recommendation
- [x] Resolve the `TODO` regarding throwing an exception when no layer is specified
- [x] Add missing nullability-specifiers to the `LAAnimationState` class

Some additional notes:
- We should try to document all public headers, including the class interfaces, properties and methods
- There should be a `Lottie.framework` in the releases tab for easier integration
- I've made [Ti.Lottie](https://github.com/hansemannn/ti.lottie), a native module for the cross-platform Titanium framework. The same was done for the keyframes lib, so I'd be happy to have a "Frameworks" section in the README to list those integrations, together with react and others. Are you guys open for that?