### PR TITLE
Add nullability specifiers to LOTAnimationTransitionController

### DIFF
--- a/lottie-ios/Classes/AnimationCache/LOTAnimationCache.h
+++ b/lottie-ios/Classes/AnimationCache/LOTAnimationCache.h
@@ -15,6 +15,7 @@
 + (instancetype)sharedCache;
 
 - (void)addAnimation:(LOTComposition *)animation forKey:(NSString *)key;
+- (void)removeAnimationForKey:(NSString *)key;
 - (LOTComposition *)animationForKey:(NSString *)key;
 
 @end

--- a/lottie-ios/Classes/AnimationCache/LOTAnimationCache.m
+++ b/lottie-ios/Classes/AnimationCache/LOTAnimationCache.m
@@ -44,6 +44,14 @@ const NSInteger kLOTCacheSize = 50;
   [animationsCache_ setObject:animation forKey:key];
 }
 
+- (void)removeAnimationForKey:(NSString *)key {
+    if (!key) {
+        return ;
+    }
+    [lruOrderArray_ removeObject:key];
+    [animationsCache_ removeObjectForKey:key];
+}
+
 - (LOTComposition *)animationForKey:(NSString *)key {
   if (!key) {
     return nil;

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -187,6 +187,10 @@
 
 @end
 
+@interface LOTAnimationView ()
+@property (nonatomic, copy) NSString *cacheKey;
+@end
+
 @implementation LOTAnimationView {
   CALayer *_timingLayer;
   LOTCompositionLayer *_compLayer;
@@ -205,10 +209,12 @@
 + (instancetype)animationNamed:(NSString *)animationName inBundle:(NSBundle *)bundle {
   NSArray *components = [animationName componentsSeparatedByString:@"."];
   animationName = components.firstObject;
-  
+  LOTAnimationView *animationView;
   LOTComposition *comp = [[LOTAnimationCache sharedCache] animationForKey:animationName];
   if (comp) {
-    return [[LOTAnimationView alloc] initWithModel:comp inBundle:bundle];
+    animationView = [[LOTAnimationView alloc] initWithModel:comp inBundle:bundle];
+    animationView.cacheKey = animationName;
+    return animationView;
   }
   
   NSError *error;
@@ -219,7 +225,9 @@
   if (JSONObject && !error) {
     LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:JSONObject];
     [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:animationName];
-    return [[LOTAnimationView alloc] initWithModel:laScene inBundle:bundle];
+    animationView = [[LOTAnimationView alloc] initWithModel:laScene inBundle:bundle];
+    animationView.cacheKey = animationName;
+    return animationView;
   }
   
   NSException* resourceNotFoundException = [NSException exceptionWithName:@"ResourceNotFoundException"
@@ -239,10 +247,12 @@
 
 + (instancetype)animationWithFilePath:(NSString *)filePath{
     NSString *animationName = filePath;
-    
+    LOTAnimationView *animationView;
     LOTComposition *comp = [[LOTAnimationCache sharedCache] animationForKey:animationName];
     if (comp) {
-        return [[LOTAnimationView alloc] initWithModel:comp inBundle:[NSBundle mainBundle]];
+        animationView = [[LOTAnimationView alloc] initWithModel:comp inBundle:[NSBundle mainBundle]];
+        animationView.cacheKey = animationName;
+        return animationView;
     }
     
     NSError *error;
@@ -253,7 +263,9 @@
         LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:JSONObject];
         laScene.rootDirectory = [filePath stringByDeletingLastPathComponent];
         [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:animationName];
-        return [[LOTAnimationView alloc] initWithModel:laScene inBundle:[NSBundle mainBundle]];
+        animationView = [[LOTAnimationView alloc] initWithModel:laScene inBundle:[NSBundle mainBundle]];
+        animationView.cacheKey = animationName;
+        return animationView;
     }
     
     NSException* resourceNotFoundException = [NSException exceptionWithName:@"ResourceNotFoundException"
@@ -265,6 +277,7 @@
 - (instancetype)initWithContentsOfURL:(NSURL *)url {
   self = [super initWithFrame:CGRectZero];
   if (self) {
+    self.cacheKey = url.absoluteString;
     LOTComposition *laScene = [[LOTAnimationCache sharedCache] animationForKey:url.absoluteString];
     if (laScene) {
       [self _initializeAnimationContainer];
@@ -399,6 +412,18 @@
 - (void)addSubview:(LOTView *)view
       toLayerNamed:(NSString *)layer {
   [_compLayer addSublayer:view toLayerNamed:layer];
+}
+
+- (void)setCacheEnable:(BOOL)cacheEnable{
+    _cacheEnable = cacheEnable;
+    if (!self.cacheKey) {
+        return;
+    }
+    if (cacheEnable) {
+        [[LOTAnimationCache sharedCache] addAnimation:_sceneModel forKey:self.cacheKey];
+    }else {
+        [[LOTAnimationCache sharedCache] removeAnimationForKey:self.cacheKey];
+    }
 }
 
 # pragma mark - Display Link

--- a/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
+++ b/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
@@ -19,9 +19,9 @@ typedef enum : NSUInteger {
 - (instancetype _Nonnull)initWithDuration:(CGFloat)duration layer:(CALayer * _Nullable)layer frameRate:(NSNumber * _Nullable)framerate;
 
 - (void)setAnimationIsPlaying:(BOOL)animationIsPlaying;
-- (void)setAnimationDoesLoop:(BOOL)loopAnimation;
-- (void)setAnimatedProgress:(CGFloat)progress;
-- (void)setAnimationSpeed:(CGFloat)speed;
+- (void)setAnimationDoesLoop:(BOOL)loopAnimation updateAnimation:(BOOL)updateAnimation;
+- (void)setAnimatedProgress:(CGFloat)progress updateAnimation:(BOOL)updateAnimation;
+- (void)setAnimationSpeed:(CGFloat)speed updateAnimation:(BOOL)updateAnimation;
 
 @property (nonatomic, readonly) BOOL loopAnimation;
 @property (nonatomic, readonly) BOOL animationIsPlaying;

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationTransitionController.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationTransitionController.h
@@ -38,8 +38,8 @@
 
  */
 - (nonnull instancetype)initWithAnimationNamed:(nonnull NSString *)animation
-                        fromLayerNamed:(nullable NSString *)fromLayer
-                          toLayerNamed:(nullable NSString *)toLayer;
+                                fromLayerNamed:(nullable NSString *)fromLayer
+                                  toLayerNamed:(nullable NSString *)toLayer;
 
 /**
  The initializer to create a new transition animation.
@@ -56,10 +56,10 @@
  @param bundle custom bundle to load animation and images, if no bundle is specified will load
  from mainBundle
  */
-- (instancetype)initWithAnimationNamed:(NSString *)animation
-                        fromLayerNamed:(NSString *)fromLayer
-                          toLayerNamed:(NSString *)toLayer
-                              inBundle:(NSBundle *)bundle;
+- (nonnull instancetype)initWithAnimationNamed:(nonnull NSString *)animation
+                                fromLayerNamed:(nullable NSString *)fromLayer
+                                  toLayerNamed:(nullable NSString *)toLayer
+                                      inBundle:(nonnull NSBundle *)bundle;
 
 @end
 

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -16,17 +16,18 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 + (nonnull instancetype)animationNamed:(nonnull NSString *)animationName NS_SWIFT_NAME(init(name:));
 + (nonnull instancetype)animationNamed:(nonnull NSString *)animationName inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(name:bundle:));
 + (nonnull instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(init(json:));
-+ (instancetype)animationFromJSON:(NSDictionary *)animationJSON inBundle:(NSBundle *)bundle NS_SWIFT_NAME(init(json:bundle:));
++ (nonnull instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(json:bundle:));
 
 - (nonnull instancetype)initWithContentsOfURL:(nonnull NSURL *)url;
 
-+ (instancetype)animationWithFilePath:(NSString *)filePath NS_SWIFT_NAME(init(filePath:));
++ (nonnull instancetype)animationWithFilePath:(nonnull NSString *)filePath NS_SWIFT_NAME(init(filePath:));
 
 @property (nonatomic, readonly) BOOL isAnimationPlaying;
 @property (nonatomic, assign) BOOL loopAnimation;
 @property (nonatomic, assign) CGFloat animationProgress;
 @property (nonatomic, assign) CGFloat animationSpeed;
 @property (nonatomic, readonly) CGFloat animationDuration;
+@property (nonatomic, assign) BOOL cacheEnable;
 
 - (void)playWithCompletion:(nullable LOTAnimationCompletionBlock)completion;
 - (void)play;


### PR DESCRIPTION
Adds nullability specifiers in LOTAnimationTransitionController which are needed for better compatibility with Swift.

Also fixed indention.