### PR TITLE
avoid repeated loading image in different layer

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerView.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerView.m
@@ -325,16 +325,21 @@
 - (void)_setImageForAsset {
     if (_layerModel.imageAsset.imageName) {
         UIImage *image;
-        if (_layerModel.imageAsset.rootDirectory.length > 0) {
-            NSString *rootDirectory  = _layerModel.imageAsset.rootDirectory;
-            if (_layerModel.imageAsset.imageDirectory.length > 0) {
-                rootDirectory = [rootDirectory stringByAppendingPathComponent:_layerModel.imageAsset.imageDirectory];
-            }
-            NSString *imagePath = [rootDirectory stringByAppendingPathComponent:_layerModel.imageAsset.imageName];
-            image = [UIImage imageWithContentsOfFile:imagePath];
+        if (_layerModel.imageAsset.image) {
+            image = _layerModel.imageAsset.image;
         }else{
-            NSArray *components = [_layerModel.imageAsset.imageName componentsSeparatedByString:@"."];
-            image = [UIImage imageNamed:components.firstObject inBundle:_bundle compatibleWithTraitCollection:nil];
+            if (_layerModel.imageAsset.rootDirectory.length > 0) {
+                NSString *rootDirectory  = _layerModel.imageAsset.rootDirectory;
+                if (_layerModel.imageAsset.imageDirectory.length > 0) {
+                    rootDirectory = [rootDirectory stringByAppendingPathComponent:_layerModel.imageAsset.imageDirectory];
+                }
+                NSString *imagePath = [rootDirectory stringByAppendingPathComponent:_layerModel.imageAsset.imageName];
+                image = [UIImage imageWithContentsOfFile:imagePath];
+            }else{
+                NSArray *components = [_layerModel.imageAsset.imageName componentsSeparatedByString:@"."];
+                image = [UIImage imageNamed:components.firstObject inBundle:_bundle compatibleWithTraitCollection:nil];
+            }
+            _layerModel.imageAsset.image = image;
         }
         
         if (image) {
@@ -349,8 +354,15 @@
 
 - (void)_setImageForAsset {
   if (_layerModel.imageAsset.imageName) {
-    NSArray *components = [_layerModel.imageAsset.imageName componentsSeparatedByString:@"."];
-    NSImage *image = [NSImage imageNamed:components.firstObject];
+    NSImage *image;
+    if (_layerModel.imageAsset.image) {
+        image = _layerModel.imageAsset.image;
+    }else{
+        NSArray *components = [_layerModel.imageAsset.imageName componentsSeparatedByString:@"."];
+        image = [NSImage imageNamed:components.firstObject];
+        _layerModel.imageAsset.image = image;
+    }
+    
     if (image) {
       NSWindow *window = [NSApp mainWindow];
       CGFloat desiredScaleFactor = [window backingScaleFactor];

--- a/lottie-ios/Classes/AnimationCache/LOTAnimationCache.h
+++ b/lottie-ios/Classes/AnimationCache/LOTAnimationCache.h
@@ -15,6 +15,7 @@
 + (instancetype)sharedCache;
 
 - (void)addAnimation:(LOTComposition *)animation forKey:(NSString *)key;
+- (void)removeAnimationForKey:(NSString *)key;
 - (LOTComposition *)animationForKey:(NSString *)key;
 
 @end

--- a/lottie-ios/Classes/AnimationCache/LOTAnimationCache.m
+++ b/lottie-ios/Classes/AnimationCache/LOTAnimationCache.m
@@ -44,6 +44,14 @@ const NSInteger kLOTCacheSize = 50;
   [animationsCache_ setObject:animation forKey:key];
 }
 
+- (void)removeAnimationForKey:(NSString *)key {
+    if (!key) {
+        return ;
+    }
+    [lruOrderArray_ removeObject:key];
+    [animationsCache_ removeObjectForKey:key];
+}
+
 - (LOTComposition *)animationForKey:(NSString *)key {
   if (!key) {
     return nil;

--- a/lottie-ios/Classes/Models/LOTAsset.h
+++ b/lottie-ios/Classes/Models/LOTAsset.h
@@ -9,13 +9,11 @@
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-
+#import <UIKit/UIKit.h>
 @compatibility_alias LOTImage UIImage;
 #else
-
 #import <AppKit/AppKit.h>
 @compatibility_alias LOTImage NSImage;
-
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/lottie-ios/Classes/Models/LOTAsset.h
+++ b/lottie-ios/Classes/Models/LOTAsset.h
@@ -8,6 +8,15 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+
+@compatibility_alias LOTImage UIImage;
+#else
+
+#import <AppKit/AppKit.h>
+@compatibility_alias LOTImage NSImage;
+
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) NSString *imageName;
 @property (nonatomic, readonly, nullable) NSString *imageDirectory;
+@property (nonatomic, readwrite, nullable) LOTImage *image;
 
 @property (nonatomic, readonly, nullable) LOTLayerGroup *layerGroup;
 

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -8,7 +8,6 @@
 
 #import "LOTAnimationView.h"
 #import "LOTPlatformCompat.h"
-#import "LOTLayerView.h"
 #import "LOTModels.h"
 #import "LOTHelpers.h"
 #import "LOTAnimationView_Internal.h"

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -187,6 +187,10 @@
 
 @end
 
+@interface LOTAnimationView ()
+@property (nonatomic, copy) NSString *cacheKey;
+@end
+
 @implementation LOTAnimationView {
   CALayer *_timingLayer;
   LOTCompositionLayer *_compLayer;
@@ -205,10 +209,12 @@
 + (instancetype)animationNamed:(NSString *)animationName inBundle:(NSBundle *)bundle {
   NSArray *components = [animationName componentsSeparatedByString:@"."];
   animationName = components.firstObject;
-  
+  LOTAnimationView *animationView;
   LOTComposition *comp = [[LOTAnimationCache sharedCache] animationForKey:animationName];
   if (comp) {
-    return [[LOTAnimationView alloc] initWithModel:comp inBundle:bundle];
+    animationView = [[LOTAnimationView alloc] initWithModel:comp inBundle:bundle];
+    animationView.cacheKey = animationName;
+    return animationView;
   }
   
   NSError *error;
@@ -219,7 +225,9 @@
   if (JSONObject && !error) {
     LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:JSONObject];
     [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:animationName];
-    return [[LOTAnimationView alloc] initWithModel:laScene inBundle:bundle];
+    animationView = [[LOTAnimationView alloc] initWithModel:laScene inBundle:bundle];
+    animationView.cacheKey = animationName;
+    return animationView;
   }
   
   NSException* resourceNotFoundException = [NSException exceptionWithName:@"ResourceNotFoundException"
@@ -239,10 +247,12 @@
 
 + (instancetype)animationWithFilePath:(NSString *)filePath{
     NSString *animationName = filePath;
-    
+    LOTAnimationView *animationView;
     LOTComposition *comp = [[LOTAnimationCache sharedCache] animationForKey:animationName];
     if (comp) {
-        return [[LOTAnimationView alloc] initWithModel:comp inBundle:[NSBundle mainBundle]];
+        animationView = [[LOTAnimationView alloc] initWithModel:comp inBundle:[NSBundle mainBundle]];
+        animationView.cacheKey = animationName;
+        return animationView;
     }
     
     NSError *error;
@@ -253,7 +263,9 @@
         LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:JSONObject];
         laScene.rootDirectory = [filePath stringByDeletingLastPathComponent];
         [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:animationName];
-        return [[LOTAnimationView alloc] initWithModel:laScene inBundle:[NSBundle mainBundle]];
+        animationView = [[LOTAnimationView alloc] initWithModel:laScene inBundle:[NSBundle mainBundle]];
+        animationView.cacheKey = animationName;
+        return animationView;
     }
     
     NSException* resourceNotFoundException = [NSException exceptionWithName:@"ResourceNotFoundException"
@@ -265,6 +277,7 @@
 - (instancetype)initWithContentsOfURL:(NSURL *)url {
   self = [super initWithFrame:CGRectZero];
   if (self) {
+    self.cacheKey = url.absoluteString;
     LOTComposition *laScene = [[LOTAnimationCache sharedCache] animationForKey:url.absoluteString];
     if (laScene) {
       [self _initializeAnimationContainer];
@@ -399,6 +412,18 @@
 - (void)addSubview:(LOTView *)view
       toLayerNamed:(NSString *)layer {
   [_compLayer addSublayer:view toLayerNamed:layer];
+}
+
+- (void)setCacheEnable:(BOOL)cacheEnable{
+    _cacheEnable = cacheEnable;
+    if (!self.cacheKey) {
+        return;
+    }
+    if (cacheEnable) {
+        [[LOTAnimationCache sharedCache] addAnimation:_sceneModel forKey:self.cacheKey];
+    }else {
+        [[LOTAnimationCache sharedCache] removeAnimationForKey:self.cacheKey];
+    }
 }
 
 # pragma mark - Display Link

--- a/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
+++ b/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
@@ -19,9 +19,9 @@ typedef enum : NSUInteger {
 - (instancetype _Nonnull)initWithDuration:(CGFloat)duration layer:(CALayer * _Nullable)layer frameRate:(NSNumber * _Nullable)framerate;
 
 - (void)setAnimationIsPlaying:(BOOL)animationIsPlaying;
-- (void)setAnimationDoesLoop:(BOOL)loopAnimation;
-- (void)setAnimatedProgress:(CGFloat)progress;
-- (void)setAnimationSpeed:(CGFloat)speed;
+- (void)setAnimationDoesLoop:(BOOL)loopAnimation updateAnimation:(BOOL)updateAnimation;
+- (void)setAnimatedProgress:(CGFloat)progress updateAnimation:(BOOL)updateAnimation;
+- (void)setAnimationSpeed:(CGFloat)speed updateAnimation:(BOOL)updateAnimation;
 
 @property (nonatomic, readonly) BOOL loopAnimation;
 @property (nonatomic, readonly) BOOL animationIsPlaying;

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -16,17 +16,18 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 + (nonnull instancetype)animationNamed:(nonnull NSString *)animationName NS_SWIFT_NAME(init(name:));
 + (nonnull instancetype)animationNamed:(nonnull NSString *)animationName inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(name:bundle:));
 + (nonnull instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(init(json:));
-+ (instancetype)animationFromJSON:(NSDictionary *)animationJSON inBundle:(NSBundle *)bundle NS_SWIFT_NAME(init(json:bundle:));
++ (nonnull instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(json:bundle:));
 
 - (nonnull instancetype)initWithContentsOfURL:(nonnull NSURL *)url;
 
-+ (instancetype)animationWithFilePath:(NSString *)filePath NS_SWIFT_NAME(init(filePath:));
++ (nonnull instancetype)animationWithFilePath:(nonnull NSString *)filePath NS_SWIFT_NAME(init(filePath:));
 
 @property (nonatomic, readonly) BOOL isAnimationPlaying;
 @property (nonatomic, assign) BOOL loopAnimation;
 @property (nonatomic, assign) CGFloat animationProgress;
 @property (nonatomic, assign) CGFloat animationSpeed;
 @property (nonatomic, readonly) CGFloat animationDuration;
+@property (nonatomic, assign) BOOL cacheEnable;
 
 - (void)playWithCompletion:(nullable LOTAnimationCompletionBlock)completion;
 - (void)play;


### PR DESCRIPTION
when load image with method `imageWithContentsOfFile`, the image will be loaded many times, to avoid this, I cache the image in its asset object. 
here is an animation that use many image, in my app, without cache image, it use more then 160MB memory, after cache image, only 30MB used.
[ferrari.zip](https://github.com/airbnb/lottie-ios/files/1108173/ferrari.zip)