### PR TITLE
Fix animated rotation of views

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTEllipseShapeLayer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTEllipseShapeLayer.m
@@ -138,7 +138,7 @@ const CGFloat kEllipseControlPointPercentage = 0.55228;
     self.opacity = _transform.opacity.initialValue.floatValue;
     self.position = _transform.position.initialPoint;
     self.transform = _transform.scale.initialScale;
-    self.sublayerTransform = CATransform3DMakeRotation(_transform.rotation.initialValue.floatValue, 0, 0, 1);
+    self.transform = CATransform3DRotate(self.transform, _transform.rotation.initialValue.floatValue, 0, 0, 1);
     
     if (fill) {
       _fillLayer = [LOTCircleShapeLayer new];
@@ -194,8 +194,8 @@ const CGFloat kEllipseControlPointPercentage = 0.55228;
     _animation = [CAAnimationGroup LOT_animationGroupForAnimatablePropertiesWithKeyPaths:@{@"opacity" : _transform.opacity,
                                                                                        @"position" : _transform.position,
                                                                                        @"anchorPoint" : _transform.anchor,
-                                                                                       @"transform" : _transform.scale,
-                                                                                       @"sublayerTransform.rotation" : _transform.rotation}];
+                                                                                       @"transform.scale" : _transform.scale,
+                                                                                       @"transform.rotation.z" : _transform.rotation}];
     [self addAnimation:_animation forKey:@"LottieAnimation"];
   }
   

--- a/lottie-ios/Classes/AnimatableLayers/LOTGroupLayerView.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTGroupLayerView.m
@@ -43,7 +43,7 @@
     self.position = _shapeTransform.position.initialPoint;
     self.opacity = _shapeTransform.opacity.initialValue.floatValue;
     self.transform = _shapeTransform.scale.initialScale;
-    self.sublayerTransform = CATransform3DMakeRotation(_shapeTransform.rotation.initialValue.floatValue, 0, 0, 1);
+    self.transform = CATransform3DRotate(self.transform, _shapeTransform.rotation.initialValue.floatValue, 0, 0, 1);
   }
   
   NSArray *groupItems = _shapeGroup.items;
@@ -119,8 +119,8 @@
     _animation = [CAAnimationGroup LOT_animationGroupForAnimatablePropertiesWithKeyPaths:@{@"opacity" : _shapeTransform.opacity,
                                                                                        @"position" : _shapeTransform.position,
                                                                                        @"anchorPoint" : _shapeTransform.anchor,
-                                                                                       @"transform" : _shapeTransform.scale,
-                                                                                       @"sublayerTransform.rotation" : _shapeTransform.rotation}];
+                                                                                       @"transform.scale" : _shapeTransform.scale,
+                                                                                       @"transform.rotation.z" : _shapeTransform.rotation}];
     [self addAnimation:_animation forKey:@"LottieAnimation"];
   }
 }

--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerView.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerView.m
@@ -52,7 +52,7 @@
   
   self.anchorPoint = _parentModel.anchor.initialPoint;
   self.transform = _parentModel.scale.initialScale;
-  self.sublayerTransform = CATransform3DMakeRotation(_parentModel.rotation.initialValue.floatValue, 0, 0, 1);
+  self.transform = CATransform3DRotate(self.transform, _parentModel.rotation.initialValue.floatValue, 0, 0, 1);
   [self _buildAnimations];
 }
 
@@ -65,10 +65,10 @@
     [keypaths setValue:_parentModel.anchor forKey:@"anchorPoint"];
   }
   if (_parentModel.scale) {
-    [keypaths setValue:_parentModel.scale forKey:@"transform"];
+    [keypaths setValue:_parentModel.scale forKey:@"transform.scale"];
   }
   if (_parentModel.rotation) {
-    [keypaths setValue:_parentModel.rotation forKey:@"sublayerTransform.rotation"];
+    [keypaths setValue:_parentModel.rotation forKey:@"transform.rotation.z"];
   }
   if (_parentModel.positionX) {
     [keypaths setValue:_parentModel.positionX forKey:@"position.x"];
@@ -169,7 +169,7 @@
   }
   _childContainerLayer.anchorPoint = _layerModel.anchor.initialPoint;
   _childContainerLayer.transform = _layerModel.scale.initialScale;
-  _childContainerLayer.sublayerTransform = CATransform3DMakeRotation(_layerModel.rotation.initialValue.floatValue, 0, 0, 1);
+  _childContainerLayer.transform = CATransform3DRotate(_childContainerLayer.transform, _layerModel.rotation.initialValue.floatValue, 0, 0, 1);
   self.hidden = _layerModel.hasInAnimation;
   
   NSArray *groupItems = _layerModel.shapes;
