### PR TITLE
macOS Public Header Build Error

### DIFF
--- a/lottie-ios/Classes/PublicHeaders/Lottie.h
+++ b/lottie-ios/Classes/PublicHeaders/Lottie.h
@@ -21,7 +21,12 @@ FOUNDATION_EXPORT double LottieVersionNumber;
 //! Project version string for Lottie.
 FOUNDATION_EXPORT const unsigned char LottieVersionString[];
 
+#include <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE
 #import "LOTAnimationTransitionController.h"
+#endif
+
 #import "LOTAnimationView.h"
 
 #endif /* Lottie_h */


### PR DESCRIPTION
The PR fixes the macOS build error because`LOTAnimationTransitionController.h` on the public header is only for iOS.