### PR TITLE
Initialize control point to CGPointZero

### DIFF
--- a/lottie-ios/Classes/LAAnimatablePointValue.m
+++ b/lottie-ios/Classes/LAAnimatablePointValue.m
@@ -111,7 +111,8 @@
     if (endPoint) {
       NSArray *controlPoint1 = keyframe[@"to"];
       NSArray *controlPoint2 = keyframe[@"ti"];
-      CGPoint cp1, cp2 = CGPointZero;
+      CGPoint cp1 = CGPointZero;
+      CGPoint cp2 = CGPointZero;
       CGPoint vertex = [self _pointFromValueArray:endPoint];
       [pointKeyframes addObject:[NSValue valueWithCGPoint:vertex]];
       


### PR DESCRIPTION
Fix warnings about uninitialized variable.
