### PR TITLE
LOTAnimationView intrinsicContentSize

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -553,6 +553,10 @@ const NSTimeInterval singleFrameTimeValue = 1.0 / 60.0;
 
 #endif
 
+- (CGSize)intrinsicContentSize {
+    return _sceneModel.compBounds.size;
+}
+
 - (void)_layout {
   if (!hasFullyInitialized_) {
     _animationContainer.bounds = self.bounds;


### PR DESCRIPTION
The sceneModel has an intrinsic content size already given by the composition, so it makes sense that the animation view should use that size as it's intrinsic content size to help with laying out the view.