### PR TITLE
Duration fix for JSON based models

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -281,7 +281,7 @@
   _sceneModel = model;
   [self _buildSubviewsFromModel];
   LOTAnimationState *oldState = _animationState;
-  _animationState = [[LOTAnimationState alloc] initWithDuration:_sceneModel.timeDuration layer:_timingLayer frameRate:_sceneModel.framerate];
+  _animationState = [[LOTAnimationState alloc] initWithDuration:_sceneModel.timeDuration + LOT_singleFrameTimeValue layer:_timingLayer frameRate:_sceneModel.framerate];
 
   if (restoreAnimation && oldState) {
     [self setLoopAnimation:oldState.loopAnimation];


### PR DESCRIPTION
Models loaded from JSON are a bit broken now:
1) Setting `animationProgress = 1` brings you to the final frame minus 1/60 instead of final
2) Looped animation has an artifact