@@ -261,10 +261,10 @@
     [keypaths setValue:_layerModel.anchor forKey:@"anchorPoint"];
   }
   if (_layerModel.scale) {
-    [keypaths setValue:_layerModel.scale forKey:@"transform"];
+    [keypaths setValue:_layerModel.scale forKey:@"transform.scale"];
   }
   if (_layerModel.rotation) {
-    [keypaths setValue:_layerModel.rotation forKey:@"sublayerTransform.rotation"];
+    [keypaths setValue:_layerModel.rotation forKey:@"transform.rotation.z"];
   }
   if (_layerModel.positionX) {
     [keypaths setValue:_layerModel.positionX forKey:@"position.x"];
@@ -293,7 +293,6 @@
   _inOutAnimation.duration = self.layerDuration;
   [self addAnimation:_inOutAnimation forKey:@"inout"];
   self.duration = self.layerDuration + LOT_singleFrameTimeValue;
-
 }
 
 - (void)LOT_addChildLayer:(CALayer *)childLayer {

--- a/lottie-ios/Classes/AnimatableLayers/LOTRectShapeLayer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTRectShapeLayer.m
@@ -170,7 +170,7 @@
     self.opacity = _transform.opacity.initialValue.floatValue;
     self.position = _transform.position.initialPoint;
     self.transform = _transform.scale.initialScale;
-    self.sublayerTransform = CATransform3DMakeRotation(_transform.rotation.initialValue.floatValue, 0, 0, 1);
+    self.transform = CATransform3DRotate(self.transform, _transform.rotation.initialValue.floatValue, 0, 0, 1);
     
     if (fill) {
       _fillLayer = [LOTRoundRectLayer layer];
@@ -228,8 +228,8 @@
     _animation = [CAAnimationGroup LOT_animationGroupForAnimatablePropertiesWithKeyPaths:@{@"opacity" : _transform.opacity,
                                                                                        @"position" : _transform.position,
                                                                                        @"anchorPoint" : _transform.anchor,
-                                                                                       @"transform" : _transform.scale,
-                                                                                       @"sublayerTransform.rotation" : _transform.rotation}];
+                                                                                       @"transform.scale" : _transform.scale,
+                                                                                       @"transform.rotation.z" : _transform.rotation}];
     [self addAnimation:_animation forKey:@"LottieAnimation"];
   }
   

--- a/lottie-ios/Classes/AnimatableLayers/LOTShapeLayerView.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTShapeLayerView.m
@@ -45,7 +45,7 @@
     self.opacity = _transform.opacity.initialValue.floatValue;
     self.position = _transform.position.initialPoint;
     self.transform = _transform.scale.initialScale;
-    self.sublayerTransform = CATransform3DMakeRotation(_transform.rotation.initialValue.floatValue, 0, 0, 1);
+    self.transform = CATransform3DRotate(self.transform, _transform.rotation.initialValue.floatValue, 0, 0, 1);
     
     if (fill) {
       _fillLayer = [CAShapeLayer layer];
@@ -98,8 +98,8 @@
     _animation = [CAAnimationGroup LOT_animationGroupForAnimatablePropertiesWithKeyPaths:@{@"opacity" : _transform.opacity,
                                                                                        @"position" : _transform.position,
                                                                                        @"anchorPoint" : _transform.anchor,
-                                                                                       @"transform" : _transform.scale,
-                                                                                       @"sublayerTransform.rotation" : _transform.rotation}];
+                                                                                       @"transform.scale" : _transform.scale,
+                                                                                       @"transform.rotation.z" : _transform.rotation}];
     [self addAnimation:_animation forKey:@"LottieAnimation"];
   }
   

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableBoundsValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableBoundsValue.m
@@ -171,9 +171,9 @@
   return (self.boundsKeyframes.count > 0);
 }
 
