### PR TITLE
Expose completionBlock

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
+++ b/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
@@ -17,7 +17,6 @@ typedef enum : NSUInteger {
 @interface LOTAnimationView () <CAAnimationDelegate>
 
 @property (nonatomic, readonly) LOTComposition * _Nonnull sceneModel;
-@property (nonatomic, copy, nullable) LOTAnimationCompletionBlock completionBlock;
 @property (nonatomic, copy, nullable) NSString *cacheKey;
 
 @end

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -57,6 +57,9 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 /// Enables or disables caching of the backing animation model. Defaults to YES
 @property (nonatomic, assign) BOOL cacheEnable;
 
+/// Sets a completion block to call when the animation has completed
+@property (nonatomic, copy, nullable) LOTAnimationCompletionBlock completionBlock;
+
 /* 
  * Plays the animation from its current position to a specific progress. 
  * The animation will start from its current position.


### PR DESCRIPTION
Replaces #316 

### Background

PR #174 was a good first step towards enabling the chaining of animations, but it became apparent that the `completionBlock` should be decoupled from setting only via `play()` or else you'd end up with a very large nesting of animations.

Consider this a quick fix (only applicable for looping scenarios where you can explicitly control timing), but might be interesting to allow more explicit chaining or stitching together of animations in v2.0.

### Example

Let's say you were creating a network spinner and needed a continuously rotating icon to eventually turn into a different icon after the network response returned success/failure.

Currently, you can create the looping animation and then when the network response returns, you set looping to `false` and it will call the completion block. This is fine, but if you also have many other animations, it soon becomes very messy and very nested since you are defining async code (e.g. the completion block) far away from its area of concerns.

If you could set the completion block on a given animation any time and then stop looping, it allows you to isolate the code better and keep your nesting to maybe one or two levels deep maximum.