### PR TITLE
fix the Memory leak in LOTBezierPath.m file

### DIFF
--- a/lottie-ios/Classes/Extensions/LOTBezierPath.m
+++ b/lottie-ios/Classes/Extensions/LOTBezierPath.m
@@ -385,7 +385,13 @@ struct LOT_Subpath {
         // We have possibly reached the end.
         // Current From and To will possibly need to be reset.
         if (fromLength < toLength) {
-          break;
+            while (subpath) {
+                LOT_Subpath *nextNode = subpath->nextSubpath;
+                subpath->nextSubpath = NULL;
+                free(subpath);
+                subpath = nextNode;
+            }
+            break;
         } else {
           currentStartLength = fromLength;
           currentEndLength = totalLength;


### PR DESCRIPTION
There is a while loop in the method trimPathFromT: toT: offset:  in lottie-ios/Classes/Extensions/LOTBezierPath.m. Because the break keyword make the loop exit，and the  less LOT_Subpath memory couldn't free. so to fix this problem, add the code to free the less LOT_Subpath memory before break. 