### PR TITLE
Expose completionBlock

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -318,7 +318,6 @@
 		84FE12EF1E4C1485009B157C /* libLottie.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libLottie.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA1F5A9F1E42B52800FF36BF /* LOTAnimationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LOTAnimationView.h; sourceTree = "<group>"; };
 		FAE1F7E61E428CBE002E0974 /* Lottie.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lottie.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FAE1F7E71E428CBE002E0974 /* Lottie copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Lottie copy-Info.plist"; path = "/Users/alex/Projects/lottie-ios/Lottie copy-Info.plist"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -490,7 +489,6 @@
 			children = (
 				62CA59BA1E3C173B002D7188 /* Lottie */,
 				62CA59B91E3C173B002D7188 /* Products */,
-				FAE1F7E71E428CBE002E0974 /* Lottie copy-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Here is just a small sampling of the power of Lottie
 
 ![Abcs](_Gifs/Examples4.gif)
 
+## PSA
+Lottie V2 is currently in development! We are rewriting the render system. This will be a major update that will address most of the currently outstanding issues. We will only consider merging minor bugfixes in the meantime! Stay Tuned!
+Please forward all questions to Brandon Withrow, @thewithra on twitter or lottie@airbnb.com
+Thanks!
+
 ## Using Lottie
 Lottie supports iOS 8 and above.
 Lottie animations can be loaded from bundled JSON or from a URL

--- a/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTCompositionLayer.m
@@ -122,7 +122,7 @@
         CGRect convertedBounds = [child.childView.layer.superlayer convertRect:selfBounds fromLayer:self];
         child.childView.layer.frame = convertedBounds;
       } break;
-      default:
+      case LOTConstraintTypeNone:
         break;
     }
   }

--- a/lottie-ios/Classes/AnimatableLayers/LOTEllipseShapeLayer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTEllipseShapeLayer.m
@@ -10,7 +10,7 @@
 #import "CAAnimationGroup+LOTAnimatableGroup.h"
 #import "LOTStrokeShapeLayer.h"
 
-const CGFloat kEllipseControlPointPercentage = 0.55228;
+static const CGFloat kEllipseControlPointPercentage = 0.55228;
 
 @interface LOTCircleShapeLayer : LOTStrokeShapeLayer
 

--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerView.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerView.m
@@ -332,9 +332,12 @@
             }
             NSString *imagePath = [rootDirectory stringByAppendingPathComponent:_layerModel.imageAsset.imageName];
             image = [UIImage imageWithContentsOfFile:imagePath];
-        }else{
-            NSArray *components = [_layerModel.imageAsset.imageName componentsSeparatedByString:@"."];
-            image = [UIImage imageNamed:components.firstObject inBundle:_bundle compatibleWithTraitCollection:nil];
+        } else {
+            NSArray<NSString *> *components = [_layerModel.imageAsset.imageName componentsSeparatedByString:@"."];
+            NSString *imageName = components.firstObject;
+            if (imageName) {
+                image = [UIImage imageNamed:imageName inBundle:_bundle compatibleWithTraitCollection:nil];
+            }
         }
         
         if (image) {

--- a/lottie-ios/Classes/AnimatableLayers/LOTStrokeShapeLayer.h
+++ b/lottie-ios/Classes/AnimatableLayers/LOTStrokeShapeLayer.h
@@ -10,8 +10,8 @@
 
 @interface LOTStrokeShapeLayer : CAShapeLayer
 
-@property CGFloat trimStart;
-@property CGFloat trimEnd;
-@property CGFloat trimOffset;
+@property (nonatomic) CGFloat trimStart;
+@property (nonatomic) CGFloat trimEnd;
+@property (nonatomic) CGFloat trimOffset;
 
 @end

--- a/lottie-ios/Classes/AnimatableLayers/LOTStrokeShapeLayer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTStrokeShapeLayer.m
@@ -56,7 +56,7 @@
   }
 
   CGFloat threeSixty = 360;
-  CGFloat offsetAmount = fmodf(fabs(presentationLayer.trimOffset) , threeSixty) / threeSixty;
+  CGFloat offsetAmount = fmod(fabs(presentationLayer.trimOffset) , (float)threeSixty) / threeSixty;
   offsetAmount = presentationLayer.trimOffset < 0 ? offsetAmount * -1 : offsetAmount;
   BOOL startFirst = presentationLayer.trimStart < presentationLayer.trimEnd;
   

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableBoundsValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableBoundsValue.m
@@ -121,7 +121,7 @@
         // Easing function
         CGPoint cp1 = [self _pointFromValueDict:timingControlPoint1];
         CGPoint cp2 = [self _pointFromValueDict:timingControlPoint2];
-        timingFunction = [CAMediaTimingFunction functionWithControlPoints:cp1.x :cp1.y :cp2.x :cp2.y];
+        timingFunction = [CAMediaTimingFunction functionWithControlPoints:(float)cp1.x :(float)cp1.y :(float)cp2.x :(float)cp2.y];
       } else {
         // No easing function specified, fallback to linear
         timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableColorValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableColorValue.m
@@ -118,7 +118,7 @@
         // Easing function
         CGPoint cp1 = [self _pointFromValueDict:timingControlPoint1];
         CGPoint cp2 = [self _pointFromValueDict:timingControlPoint2];
-        timingFunction = [CAMediaTimingFunction functionWithControlPoints:cp1.x :cp1.y :cp2.x :cp2.y];
+        timingFunction = [CAMediaTimingFunction functionWithControlPoints:(float)cp1.x :(float)cp1.y :(float)cp2.x :(float)cp2.y];
       } else {
         // No easing function specified, fallback to linear
         timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableNumberValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableNumberValue.m
@@ -118,7 +118,7 @@
         // Easing function
         CGPoint cp1 = [self _pointFromValueDict:timingControlPoint1];
         CGPoint cp2 = [self _pointFromValueDict:timingControlPoint2];
-        timingFunction = [CAMediaTimingFunction functionWithControlPoints:cp1.x :cp1.y :cp2.x :cp2.y];
+        timingFunction = [CAMediaTimingFunction functionWithControlPoints:(float)cp1.x :(float)cp1.y :(float)cp2.x :(float)cp2.y];
       } else {
         // No easing function specified, fallback to linear
         timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatablePointValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatablePointValue.m
@@ -147,9 +147,9 @@
       
       if (timingControlPoint1 && timingControlPoint2) {
         // Easing function
-        CGPoint cp1 = [self _pointFromValueDict:timingControlPoint1];
-        CGPoint cp2 = [self _pointFromValueDict:timingControlPoint2];
-        timingFunction = [CAMediaTimingFunction functionWithControlPoints:cp1.x :cp1.y :cp2.x :cp2.y];
+        CGPoint point1 = [self _pointFromValueDict:timingControlPoint1];
+        CGPoint point2 = [self _pointFromValueDict:timingControlPoint2];
+        timingFunction = [CAMediaTimingFunction functionWithControlPoints:(float)point1.x :(float)point1.y :(float)point2.x :(float)point2.y];
       } else {
         // No easing function specified, fallback to linear
         timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableScaleValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableScaleValue.m
@@ -118,7 +118,7 @@
         // Easing function
         CGPoint cp1 = [self _pointFromValueDict:timingControlPoint1];
         CGPoint cp2 = [self _pointFromValueDict:timingControlPoint2];
-        timingFunction = [CAMediaTimingFunction functionWithControlPoints:cp1.x :cp1.y :cp2.x :cp2.y];
+        timingFunction = [CAMediaTimingFunction functionWithControlPoints:(float)cp1.x :(float)cp1.y :(float)cp2.x :(float)cp2.y];
       } else {
         // No easing function specified, fallback to linear
         timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];

--- a/lottie-ios/Classes/AnimatableProperties/LOTAnimatableShapeValue.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTAnimatableShapeValue.m
@@ -82,7 +82,10 @@
     // Calculate percentage value for keyframe.
     //CA Animations accept time values of 0-1 as a percentage of animation completed.
     NSNumber *timePercentage = @((frame.floatValue - _startFrame.floatValue) / _durationFrames.floatValue);
-    
+
+// Silences "Cast from 'const struct CGPath *' to 'id' drops const qualifier" warning when adding CGPath's to array
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
     if (outShape) {
       //add out value
       [shapeValues addObject:(id)[[self _bezierShapeFromValue:outShape closed:closed] CGPath]];
@@ -129,14 +132,15 @@
         // Easing function
         CGPoint cp1 = [self _pointFromValueDict:timingControlPoint1];
         CGPoint cp2 = [self _pointFromValueDict:timingControlPoint2];
-        timingFunction = [CAMediaTimingFunction functionWithControlPoints:cp1.x :cp1.y :cp2.x :cp2.y];
+        timingFunction = [CAMediaTimingFunction functionWithControlPoints:(float)cp1.x :(float)cp1.y :(float)cp2.x :(float)cp2.y];
       } else {
         // No easing function specified, fallback to linear
         timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
       }
       [timingFunctions addObject:timingFunction];
     }
-    
+#pragma clang diagnostic pop
+
     // add time
     [keyTimes addObject:timePercentage];
     
@@ -184,7 +188,7 @@
   
   [shape moveToPoint:[self _vertexAtIndex:0 inArray:pointsArray]];
   
-  for (int i = 1; i < pointsArray.count; i ++) {
+  for (NSUInteger i = 1; i < pointsArray.count; i ++) {
     CGPoint vertex = [self _vertexAtIndex:i inArray:pointsArray];
     CGPoint previousVertex = [self _vertexAtIndex:i - 1 inArray:pointsArray];
     CGPoint cp1 = LOT_PointAddedToPoint(previousVertex, [self _vertexAtIndex:i - 1 inArray:outTangents]);
@@ -247,7 +251,7 @@
 }
 
 - (CGPoint)_vertexAtIndex:(NSInteger)idx inArray:(NSArray *)points {
-  NSAssert((idx < points.count),
+  NSAssert((idx < (NSInteger)points.count),
            @"Lottie: Vertex Point out of bounds");
   
   NSArray *pointArray = points[idx];

--- a/lottie-ios/Classes/AnimationCache/LOTAnimationCache.h
+++ b/lottie-ios/Classes/AnimationCache/LOTAnimationCache.h
@@ -15,6 +15,7 @@
 + (instancetype)sharedCache;
 
 - (void)addAnimation:(LOTComposition *)animation forKey:(NSString *)key;
+- (void)removeAnimationForKey:(NSString *)key;
 - (LOTComposition *)animationForKey:(NSString *)key;
 
 @end

--- a/lottie-ios/Classes/AnimationCache/LOTAnimationCache.m
+++ b/lottie-ios/Classes/AnimationCache/LOTAnimationCache.m
@@ -8,7 +8,7 @@
 
 #import "LOTAnimationCache.h"
 
-const NSInteger kLOTCacheSize = 50;
+static const NSInteger kLOTCacheSize = 50;
 
 @implementation LOTAnimationCache {
   NSMutableDictionary *animationsCache_;

--- a/lottie-ios/Classes/AnimationCache/LOTAnimationCache.m
+++ b/lottie-ios/Classes/AnimationCache/LOTAnimationCache.m
@@ -44,6 +44,14 @@ const NSInteger kLOTCacheSize = 50;
   [animationsCache_ setObject:animation forKey:key];
 }
 
+- (void)removeAnimationForKey:(NSString *)key {
+    if (!key) {
+        return ;
+    }
+    [lruOrderArray_ removeObject:key];
+    [animationsCache_ removeObjectForKey:key];
+}
+
 - (LOTComposition *)animationForKey:(NSString *)key {
   if (!key) {
     return nil;

--- a/lottie-ios/Classes/Extensions/CGGeometry+LOTAdditions.m
+++ b/lottie-ios/Classes/Extensions/CGGeometry+LOTAdditions.m
@@ -10,8 +10,8 @@ const CGSize CGSizeMax = {CGFLOAT_MAX, CGFLOAT_MAX};
 // For a rect with .origin={5, 5.5}, .size=(10, 10), it will return .origin={5,5}, .size={10, 11};
 // LOT_RectIntegral will return {5,5}, {10, 10}.
 CGRect LOT_RectIntegral(CGRect rect) {
-  rect.origin = CGPointMake(rintf(rect.origin.x), rintf(rect.origin.y));
-  rect.size = CGSizeMake(ceilf(rect.size.width), ceil(rect.size.height));
+  rect.origin = CGPointMake(rintf((float)rect.origin.x), rintf((float)rect.origin.y));
+  rect.size = CGSizeMake(ceilf((float)rect.size.width), ceil(rect.size.height));
   return rect;
 }
 
@@ -93,8 +93,8 @@ CGRect LOT_RectInsetAll(CGRect rect, CGFloat leftInset, CGFloat rightInset, CGFl
 
 CGRect LOT_RectFramedCenteredInRect(CGRect rect, CGSize size, BOOL integral) {
   CGRect result;
-  result.origin.x = rect.origin.x + rintf(0.5f * (rect.size.width - size.width));
-  result.origin.y = rect.origin.y + rintf(0.5f * (rect.size.height - size.height));
+  result.origin.x = rect.origin.x + rintf(0.5f * (float)(rect.size.width - size.width));
+  result.origin.y = rect.origin.y + rintf(0.5f * (float)(rect.size.height - size.height));
   result.size = size;
   
   if (integral) { result = LOT_RectIntegral(result); }
@@ -106,7 +106,7 @@ CGRect LOT_RectFramedCenteredInRect(CGRect rect, CGSize size, BOOL integral) {
 CGRect LOT_RectFramedLeftInRect(CGRect rect, CGSize size, CGFloat inset, BOOL integral) {
   CGRect result;
   result.origin.x = rect.origin.x + inset;
-  result.origin.y = rect.origin.y + rintf(0.5f * (rect.size.height - size.height));
+  result.origin.y = rect.origin.y + rintf(0.5f * (float)(rect.size.height - size.height));
   result.size = size;
   
   if (integral) { result = LOT_RectIntegral(result); }
@@ -116,7 +116,7 @@ CGRect LOT_RectFramedLeftInRect(CGRect rect, CGSize size, CGFloat inset, BOOL in
 CGRect LOT_RectFramedRightInRect(CGRect rect, CGSize size, CGFloat inset, BOOL integral) {
   CGRect result;
   result.origin.x = rect.origin.x + rect.size.width - size.width - inset;
-  result.origin.y = rect.origin.y + rintf(0.5f * (rect.size.height - size.height));
+  result.origin.y = rect.origin.y + rintf(0.5f * (float)(rect.size.height - size.height));
   result.size = size;
   
   if (integral) { result = LOT_RectIntegral(result); }
@@ -125,7 +125,7 @@ CGRect LOT_RectFramedRightInRect(CGRect rect, CGSize size, CGFloat inset, BOOL i
 
 CGRect LOT_RectFramedTopInRect(CGRect rect, CGSize size, CGFloat inset, BOOL integral) {
   CGRect result;
-  result.origin.x = rect.origin.x + rintf(0.5f * (rect.size.width - size.width));
+  result.origin.x = rect.origin.x + rintf(0.5f * (float)(rect.size.width - size.width));
   result.origin.y = rect.origin.y + inset;
   result.size = size;
   
@@ -135,7 +135,7 @@ CGRect LOT_RectFramedTopInRect(CGRect rect, CGSize size, CGFloat inset, BOOL int
 
 CGRect LOT_RectFramedBottomInRect(CGRect rect, CGSize size, CGFloat inset, BOOL integral) {
   CGRect result;
-  result.origin.x = rect.origin.x + rintf(0.5f * (rect.size.width - size.width));
+  result.origin.x = rect.origin.x + rintf(0.5f * (float)(rect.size.width - size.width));
   result.origin.y = rect.origin.y + rect.size.height - size.height - inset;
   result.size = size;
   
@@ -188,7 +188,7 @@ CGRect LOT_RectFramedBottomRightInRect(CGRect rect, CGSize size, CGFloat insetWi
 CGRect LOT_RectAttachedLeftToRect(CGRect rect, CGSize size, CGFloat margin, BOOL integral) {
   CGRect result;
   result.origin.x = rect.origin.x - size.width - margin;
-  result.origin.y = rect.origin.y + rintf(0.5f * (rect.size.height - size.height));
+  result.origin.y = rect.origin.y + rintf(0.5f * (float)(rect.size.height - size.height));
   result.size = size;
   
   if (integral) { result = LOT_RectIntegral(result); }
@@ -198,7 +198,7 @@ CGRect LOT_RectAttachedLeftToRect(CGRect rect, CGSize size, CGFloat margin, BOOL
 CGRect LOT_RectAttachedRightToRect(CGRect rect, CGSize size, CGFloat margin, BOOL integral) {
   CGRect result;
   result.origin.x = rect.origin.x + rect.size.width + margin;
-  result.origin.y = rect.origin.y + rintf(0.5f * (rect.size.height - size.height));
+  result.origin.y = rect.origin.y + rintf(0.5f * (float)(rect.size.height - size.height));
   result.size = size;
   
   if (integral) { result = LOT_RectIntegral(result); }
@@ -207,7 +207,7 @@ CGRect LOT_RectAttachedRightToRect(CGRect rect, CGSize size, CGFloat margin, BOO
 
 CGRect LOT_RectAttachedTopToRect(CGRect rect, CGSize size, CGFloat margin, BOOL integral) {
   CGRect result;
-  result.origin.x = rect.origin.x + rintf(0.5f * (rect.size.width - size.width));
+  result.origin.x = rect.origin.x + rintf(0.5f * (float)(rect.size.width - size.width));
   result.origin.y = rect.origin.y - size.height - margin;
   result.size = size;
   
@@ -237,7 +237,7 @@ CGRect LOT_RectAttachedTopRightToRect(CGRect rect, CGSize size, CGFloat marginWi
 
 CGRect LOT_RectAttachedBottomToRect(CGRect rect, CGSize size, CGFloat margin, BOOL integral) {
   CGRect result;
-  result.origin.x = rect.origin.x + rintf(0.5f * (rect.size.width - size.width));
+  result.origin.x = rect.origin.x + rintf(0.5f * (float)(rect.size.width - size.width));
   result.origin.y = rect.origin.y + rect.size.height + margin;
   result.size = size;
   
@@ -320,10 +320,10 @@ CGFloat LOT_DegreesToRadians(CGFloat degrees) {
 }
 
 GLKMatrix4 LOT_GLKMatrix4FromCATransform(CATransform3D xform) {
-  return GLKMatrix4Make(xform.m11, xform.m12, xform.m13, xform.m14,
-                        xform.m21, xform.m22, xform.m23, xform.m24,
-                        xform.m31, xform.m32, xform.m33, xform.m34,
-                        xform.m41, xform.m42, xform.m43, xform.m44);
+  return GLKMatrix4Make((float)xform.m11, (float)xform.m12, (float)xform.m13, (float)xform.m14,
+                        (float)xform.m21, (float)xform.m22, (float)xform.m23, (float)xform.m24,
+                        (float)xform.m31, (float)xform.m32, (float)xform.m33, (float)xform.m34,
+                        (float)xform.m41, (float)xform.m42, (float)xform.m43, (float)xform.m44);
 }
 
 CATransform3D LOT_CATransform3DFromGLKMatrix4(GLKMatrix4 xform) {
@@ -356,10 +356,10 @@ CATransform3D LOT_CATransform3DSlerpToTransform(CATransform3D fromXorm, CATransf
   GLKMatrix4 xform2 = LOT_GLKMatrix4FromCATransform(toXform);
   GLKQuaternion q1 = GLKQuaternionMakeWithMatrix4(xform1);
   GLKQuaternion q2 = GLKQuaternionMakeWithMatrix4(xform2);
-  GLKQuaternion r1 = GLKQuaternionSlerp(q1, q2, amount);
+  GLKQuaternion r1 = GLKQuaternionSlerp(q1, q2, (float)amount);
   GLKVector4 t1 = GLKVector4Make(xform1.m30, xform1.m31, xform1.m32, xform1.m33);
   GLKVector4 t2 = GLKVector4Make(xform2.m30, xform2.m31, xform2.m32, xform2.m33);
-  GLKVector4 r2 = GLKVector4Lerp(t1, t2, amount);
+  GLKVector4 r2 = GLKVector4Lerp(t1, t2, (float)amount);
   
   GLKMatrix4 rX = GLKMatrix4MakeWithQuaternion(r1);
   rX.m30 = r2.x;

--- a/lottie-ios/Classes/Extensions/UIColor+Expanded.m
+++ b/lottie-ios/Classes/Extensions/UIColor+Expanded.m
@@ -74,7 +74,12 @@ static NSMutableDictionary *colorNameCache = nil;
 		case kCGColorSpaceModelRGB:
 		case kCGColorSpaceModelMonochrome:
 			return YES;
-		default:
+ 		case kCGColorSpaceModelLab:
+ 		case kCGColorSpaceModelCMYK:
+ 		case kCGColorSpaceModelDeviceN:
+ 		case kCGColorSpaceModelIndexed:
+ 		case kCGColorSpaceModelPattern:
+ 		case kCGColorSpaceModelUnknown:
 			return NO;
 	}
 }
@@ -86,10 +91,10 @@ static NSMutableDictionary *colorNameCache = nil;
 	if (![self LOT_red:&r green:&g blue:&b alpha:&a]) return nil;
   
 	return [NSArray arrayWithObjects:
-          [NSNumber numberWithFloat:r],
-          [NSNumber numberWithFloat:g],
-          [NSNumber numberWithFloat:b],
-          [NSNumber numberWithFloat:a],
+          [NSNumber numberWithFloat:(float)r],
+          [NSNumber numberWithFloat:(float)g],
+          [NSNumber numberWithFloat:(float)b],
+          [NSNumber numberWithFloat:(float)a],
           nil];
 }
 
@@ -109,7 +114,13 @@ static NSMutableDictionary *colorNameCache = nil;
 			b = components[2];
 			a = components[3];
 			break;
-		default:	// We don't know how to handle this model
+ 		case kCGColorSpaceModelUnknown:
+ 		case kCGColorSpaceModelPattern:
+ 		case kCGColorSpaceModelIndexed:
+ 		case kCGColorSpaceModelDeviceN:
+ 		case kCGColorSpaceModelCMYK:
+ 		case kCGColorSpaceModelLab:
+        // We don't know how to handle this model
 			return NO;
 	}
   
@@ -161,9 +172,9 @@ static NSMutableDictionary *colorNameCache = nil;
 	g = MIN(MAX(self.green, 0.0f), 1.0f);
 	b = MIN(MAX(self.blue, 0.0f), 1.0f);
   
-	return (((int)roundf(r * 255)) << 16)
-  | (((int)roundf(g * 255)) << 8)
-  | (((int)roundf(b * 255)));
+	return (UInt32)((lround(r * 255.f)) << 16)
+  | (UInt32)((lround(g * 255.f)) << 8)
+  | (UInt32)((lround(b * 255.f)));
 }
 
 #pragma mark Arithmetic operations
@@ -293,7 +304,12 @@ static NSMutableDictionary *colorNameCache = nil;
 		case kCGColorSpaceModelMonochrome:
 			result = [NSString stringWithFormat:@"{%0.3f, %0.3f}", self.white, self.alpha];
 			break;
-		default:
+ 		case kCGColorSpaceModelLab:
+ 		case kCGColorSpaceModelCMYK:
+ 		case kCGColorSpaceModelDeviceN:
+ 		case kCGColorSpaceModelIndexed:
+ 		case kCGColorSpaceModelPattern:
+ 		case kCGColorSpaceModelUnknown:
 			result = nil;
 	}
 	return result;
@@ -339,9 +355,9 @@ static NSMutableDictionary *colorNameCache = nil;
 #pragma mark Class methods
 
 + (UIColor *)LOT_randomColor {
-	return [UIColor colorWithRed:(CGFloat)random() / (CGFloat)RAND_MAX
-                         green:(CGFloat)random() / (CGFloat)RAND_MAX
-                          blue:(CGFloat)random() / (CGFloat)RAND_MAX
+	return [UIColor colorWithRed:random() / (CGFloat)RAND_MAX
+                         green:random() / (CGFloat)RAND_MAX
+                          blue:random() / (CGFloat)RAND_MAX
                          alpha:1.0f];
 }
 
@@ -394,10 +410,10 @@ static NSMutableDictionary *colorNameCache = nil;
   amount = CLAMP(amount, 0.f, 1.f);
   const CGFloat *fromComponents = CGColorGetComponents(fromColor.CGColor);
   const CGFloat *toComponents = CGColorGetComponents(toColor.CGColor);
-  float r = fromComponents[0] + ((toComponents[0] - fromComponents[0]) * amount);
-  float g = fromComponents[1] + ((toComponents[1] - fromComponents[1]) * amount);
-  float b = fromComponents[2] + ((toComponents[2] - fromComponents[2]) * amount);
-  float a = fromComponents[3] + ((toComponents[3] - fromComponents[3]) * amount);
+  CGFloat r = fromComponents[0] + ((toComponents[0] - fromComponents[0]) * amount);
+  CGFloat g = fromComponents[1] + ((toComponents[1] - fromComponents[1]) * amount);
+  CGFloat b = fromComponents[2] + ((toComponents[2] - fromComponents[2]) * amount);
+  CGFloat a = fromComponents[3] + ((toComponents[3] - fromComponents[3]) * amount);
   return [UIColor colorWithRed:r green:g blue:b alpha:a];
 }
 

--- a/lottie-ios/Classes/Models/LOTLayerGroup.h
+++ b/lottie-ios/Classes/Models/LOTLayerGroup.h
@@ -23,8 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) NSArray <LOTLayer *> *layers;
 
-- (LOTLayer *)layerModelForID:(NSNumber *)layerID;
-- (LOTLayer *)layerForReferenceID:(NSString *)referenceID;
+- (nullable LOTLayer *)layerModelForID:(NSNumber *)layerID;
+- (nullable LOTLayer *)layerForReferenceID:(NSString *)referenceID;
 
 @end
 

--- a/lottie-ios/Classes/Models/LOTLayerGroup.m
+++ b/lottie-ios/Classes/Models/LOTLayerGroup.m
@@ -13,8 +13,8 @@
 @implementation LOTLayerGroup {
   CGRect _bounds;
   NSNumber *_framerate;
-  NSDictionary *_modelMap;
-  NSDictionary *_referenceIDMap;
+  NSDictionary<NSNumber *, LOTLayer *> *_modelMap;
+  NSDictionary<NSString *, LOTLayer *> *_referenceIDMap;
 }
 
 - (instancetype)initWithLayerJSON:(NSArray *)layersJSON

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -65,7 +65,7 @@
   }
   CGFloat speed = _animationIsPlaying ? _animationSpeed : 0;
   
-  _layer.speed = speed;
+  _layer.speed = (float)speed;
   _layer.repeatCount = _loopAnimation ? HUGE_VALF : 0;
   _layer.timeOffset = 0;
   _layer.beginTime = 0;
@@ -84,11 +84,11 @@
   if (!_needsAnimationUpdate) {
     _needsAnimationUpdate = YES;
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-      _needsAnimationUpdate = NO;
-      if (_animationIsPlaying) {
-        [self setAnimationIsPlaying:_animationIsPlaying];
+      self->_needsAnimationUpdate = NO;
+      if (self->_animationIsPlaying) {
+        [self setAnimationIsPlaying:self->_animationIsPlaying];
       } else {
-        [self setAnimatedProgress:_animatedProgress updateAnimation:true];
+        [self setAnimatedProgress:self->_animatedProgress updateAnimation:true];
       }
       [self.layer setNeedsDisplay];
     }];
@@ -152,8 +152,8 @@
 - (CGFloat)animatedProgress {
   if (_animationIsPlaying) {
     CFTimeInterval localTime = [_layer convertTime:CACurrentMediaTime() fromLayer:nil];
-    NSInteger eLocalTime = roundf(localTime * 10000);
-    NSInteger eDuration = roundf(_animationDuration * 10000);
+    NSInteger eLocalTime = lroundf((float)localTime * 10000.f);
+    NSInteger eDuration = lroundf((float)_animationDuration * 10000.f);
     if (eLocalTime > 0) {
       return  (float)eLocalTime / (float)eDuration;
     }
@@ -166,8 +166,8 @@
     CFTimeInterval localTime = [_layer convertTime:CACurrentMediaTime() fromLayer:nil];
     if (_previousLocalTime == localTime && localTime != 0) {
       _animationIsPlaying = NO;
-      NSInteger eLocalTime = roundf(localTime * 10000);
-      NSInteger eDuration = roundf(_animationDuration * 10000);
+      NSInteger eLocalTime = lroundf((float)localTime * 10000.f);
+      NSInteger eDuration = lroundf((float)_animationDuration * 10000.f);
 
       _animatedProgress = (float)eLocalTime / (float)eDuration;
       if (eLocalTime == eDuration) {
@@ -296,11 +296,11 @@
           return;
         }
         
-        LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:animationJSON];
+        LOTComposition *laScene2 = [[LOTComposition alloc] initWithJSON:animationJSON];
         dispatch_async(dispatch_get_main_queue(), ^(void){
-          [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:url.absoluteString];
+          [[LOTAnimationCache sharedCache] addAnimation:laScene2 forKey:url.absoluteString];
           [self _initializeAnimationContainer];
-          [self _setupWithSceneModel:laScene restoreAnimationState:YES];
+          [self _setupWithSceneModel:laScene2 restoreAnimationState:YES];
         });
       });
     }
@@ -502,6 +502,8 @@
 
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-macros"
 #define LOTViewContentMode UIViewContentMode
 #define LOTViewContentModeScaleToFill UIViewContentModeScaleToFill
 #define LOTViewContentModeScaleAspectFit UIViewContentModeScaleAspectFit
@@ -516,6 +518,7 @@
 #define LOTViewContentModeTopRight UIViewContentModeTopRight
 #define LOTViewContentModeBottomLeft UIViewContentModeBottomLeft
 #define LOTViewContentModeBottomRight UIViewContentModeBottomRight
+#pragma clang diagnostic pop
 
 - (void)didMoveToWindow {
   [super didMoveToWindow];

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -187,6 +187,10 @@
 
 @end
 
+@interface LOTAnimationView ()
+@property (nonatomic, copy) NSString *cacheKey;
+@end
+
 @implementation LOTAnimationView {
   CALayer *_timingLayer;
   LOTCompositionLayer *_compLayer;
@@ -205,10 +209,12 @@
 + (instancetype)animationNamed:(NSString *)animationName inBundle:(NSBundle *)bundle {
   NSArray *components = [animationName componentsSeparatedByString:@"."];
   animationName = components.firstObject;
-  
+  LOTAnimationView *animationView;
   LOTComposition *comp = [[LOTAnimationCache sharedCache] animationForKey:animationName];
   if (comp) {
-    return [[LOTAnimationView alloc] initWithModel:comp inBundle:bundle];
+    animationView = [[LOTAnimationView alloc] initWithModel:comp inBundle:bundle];
+    animationView.cacheKey = animationName;
+    return animationView;
   }
   
   NSError *error;
@@ -219,7 +225,9 @@
   if (JSONObject && !error) {
     LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:JSONObject];
     [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:animationName];
-    return [[LOTAnimationView alloc] initWithModel:laScene inBundle:bundle];
+    animationView = [[LOTAnimationView alloc] initWithModel:laScene inBundle:bundle];
+    animationView.cacheKey = animationName;
+    return animationView;
   }
   
   NSException* resourceNotFoundException = [NSException exceptionWithName:@"ResourceNotFoundException"
@@ -239,10 +247,12 @@
 
 + (instancetype)animationWithFilePath:(NSString *)filePath{
     NSString *animationName = filePath;
-    
+    LOTAnimationView *animationView;
     LOTComposition *comp = [[LOTAnimationCache sharedCache] animationForKey:animationName];
     if (comp) {
-        return [[LOTAnimationView alloc] initWithModel:comp inBundle:[NSBundle mainBundle]];
+        animationView = [[LOTAnimationView alloc] initWithModel:comp inBundle:[NSBundle mainBundle]];
+        animationView.cacheKey = animationName;
+        return animationView;
     }
     
     NSError *error;
@@ -253,7 +263,9 @@
         LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:JSONObject];
         laScene.rootDirectory = [filePath stringByDeletingLastPathComponent];
         [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:animationName];
-        return [[LOTAnimationView alloc] initWithModel:laScene inBundle:[NSBundle mainBundle]];
+        animationView = [[LOTAnimationView alloc] initWithModel:laScene inBundle:[NSBundle mainBundle]];
+        animationView.cacheKey = animationName;
+        return animationView;
     }
     
     NSException* resourceNotFoundException = [NSException exceptionWithName:@"ResourceNotFoundException"
@@ -265,6 +277,7 @@
 - (instancetype)initWithContentsOfURL:(NSURL *)url {
   self = [super initWithFrame:CGRectZero];
   if (self) {
+    self.cacheKey = url.absoluteString;
     LOTComposition *laScene = [[LOTAnimationCache sharedCache] animationForKey:url.absoluteString];
     if (laScene) {
       [self _initializeAnimationContainer];
@@ -399,6 +412,18 @@
 - (void)addSubview:(LOTView *)view
       toLayerNamed:(NSString *)layer {
   [_compLayer addSublayer:view toLayerNamed:layer];
+}
+
+- (void)setCacheEnable:(BOOL)cacheEnable{
+    _cacheEnable = cacheEnable;
+    if (!self.cacheKey) {
+        return;
+    }
+    if (cacheEnable) {
+        [[LOTAnimationCache sharedCache] addAnimation:_sceneModel forKey:self.cacheKey];
+    }else {
+        [[LOTAnimationCache sharedCache] removeAnimationForKey:self.cacheKey];
+    }
 }
 
 # pragma mark - Display Link

--- a/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
+++ b/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
@@ -19,9 +19,9 @@ typedef enum : NSUInteger {
 - (instancetype _Nonnull)initWithDuration:(CGFloat)duration layer:(CALayer * _Nullable)layer frameRate:(NSNumber * _Nullable)framerate;
 
 - (void)setAnimationIsPlaying:(BOOL)animationIsPlaying;
-- (void)setAnimationDoesLoop:(BOOL)loopAnimation;
-- (void)setAnimatedProgress:(CGFloat)progress;
-- (void)setAnimationSpeed:(CGFloat)speed;
+- (void)setAnimationDoesLoop:(BOOL)loopAnimation updateAnimation:(BOOL)updateAnimation;
+- (void)setAnimatedProgress:(CGFloat)progress updateAnimation:(BOOL)updateAnimation;
+- (void)setAnimationSpeed:(CGFloat)speed updateAnimation:(BOOL)updateAnimation;
 
 @property (nonatomic, readonly) BOOL loopAnimation;
 @property (nonatomic, readonly) BOOL animationIsPlaying;

--- a/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
+++ b/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
@@ -39,6 +39,5 @@ typedef enum : NSUInteger {
 
 @property (nonatomic, readonly) LOTComposition * _Nonnull sceneModel;
 @property (nonatomic, strong) LOTAnimationState *_Nonnull animationState;
-@property (nonatomic, copy, nullable) LOTAnimationCompletionBlock completionBlock;
 
 @end

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -16,17 +16,18 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 + (nonnull instancetype)animationNamed:(nonnull NSString *)animationName NS_SWIFT_NAME(init(name:));
 + (nonnull instancetype)animationNamed:(nonnull NSString *)animationName inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(name:bundle:));
 + (nonnull instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(init(json:));
-+ (instancetype)animationFromJSON:(NSDictionary *)animationJSON inBundle:(NSBundle *)bundle NS_SWIFT_NAME(init(json:bundle:));
++ (nonnull instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(json:bundle:));
 
 - (nonnull instancetype)initWithContentsOfURL:(nonnull NSURL *)url;
 
-+ (instancetype)animationWithFilePath:(NSString *)filePath NS_SWIFT_NAME(init(filePath:));
++ (nonnull instancetype)animationWithFilePath:(nonnull NSString *)filePath NS_SWIFT_NAME(init(filePath:));
 
 @property (nonatomic, readonly) BOOL isAnimationPlaying;
 @property (nonatomic, assign) BOOL loopAnimation;
 @property (nonatomic, assign) CGFloat animationProgress;
 @property (nonatomic, assign) CGFloat animationSpeed;
 @property (nonatomic, readonly) CGFloat animationDuration;
+@property (nonatomic, assign) BOOL cacheEnable;
 
 - (void)playWithCompletion:(nullable LOTAnimationCompletionBlock)completion;
 - (void)play;

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -28,6 +28,7 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 @property (nonatomic, assign) CGFloat animationSpeed;
 @property (nonatomic, readonly) CGFloat animationDuration;
 @property (nonatomic, assign) BOOL cacheEnable;
+@property (nonatomic, copy, nullable) LOTAnimationCompletionBlock completionBlock;
 
 - (void)playWithCompletion:(nullable LOTAnimationCompletionBlock)completion;
 - (void)play;


### PR DESCRIPTION
### Background

PR #174 was a good first step towards enabling the chaining of animations, but it became apparent that the `completionBlock` should be decoupled from setting only via `play()` or else you'd end up with a very large nesting of animations.

Consider this a quick fix (only applicable for looping scenarios where you can explicitly control timing), but might be interesting to allow more explicit chaining or stitching together of animations in v2.0.

### Example

Let's say you were creating a network spinner and needed a continuously rotating icon to eventually turn into a different icon after the network response returned success/failure.

Currently, you can create the looping animation and then when the network response returns, you set looping to `false` and it will call the completion block. This is fine, but if you also have many other animations, it soon becomes very messy and very nested since you are defining async code (e.g. the completion block) far away from its area of concerns.

If you could set the completion block on a given animation any time and then stop looping, it allows you to isolate the code better and keep your nesting to maybe one or two levels deep maximum.