### PR TITLE
Fixed README.md typo error

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ animationView.play(completion: { finished in
 ```
 ## Note:
 Animation file name should be first added to your project. as for the above code sample, It won't work until you add an animation file called `hamburger.json`.. 
-`let animationView = LOTAnimatedView.animationNamed("here_goes_your_json_file_name_without_.json")` 
+`let animationView = LOTAnimationView(name: "here_goes_your_json_file_name_without_.json")` 
 
 ## Supported After Effects Features
 


### PR DESCRIPTION
Fix the typo error in README.md mentioned in the #180 by @madsonic
Method signature gave the README.md was wrong