### PR TITLE
Fix bounds calculation for masked sublayers

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.m
@@ -115,7 +115,7 @@
         child.childView.frame = child.layer.bounds;
         break;
       case LOTConstraintTypeAlignToBounds: {
-        CGRect selfBounds = self.frame;
+        CGRect selfBounds = self.bounds;
         CGRect convertedBounds = [child.childView.layer.superlayer convertRect:selfBounds fromLayer:self];
         child.childView.layer.frame = convertedBounds;
       } break;
@@ -141,7 +141,8 @@
   } else {
     newChild.layer = layerObject;
     [layerObject.superlayer insertSublayer:view.layer above:layerObject];
-    
+
+    [layerObject removeFromSuperlayer];
     view.layer.mask = layerObject;
   }
   


### PR DESCRIPTION
This fixes an issue where views added via `addSublayer:toLayerNamed:` would receive incorrect frames.

It looks like when the bounds calculation for `LOTCustomChild` was moved from `LOTAnimationView` to `LOTCompositionLayer` in #110, the reference layer for the bounds of the child layer didn't get updated correctly. This is visible in the sample transition animations included with `lottie-ios-Example`.

Additionally, this removes the mask layer from its superlayer, as CALayer.mask's docs say `The layer you assign to this property must not have a superlayer. If it does, the behavior is undefined.`

### Before:
![apr-04-2017 14-37-17](https://cloud.githubusercontent.com/assets/35043/24680048/40b596e6-1944-11e7-908d-5655748e1559.gif)

### After:
![apr-04-2017 14-35-50](https://cloud.githubusercontent.com/assets/35043/24680046/3f24a11e-1944-11e7-9e10-536800e5b422.gif)

