### PR TITLE
Fix broken README image previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Here is just a small sampling of the power of Lottie
 ![Example1](_Gifs/Examples1.gif)
 ![Example2](_Gifs/Examples2.gif)
 
-![Community](_Gifs/Community 2_3.gif)
+<img src="_Gifs/Community 2_3.gif" />
+
 ![Example3](_Gifs/Examples3.gif)
 
 ![Abcs](_Gifs/Examples4.gif)


### PR DESCRIPTION
Change to HTML based image, however feel free to fix it by removing the white space in the file name