### PR TITLE
Fix @import compatibility with .mm files

### DIFF
--- a/lottie-ios/Classes/PublicHeaders/Lottie.h
+++ b/lottie-ios/Classes/PublicHeaders/Lottie.h
@@ -5,7 +5,13 @@
 //  Created by brandon_withrow on 1/27/17.
 //
 //
+
+#if __has_feature(modules)
 @import Foundation;
+#else
+#import <Foundation/Foundation.h>
+#endif
+
 #ifndef Lottie_h
 #define Lottie_h
 


### PR DESCRIPTION
.mm does not support `@import` module syntax which could cause a compile error when import `Lottie.h` to a .mm file or projects that modules disabled. 