### PR TITLE
Uses -[UITableView dequeueReusableCellWithIdentifier:indexPath:]

### DIFF
--- a/Example/lottie-ios/JSONExplorerViewController.m
+++ b/Example/lottie-ios/JSONExplorerViewController.m
@@ -45,7 +45,7 @@
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell" forIndexPath:indexPath];
   NSString *fileURL = self.jsonFiles[indexPath.row];
   NSArray *components = [fileURL componentsSeparatedByString:@"/"];
   cell.textLabel.text = components.lastObject;

--- a/Example/lottie-ios/LottieRootViewController.m
+++ b/Example/lottie-ios/LottieRootViewController.m
@@ -81,7 +81,7 @@
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell" forIndexPath:indexPath];
   cell.textLabel.text = self.tableViewItems[indexPath.row][@"name"];
   return cell;
 }


### PR DESCRIPTION
Uses -[UITableView dequeueReusableCellWithIdentifier:indexPath:] instead of -[UITableView dequeueReusableCellWithIdentifier:].
The last one might return nil, when first one guaranteed never return nil.