### PR TITLE
Fixed Carthage support for Swift projects

### DIFF
--- a/Lottie/Lottie.h
+++ b/Lottie/Lottie.h
@@ -16,4 +16,4 @@ FOUNDATION_EXPORT const unsigned char LottieVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <Lottie/PublicHeader.h>
 
-
+#import <Lottie/Lottie.h>


### PR DESCRIPTION
Actual master branch builds with Carthage but project (on Swift) can't access `LAAnimationView` and `LAAnimationTransitionController` because of umbrella header doesn't import them.