### PR TITLE
Moved convenience intializers to LOTComposition

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationCache.m
+++ b/lottie-ios/Classes/Private/LOTAnimationCache.m
@@ -64,4 +64,10 @@ const NSInteger kLOTCacheSize = 50;
   [animationsCache_ removeObjectForKey:key];
 }
 
+- (void)disableCaching {
+  [self clearCache];
+  animationsCache_ = nil;
+  lruOrderArray_ = nil;
+}
+
 @end

--- a/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
+++ b/lottie-ios/Classes/Private/LOTAnimationView_Internal.h
@@ -16,6 +16,4 @@ typedef enum : NSUInteger {
 
 @interface LOTAnimationView () <CAAnimationDelegate>
 
-@property (nonatomic, copy, nullable) NSString *cacheKey;
-
 @end

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationCache.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationCache.h
@@ -29,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Clears Everything from the Cache
 - (void)clearCache;
 
+/// Disables Caching Animation Model Objects
+- (void)disableCaching;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/lottie-ios/Classes/PublicHeaders/LOTComposition.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTComposition.h
@@ -15,17 +15,36 @@
 
 @interface LOTComposition : NSObject
 
-- (instancetype)initWithJSON:(NSDictionary *)jsonDictionary
-             withAssetBundle:(NSBundle *)bundle;
+/// Load animation by name from the default bundle, Images are also loaded from the bundle
++ (nullable instancetype)animationNamed:(nonnull NSString *)animationName NS_SWIFT_NAME(init(name:));
+
+/// Loads animation by name from specified bundle, Images are also loaded from the bundle
++ (nullable instancetype)animationNamed:(nonnull NSString *)animationName
+                              inBundle:(nonnull NSBundle *)bundle NS_SWIFT_NAME(init(name:bundle:));
+
+/// Loads an animation from a specific file path. WARNING Do not use a web URL for file path.
++ (nullable instancetype)animationWithFilePath:(nonnull NSString *)filePath NS_SWIFT_NAME(init(filePath:));
+
+/// Creates an animation from the deserialized JSON Dictionary
++ (nonnull instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(init(json:));
+
+/// Creates an animation from the deserialized JSON Dictionary, images are loaded from the specified bundle
++ (nonnull instancetype)animationFromJSON:(nullable NSDictionary *)animationJSON
+                                 inBundle:(nullable NSBundle *)bundle NS_SWIFT_NAME(init(json:bundle:));
+
+
+- (instancetype _Nonnull)initWithJSON:(NSDictionary * _Nullable)jsonDictionary
+                      withAssetBundle:(NSBundle * _Nullable)bundle;
 
 @property (nonatomic, readonly) CGRect compBounds;
-@property (nonatomic, readonly) NSNumber *startFrame;
-@property (nonatomic, readonly) NSNumber *endFrame;
-@property (nonatomic, readonly) NSNumber *framerate;
+@property (nonatomic, readonly, nullable) NSNumber *startFrame;
+@property (nonatomic, readonly, nullable) NSNumber *endFrame;
+@property (nonatomic, readonly, nullable) NSNumber *framerate;
 @property (nonatomic, readonly) NSTimeInterval timeDuration;
-@property (nonatomic, readonly) LOTLayerGroup *layerGroup;
-@property (nonatomic, readonly) LOTAssetGroup *assetGroup;
-@property (nonatomic, readwrite) NSString *rootDirectory;
-@property (nonatomic, readonly) NSBundle *assetBundle;
+@property (nonatomic, readonly, nullable) LOTLayerGroup *layerGroup;
+@property (nonatomic, readonly, nullable) LOTAssetGroup *assetGroup;
+@property (nonatomic, readwrite, nullable) NSString *rootDirectory;
+@property (nonatomic, readonly, nullable) NSBundle *assetBundle;
+@property (nonatomic, copy, nullable) NSString *cacheKey;
 
 @end


### PR DESCRIPTION
It makes more sense for the LOTComposition to own the convenience initializers in the same way UIImage owns the `imageNamed`  initializer