### PR TITLE
Fix for layer out frame

### DIFF
--- a/lottie-ios/Classes/Models/LOTLayer.m
+++ b/lottie-ios/Classes/Models/LOTLayer.m
@@ -173,7 +173,7 @@
   
   NSMutableArray *keys = [NSMutableArray array];
   NSMutableArray *keyTimes = [NSMutableArray array];
-  CGFloat layerLength = _outFrame.integerValue;
+  CGFloat layerLength = _outFrame.integerValue - 1;
   _layerDuration = (layerLength / _framerate.floatValue);
   
   if (_hasInAnimation) {


### PR DESCRIPTION
The out time for layers was a frame late. This was a simple mathematical error. Fixed now!