### PR TITLE
Allow consumer to control clipping behavior

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.m
@@ -36,7 +36,6 @@
                         withBounds:(CGRect)bounds {
   self = [super init];
   if (self) {
-    self.masksToBounds = YES;
     [self _setupWithLayerGroup:layerGroup withAssetGroup:assetGroup withBounds:bounds];
   }
   return self;


### PR DESCRIPTION
Currently when you want to allow items to be drawn outside of the LOTAnimationView's frame, you must set two properties:

1. `LOTAnimationView.clipsToBounds = false`
1. `LOTCompositionLayer.masksToBounds = false`

Doing the former is easy, as that is how UIKit is built: 

```
lotAnimationView.clipsToBounds = false
```

Doing the latter is more difficult, since the LOTCompositionLayer is not exposed, and we're forced to mess around with the internals of LOTAnimationView:

```
if let lotCompositionLayer = lotAnimationView.layer.sublayers?.first?.sublayers?.first {
  assert(String(describing: type(of: lotCompositionLayer)) == "LOTCompositionLayer", "Make sure we're modifying the correct layer")
  lotCompositionLayer.masksToBounds = false
}
```

Instead, I propose we remove the line of code that sets `masksToBounds = YES` in `LOTCompositionLayer`, so that it uses the default `NO` instead.

This will allow the consumer to control the clipping behavior by a single, exposed property `LOTAnimationView.clipsToBounds` rather than having to muck with an internal setting, and/or set two different properties.

This shouldn't introduce problems because it seems like setting `masksToBounds` on the layer wasn't adding any new functionality, since `clipsToBounds` was already being controlled by the view.

# Screenshots

Notes:

- In both cases, I manually set `lotAnimationView.clipsToBounds = false`
- The red background represents the LOTAnimationView's frame

**Before**: (Notice how the bottom left image is incorrectly clipped)

<img width="366" alt="screen shot 2017-05-21 at 10 50 12 am" src="https://cloud.githubusercontent.com/assets/2894588/26286177/8dccee5e-3e13-11e7-91a3-ec93fc449632.png">

**After**: (Notice how the bottom left image is correctly no longer clipped)

<img width="368" alt="screen shot 2017-05-21 at 10 50 54 am" src="https://cloud.githubusercontent.com/assets/2894588/26286178/93220038-3e13-11e7-85ef-4792d490ae31.png">
