### PR TITLE
Fixes the addSublayer method name in LOTCompositionLayer implementation file

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.m
@@ -125,7 +125,7 @@
   }
 }
 
-- (void)addSubview:(LOTView *)view
+- (void)addSublayer:(LOTView *)view
       toLayerNamed:(NSString *)layer {
   LOTConstraintType constraint = LOTConstraintTypeAlignToBounds;
   LOTLayerView *layerObject = _layerNameMap[layer];


### PR DESCRIPTION
The class `LOTCompositionLayer.m` implements a method called [`addSubview:toLayerNamed:`](https://github.com/airbnb/lottie-ios/blob/master/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.m#L128) but in the interface file it’s defined as [`addSublayer:toLayerNamed:`](https://github.com/airbnb/lottie-ios/blob/master/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.h#L21)

This is throwing an `Unrecognized selector sent to instance` when tries to run the Transition Demo.
```sh
Lottie-Example[54428:9658547] -[LOTCompositionLayer addSublayer:toLayerNamed:]: unrecognized selector sent to instance 0x6000000570a0
Lottie-Example[54428:9658547] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[LOTCompositionLayer addSublayer:toLayerNamed:]: unrecognized selector sent to instance 0x6000000570a0'
```

`LOTAnimationView.m` tries [to call the addSublayer](https://github.com/airbnb/lottie-ios/blob/master/lottie-ios/Classes/Private/LOTAnimationView.m#L347) method 