### PR TITLE
Resolve Xcode Analyser warnings, throw error when invalid JSON resource specified

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -196,7 +196,10 @@ const NSTimeInterval singleFrameTimeValue = 1.0 / 60.0;
     return [[LOTAnimationView alloc] initWithModel:laScene];
   }
   
-  return [[LOTAnimationView alloc] initWithModel:nil];
+  NSException* resourceNotFoundException = [NSException exceptionWithName:@"ResourceNotFoundException"
+                                                                   reason:[error localizedDescription]
+                                                                 userInfo:nil];
+  @throw resourceNotFoundException;
 }
 
 + (instancetype)animationFromJSON:(NSDictionary *)animationJSON {
@@ -399,10 +402,10 @@ const NSTimeInterval singleFrameTimeValue = 1.0 / 60.0;
   newChild.childView = view;
   
   if (!layer) {
-    NSException* myException = [NSException exceptionWithName:@"LayerNotFoundException"
-                                                       reason:@"The required layer was not specified."
-                                                     userInfo:nil];
-    @throw myException;
+    NSException* layerNotFoundExpection = [NSException exceptionWithName:@"LayerNotFoundException"
+                                                                  reason:@"The required layer was not specified."
+                                                                userInfo:nil];
+    @throw layerNotFoundExpection;
   } else {
     newChild.layer = layerObject;
     [layerObject.superlayer insertSublayer:view.layer above:layerObject];


### PR DESCRIPTION
When there is no JSON resource is specified or the specified resource is invalid, Lottie is a bad girl and continues without a valid scene model, causing the Xcode Analyser to complain. I recently resolved the same when an invalid layer is specified, so the Developers will know what's wrong and not receive an empty / stateless view.

To reproduce, just run the Xcode Analyser (`Shift+Command+B`) and follow the nil-path.