### PR TITLE
Allow animation to stop looping via flag [#142]

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -403,9 +403,6 @@
 
 - (void)setLoopAnimation:(BOOL)loopAnimation {
   [_animationState setAnimationDoesLoop:loopAnimation];
-  if (loopAnimation) {
-    [self stopDisplayLink];
-  }
 }
 
 - (BOOL)loopAnimation {

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -355,8 +355,7 @@
 # pragma mark - Display Link
 
 - (void)startDisplayLink {
-  if (_animationState.animationIsPlaying == NO ||
-      _animationState.loopAnimation) {
+  if (_animationState.animationIsPlaying == NO) {
     return;
   }
   


### PR DESCRIPTION
I'm running into the same use case as @christoph-eero in https://github.com/airbnb/lottie-ios/issues/142.

These changes have allowed me to set the `loopAnimation` flag, which when set to false on a looping animation will stop at the end of the current loop and call the completion callback.

Let me know if there are any ramifications to doing this. It looks like `[self stopDisplayLink]` is being called later on down the line.

@buba447 - We're also using this on an Android project if we can get this figured out. Is this something that can be easily implemented on the Android side?