### PR TITLE
Fix for ios 8.1 and presentation layer crash

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -199,7 +199,7 @@
   if (self = [super initWithLayer:layer]) {
     if ([layer isKindOfClass:[LOTLayerContainer class]]) {
       LOTLayerContainer *other = (LOTLayerContainer *)layer;
-      self.currentFrame = other.currentFrame;
+      self.currentFrame = [other.currentFrame copy];
     }
   }
   return self;

--- a/lottie-ios/Classes/Extensions/LOTRadialGradientLayer.m
+++ b/lottie-ios/Classes/Extensions/LOTRadialGradientLayer.m
@@ -28,11 +28,7 @@
   return [super needsDisplayForKey:key];
 }
 
-- (id)actionForKey:(NSString *)key {
-  if (self.actions[key]) {
-    return self.actions[key];
-  }
-  
+- (id)actionForKey:(NSString *)key {  
   if ([key isEqualToString:@"startPoint"] ||
       [key isEqualToString:@"endPoint"] ||
       [key isEqualToString:@"colors"] ||


### PR DESCRIPTION
Two crashes here.

1. This fixes an issue with ios 8.1 where passing NSNull to a calayer in `actionForKey` resulted in a crash.
https://github.com/airbnb/lottie-ios/issues/392

2. The other is a rare crash that happens when a presentation layer is dereferenced by a webcore thread.
https://github.com/airbnb/lottie-ios/issues/387