-- (nullable CAKeyframeAnimation *)animationForKeyPath:(nonnull NSString *)keypath {
+- (NSArray<CAKeyframeAnimation *> *)animationsForKeyPath:(NSString *)keypath {
   if (self.hasAnimation == NO) {
-    return nil;
+    return @[];
   }
   CAKeyframeAnimation *keyframeAnimation = [CAKeyframeAnimation animationWithKeyPath:keypath];
   keyframeAnimation.keyTimes = self.keyTimes;
@@ -182,7 +182,7 @@
   keyframeAnimation.duration = self.duration;
   keyframeAnimation.beginTime = self.delay;
   keyframeAnimation.fillMode = kCAFillModeForwards;
-  return keyframeAnimation;
+  return @[keyframeAnimation];
 }
 
 - (NSString *)description {

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableColorValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableColorValue.m
@@ -180,9 +180,9 @@
   return (self.colorKeyframes.count > 0);
 }
 
-- (nullable CAKeyframeAnimation *)animationForKeyPath:(nonnull NSString *)keypath {
+- (NSArray<CAKeyframeAnimation *> *)animationsForKeyPath:(NSString *)keypath {
   if (self.hasAnimation == NO) {
-    return nil;
+    return @[];
   }
   CAKeyframeAnimation *keyframeAnimation = [CAKeyframeAnimation animationWithKeyPath:keypath];
   keyframeAnimation.keyTimes = self.keyTimes;
@@ -191,7 +191,7 @@
   keyframeAnimation.duration = self.duration;
   keyframeAnimation.beginTime = self.delay;
   keyframeAnimation.fillMode = kCAFillModeForwards;
-  return keyframeAnimation;
+  return @[keyframeAnimation];
 }
 
 - (NSString *)description {

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableNumberValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableNumberValue.m
@@ -195,9 +195,9 @@
   return (self.valueKeyframes.count > 0);
 }
 
-- (nullable CAKeyframeAnimation *)animationForKeyPath:(nonnull NSString *)keypath {
+- (NSArray<CAKeyframeAnimation *> *)animationsForKeyPath:(NSString *)keypath {
   if (self.hasAnimation == NO) {
-    return nil;
+    return @[];
   }
   CAKeyframeAnimation *keyframeAnimation = [CAKeyframeAnimation animationWithKeyPath:keypath];
   keyframeAnimation.keyTimes = self.keyTimes;
@@ -206,7 +206,7 @@
   keyframeAnimation.duration = self.duration;
   keyframeAnimation.beginTime = self.delay;
   keyframeAnimation.fillMode = kCAFillModeForwards;
-  return keyframeAnimation;
+  return @[keyframeAnimation];
 }
 
 - (NSString *)description {

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatablePointValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatablePointValue.m
@@ -220,9 +220,9 @@
   return (self.animationPath != nil || self.pointKeyframes.count > 0);
 }
 
-- (nullable CAKeyframeAnimation *)animationForKeyPath:(nonnull NSString *)keypath {
+- (NSArray<CAKeyframeAnimation *> *)animationsForKeyPath:(NSString *)keypath {
   if (self.hasAnimation == NO) {
-    return nil;
+    return @[];
   }
   CAKeyframeAnimation *keyframeAnimation = [CAKeyframeAnimation animationWithKeyPath:keypath];
   keyframeAnimation.keyTimes = self.keyTimes;
@@ -235,7 +235,7 @@
   keyframeAnimation.duration = self.duration;
   keyframeAnimation.beginTime = self.delay;
   keyframeAnimation.fillMode = kCAFillModeForwards;
-  return keyframeAnimation;
+  return @[keyframeAnimation];
 }
 
 - (NSString *)description {

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableShapeValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableShapeValue.m
@@ -282,9 +282,9 @@
   return (self.shapeKeyframes.count > 0);
 }
 
-- (nullable CAKeyframeAnimation *)animationForKeyPath:(nonnull NSString *)keypath {
+- (NSArray<CAKeyframeAnimation *> *)animationsForKeyPath:(NSString *)keypath {
   if (self.hasAnimation == NO) {
-    return nil;
+    return @[];
   }
   CAKeyframeAnimation *keyframeAnimation = [CAKeyframeAnimation animationWithKeyPath:keypath];
   keyframeAnimation.keyTimes = self.keyTimes;
@@ -293,7 +293,7 @@
   keyframeAnimation.duration = self.duration;
   keyframeAnimation.beginTime = self.delay;
   keyframeAnimation.fillMode = kCAFillModeForwards;
-  return keyframeAnimation;
+  return @[keyframeAnimation];
 }
 
 - (NSString *)description {

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableValue.h
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableValue.h
@@ -11,7 +11,7 @@
 
 @protocol LOTAnimatableValue <NSObject>
 
-- (CAKeyframeAnimation *)animationForKeyPath:(NSString *)keypath;
+- (NSArray<CAKeyframeAnimation *> *)animationsForKeyPath:(NSString *)keypath;
 - (BOOL)hasAnimation;
 
 @end

--- a/lottie-ios/Classes/Extensions/CAAnimationGroup+LOTAnimatableGroup.m
+++ b/lottie-ios/Classes/Extensions/CAAnimationGroup+LOTAnimatableGroup.m
@@ -16,11 +16,13 @@
   for (NSString *keyPath in properties.allKeys) {
     id <LOTAnimatableValue>property = properties[keyPath];
     if ([property hasAnimation]) {
-      CAKeyframeAnimation *animation = [property animationForKeyPath:keyPath];
-      [animations addObject:animation];
-      
-      if (animation.duration + animation.beginTime > animduration) {
-        animduration = animation.duration + animation.beginTime;
+      NSArray<CAKeyframeAnimation *> *propertyAnimations = [property animationsForKeyPath:keyPath];
+      [animations addObjectsFromArray:propertyAnimations];
+
+      for (CAKeyframeAnimation *animation in propertyAnimations) {
+        if (animation.duration + animation.beginTime > animduration) {
+          animduration = animation.duration + animation.beginTime;
+        }
       }
     }
   }


### PR DESCRIPTION
First of all, thanks for adding image support! This brings us much closer to being able to use Lottie in our app!

However, as far as I can tell, when a layer has its [rotation](https://github.com/bodymovin/bodymovin/blob/master/docs/json/helpers/transform.json#L44-L56) animated with keyframes, this unfortunately has no effect currently. I have seen this behavior after attempting to view the animation posted in #14.

As far as I can tell, this is due to the `sublayerTransform` is being used to perform layer rotation, rather than `transform`. If I’m interpreting the code correctly, this decision was made due to the idea that the `transform` keypath could not have both its `scale` and `rotation` animated concurrently. However, I don’t believe that’s an issue.

I’ve updated both the `rotation` and `scale` properties to animate using the `transform` property, which seems to have fixed the issue with our animation.

Thanks!