### PR TITLE
Add better support for negative animation speeds

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -210,27 +210,14 @@ static NSString * const kCompContainerAnimationKey = @"play";
   if (!_sceneModel) {
     return 0;
   }
-  CGFloat absoluteProgress = ((frame.floatValue - _sceneModel.startFrame.floatValue) / (_sceneModel.endFrame.floatValue - _sceneModel.startFrame.floatValue));
-  if ([self _isPlayingForwards]) {
-    return absoluteProgress;
-  } else {
-    // If the animation is playing backwards, the progress is inverted.
-    return 1 - absoluteProgress;
-  }
+  return ((frame.floatValue - _sceneModel.startFrame.floatValue) / (_sceneModel.endFrame.floatValue - _sceneModel.startFrame.floatValue));
 }
 
 - (NSNumber *)_frameForProgress:(CGFloat)progress {
   if (!_sceneModel) {
     return @0;
   }
-  CGFloat absoluteProgress = ((_sceneModel.endFrame.floatValue - _sceneModel.startFrame.floatValue) * progress);
-  if ([self _isPlayingForwards]) {
-    // If we're moving forward, then add the absolute progress to the start.
-    return @(absoluteProgress + _sceneModel.startFrame.floatValue);
-  } else {
-    // It the animation is playing backwards, subtract the progress from the end.
-    return @(_sceneModel.endFrame.floatValue - absoluteProgress);
-  }
+  return @(((_sceneModel.endFrame.floatValue - _sceneModel.startFrame.floatValue) * progress) + _sceneModel.startFrame.floatValue);
 }
 
 - (BOOL)_isPlayingForwards {
@@ -397,18 +384,11 @@ static NSString * const kCompContainerAnimationKey = @"play";
 }
 
 -(void)setAnimationSpeed:(CGFloat)animationSpeed {
-  BOOL directionChange = NO;
-  if ((animationSpeed >= 0 && _animationSpeed < 0) || (animationSpeed < 0 && _animationSpeed >= 0)) {
-    directionChange = YES;
-  }
   _animationSpeed = animationSpeed;
-  NSNumber *frame = [_compContainer.presentationLayer.currentFrame copy];
   if (_isAnimationPlaying && _sceneModel) {
+    NSNumber *frame = [_compContainer.presentationLayer.currentFrame copy];
     [self setProgressWithFrame:frame callCompletionIfNecessary:NO];
     [self playFromFrame:_playRangeStartFrame toFrame:_playRangeEndFrame withCompletion:self.completionBlock];
-  } else if (directionChange) {
-    // The progress needs to be re-calculated if the speed direction changes if the animation is not playing.
-    _animationProgress = [self _progressForFrame:frame];
   }
 }
 

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -220,7 +220,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
   return @(((_sceneModel.endFrame.floatValue - _sceneModel.startFrame.floatValue) * progress) + _sceneModel.startFrame.floatValue);
 }
 
-- (BOOL)_isPlayingForwards {
+- (BOOL)_isSpeedNegative {
   // If the animation speed is negative, then we're moving backwards.
   return _animationSpeed >= 0;
 }
@@ -302,7 +302,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
   NSNumber *currentFrame = [self _frameForProgress:_animationProgress];
 
   currentFrame = @(MAX(MIN(currentFrame.floatValue, toEndFrame.floatValue), fromStartFrame.floatValue));
-  BOOL playingForward = [self _isPlayingForwards];
+  BOOL playingForward = [self _isSpeedNegative];
   if (currentFrame.floatValue == toEndFrame.floatValue && playingForward) {
     currentFrame = fromStartFrame;
   } else if (currentFrame.floatValue == fromStartFrame.floatValue && !playingForward) {
@@ -613,7 +613,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
     if (complete) {
       // Set the final frame based on the animation to/from values. If playing forward, use the
       // toValue otherwise we want to end on the fromValue.
-      frame = [self _isPlayingForwards] ? (NSNumber *)playAnimation.toValue : (NSNumber *)playAnimation.fromValue;
+      frame = [self _isSpeedNegative] ? (NSNumber *)playAnimation.toValue : (NSNumber *)playAnimation.fromValue;
     }
     [self _removeCurrentAnimationIfNecessary];
     [self setProgressWithFrame:frame callCompletionIfNecessary:NO];

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -46,9 +46,12 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 
 // TODO
 /// Sets a progress from 0 - 1 of the animation. If the animation is playing it will stop and the compeltion block will be called.
+/// The animation progress is in terms of absolute progress of the defined animation and does not
+/// take into account negative speeds.
 @property (nonatomic, assign) CGFloat animationProgress;
 
-/// Sets the speed of the animation. Accepts a negative value for reversing animation
+/// Sets the speed of the animation. Accepts a negative value for reversing animation.
+/// Negative speeds do not affect animationProgress
 @property (nonatomic, assign) CGFloat animationSpeed;
 
 /// Read only of the duration in seconds of the animation at speed of 1

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -46,12 +46,12 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 
 // TODO
 /// Sets a progress from 0 - 1 of the animation. If the animation is playing it will stop and the compeltion block will be called.
-/// The animation progress is in terms of absolute progress of the defined animation and does not
-/// take into account negative speeds.
+/// The current progress of the animation in absolute time.
+/// e.g. a value of 0.75 always represents the same point in the animation, regardless of positive
+/// or negative speed.
 @property (nonatomic, assign) CGFloat animationProgress;
 
 /// Sets the speed of the animation. Accepts a negative value for reversing animation.
-/// Negative speeds do not affect animationProgress
 @property (nonatomic, assign) CGFloat animationSpeed;
 
 /// Read only of the duration in seconds of the animation at speed of 1


### PR DESCRIPTION
- The progress can be calculated basd on negative speed
  + The end frame would be a progress of 0 and the start frame a progress of 1
  + Recalculate progress when the speed changes, otherwise a "jump" will be seen when restarting animation

- The frame for the progress can be calculated using the newly inverted progress
  + Determine the absolute progress based on current progress and determine which frame to use based on animation speed

- This fixes issues of animations playing with negative speeds "bouncing" back to their final position
  which was caused by the final frame being calculated based on a completed progress of 1 which then did not take into
  account the negative animation speed.