### PR TITLE
Fix Markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Animation file name should be first added to your project. as for the above code
 
 ## Install Lottie
 
-###CocoaPods
+### CocoaPods
 Add the pod to your podfile
 ```
 pod 'lottie-ios'
@@ -227,7 +227,7 @@ run
 pod install
 ```
 
-###Carthage
+### Carthage
 Install Carthage (https://github.com/Carthage/Carthage)
 Add Lottie to your Cartfile
 ```


### PR DESCRIPTION
This PR addresses the formatting errors pointed out by #180.
It simply adds a space after the '#' in the third tier headings since this is now required.

As linked in the original issue: https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown