### PR TITLE
Add nullability annotations to improve Swift compatibility

### DIFF
--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationTransitionController.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationTransitionController.h
@@ -37,9 +37,9 @@
  and a fade transition is performed along with the Lottie animation.
 
  */
-- (instancetype)initWithAnimationNamed:(NSString *)animation
-                        fromLayerNamed:(NSString *)fromLayer
-                          toLayerNamed:(NSString *)toLayer;
+- (nonnull instancetype)initWithAnimationNamed:(nonnull NSString *)animation
+                        fromLayerNamed:(nullable NSString *)fromLayer
+                          toLayerNamed:(nullable NSString *)toLayer;
 
 @end
 

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -13,11 +13,11 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 
 @interface LOTAnimationView : LOTView
 
-+ (instancetype)animationNamed:(NSString *)animationName NS_SWIFT_NAME(init(name:));
-+ (instancetype)animationNamed:(NSString *)animationName inBundle:(NSBundle *)bundle NS_SWIFT_NAME(init(name:bundle:));
-+ (instancetype)animationFromJSON:(NSDictionary *)animationJSON NS_SWIFT_NAME(init(json:));
++ (nullable instancetype)animationNamed:(nonnull NSString *)animationName NS_SWIFT_NAME(init(name:));
++ (nullable instancetype)animationNamed:(nonnull NSString *)animationName inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(name:bundle:));
++ (nullable instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(init(json:));
 
-- (instancetype)initWithContentsOfURL:(NSURL *)url;
+- (nullable instancetype)initWithContentsOfURL:(nonnull NSURL *)url;
 
 @property (nonatomic, readonly) BOOL isAnimationPlaying;
 @property (nonatomic, assign) BOOL loopAnimation;
@@ -25,12 +25,12 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 @property (nonatomic, assign) CGFloat animationSpeed;
 @property (nonatomic, readonly) CGFloat animationDuration;
 
-- (void)playWithCompletion:(LOTAnimationCompletionBlock)completion;
+- (void)playWithCompletion:(nullable LOTAnimationCompletionBlock)completion;
 - (void)play;
 - (void)pause;
 
-- (void)addSubview:(LOTView *)view
-      toLayerNamed:(NSString *)layer;
+- (void)addSubview:(nonnull LOTView *)view
+      toLayerNamed:(nonnull NSString *)layer;
 
 #if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
 @property (nonatomic) LOTViewContentMode contentMode;

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -13,11 +13,11 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 
 @interface LOTAnimationView : LOTView
 
-+ (nullable instancetype)animationNamed:(nonnull NSString *)animationName NS_SWIFT_NAME(init(name:));
-+ (nullable instancetype)animationNamed:(nonnull NSString *)animationName inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(name:bundle:));
-+ (nullable instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(init(json:));
++ (nonnull instancetype)animationNamed:(nonnull NSString *)animationName NS_SWIFT_NAME(init(name:));
++ (nonnull instancetype)animationNamed:(nonnull NSString *)animationName inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(name:bundle:));
++ (nonnull instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(init(json:));
 
-- (nullable instancetype)initWithContentsOfURL:(nonnull NSURL *)url;
+- (nonnull instancetype)initWithContentsOfURL:(nonnull NSURL *)url;
 
 @property (nonatomic, readonly) BOOL isAnimationPlaying;
 @property (nonatomic, assign) BOOL loopAnimation;


### PR DESCRIPTION
I added nullability annotations to public headers, which makes the library nicer to work with in Swift. I'm not 100% sure that some of my nonnull instancetypes are correct — it seems, however, that Lottie will crash if given invalid names, etc., rather than return a nil animation view, so it seemed appropriate. 