### PR TITLE
Fix memory-leaks, analyser warnings and code-style

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.h
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.h
@@ -12,7 +12,7 @@
 
 @interface LOTLayerContainer : CALayer
 
-- (instancetype _Nonnull )initWithModel:(LOTLayer * _Nullable)layer
+- (instancetype _Nonnull)initWithModel:(LOTLayer * _Nullable)layer
                  inLayerGroup:(LOTLayerGroup * _Nullable)layerGroup;
 
 @property (nonatomic,  readonly, strong, nullable) NSString *layerName;

--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -143,7 +143,7 @@
       } else {
         image = [UIImage imageWithContentsOfFile:imagePath];
       }
-    }else{
+    } else {
       NSArray *components = [asset.imageName componentsSeparatedByString:@"."];
       image = [UIImage imageNamed:components.firstObject inBundle:asset.assetBundle compatibleWithTraitCollection:nil];
     }
@@ -184,8 +184,8 @@
   return [super needsDisplayForKey:key];
 }
 
--(id<CAAction>)actionForKey:(NSString *)event {
-  if([event isEqualToString:@"currentFrame"]) {
+- (id<CAAction>)actionForKey:(NSString *)event {
+  if ([event isEqualToString:@"currentFrame"]) {
     CABasicAnimation *theAnimation = [CABasicAnimation
                                       animationWithKeyPath:event];
     theAnimation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];

--- a/lottie-ios/Classes/AnimatableLayers/LOTMaskContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTMaskContainer.m
@@ -47,6 +47,7 @@
       CGPathAddPath(pathRef, NULL, path.CGPath);
       self.path = pathRef;
       self.fillRule = @"even-odd";
+      CGPathRelease(pathRef);
     } else {
       self.path = path.CGPath;
     }

--- a/lottie-ios/Classes/AnimatableProperties/LOTKeyframe.m
+++ b/lottie-ios/Classes/AnimatableProperties/LOTKeyframe.m
@@ -87,7 +87,7 @@
 
 - (void)setupOutputWithData:(id)data {
   if ([data isKindOfClass:[NSNumber class]]) {
-    _floatValue = [(NSNumber*)data floatValue];
+    _floatValue = [(NSNumber *)data floatValue];
   }
   if ([data isKindOfClass:[NSArray class]] &&
       [[(NSArray *)data firstObject] isKindOfClass:[NSNumber class]]) {
@@ -221,7 +221,7 @@
   }
 }
 
--(void)remapKeyframesWithBlock:(CGFloat (^)(CGFloat))remapBlock {
+- (void)remapKeyframesWithBlock:(CGFloat (^)(CGFloat))remapBlock {
   for (LOTKeyframe *keyframe in _keyframes) {
     [keyframe remapValueWithBlock:remapBlock];
   }

--- a/lottie-ios/Classes/Extensions/CGGeometry+LOTAdditions.m
+++ b/lottie-ios/Classes/Extensions/CGGeometry+LOTAdditions.m
@@ -347,7 +347,7 @@ CATransform3D LOT_CATransform3DFromGLKMatrix4(GLKMatrix4 xform) {
   return newXform;
 }
 
-CATransform3D LOT_CATransform3DSlerpToTransform(CATransform3D fromXorm, CATransform3D toXform, CGFloat amount ){
+CATransform3D LOT_CATransform3DSlerpToTransform(CATransform3D fromXorm, CATransform3D toXform, CGFloat amount ) {
   //  amount = MIN(MAX(0, amount), 1);
   if (amount == 0 || amount == 1) {
     return amount == 0 ? fromXorm : toXform;

--- a/lottie-ios/Classes/Extensions/LOTBezierPath.m
+++ b/lottie-ios/Classes/Extensions/LOTBezierPath.m
@@ -340,7 +340,6 @@ struct LOT_Subpath {
           toPoint = LOT_PointInLine(currentPoint, subpath->endPoint, currentSpanEndT);
         }
         [self LOT_addLineToPoint:toPoint];
-        currentPoint = toPoint;
       } else if (subpath->type == kCGPathElementAddCurveToPoint) {
 
         CGPoint cp1, cp2, end;

--- a/lottie-ios/Classes/Extensions/LOTBezierPath.m
+++ b/lottie-ios/Classes/Extensions/LOTBezierPath.m
@@ -340,6 +340,7 @@ struct LOT_Subpath {
           toPoint = LOT_PointInLine(currentPoint, subpath->endPoint, currentSpanEndT);
         }
         [self LOT_addLineToPoint:toPoint];
+        currentPoint = toPoint;
       } else if (subpath->type == kCGPathElementAddCurveToPoint) {
 
         CGPoint cp1, cp2, end;

--- a/lottie-ios/Classes/Extensions/LOTRadialGradientLayer.m
+++ b/lottie-ios/Classes/Extensions/LOTRadialGradientLayer.m
@@ -51,12 +51,12 @@
 
 - (void)drawInContext:(CGContextRef)ctx {
   NSInteger numberOfLocations = self.locations.count;
-  NSInteger numbOfComponents = 0;
+  NSInteger numberOfComponents = 0;
   CGColorSpaceRef colorSpace = NULL;
   
   if (self.colors.count) {
     CGColorRef colorRef = (__bridge CGColorRef)[self.colors objectAtIndex:0];
-    numbOfComponents = CGColorGetNumberOfComponents(colorRef);
+    numberOfComponents = CGColorGetNumberOfComponents(colorRef);
     colorSpace = CGColorGetColorSpace(colorRef);
   }
   
@@ -64,15 +64,15 @@
   CGFloat radius = LOT_PointDistanceFromPoint(self.startPoint, self.endPoint);
   
   CGFloat gradientLocations[numberOfLocations];
-  CGFloat gradientComponents[numberOfLocations * numbOfComponents];
+  CGFloat gradientComponents[numberOfLocations * numberOfComponents];
   
   for (NSInteger locationIndex = 0; locationIndex < numberOfLocations; locationIndex++) {
     
     gradientLocations[locationIndex] = [self.locations[locationIndex] floatValue];
     const CGFloat *colorComponents = CGColorGetComponents((__bridge CGColorRef)self.colors[locationIndex]);
     
-    for (NSInteger componentIndex = 0; componentIndex < numbOfComponents; componentIndex++) {
-      gradientComponents[numbOfComponents * locationIndex + componentIndex] = colorComponents[componentIndex];
+    for (NSInteger componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      gradientComponents[numberOfComponents * locationIndex + componentIndex] = colorComponents[componentIndex];
     }
   }
   

--- a/lottie-ios/Classes/Models/LOTAsset.m
+++ b/lottie-ios/Classes/Models/LOTAsset.m
@@ -27,7 +27,7 @@
 
 
 - (void)_mapFromJSON:(NSDictionary *)jsonDictionary
-      withAssetGroup:(LOTAssetGroup * _Nullable)assetGroup{
+      withAssetGroup:(LOTAssetGroup * _Nullable)assetGroup {
   _referenceID = [jsonDictionary[@"id"] copy];
   
   if (jsonDictionary[@"w"]) {

--- a/lottie-ios/Classes/Models/LOTAssetGroup.m
+++ b/lottie-ios/Classes/Models/LOTAssetGroup.m
@@ -57,7 +57,8 @@
 - (LOTAsset *)assetModelForID:(NSString *)assetID {
   return _assetMap[assetID];
 }
-- (void)setRootDirectory:(NSString *)rootDirectory{
+
+- (void)setRootDirectory:(NSString *)rootDirectory {
     _rootDirectory = rootDirectory;
     [_assetMap enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, LOTAsset * _Nonnull obj, BOOL * _Nonnull stop) {
         obj.rootDirectory = rootDirectory;

--- a/lottie-ios/Classes/Models/LOTLayer.m
+++ b/lottie-ios/Classes/Models/LOTLayer.m
@@ -28,7 +28,7 @@
 }
 
 - (void)_mapFromJSON:(NSDictionary *)jsonDictionary
-      withAssetGroup:(LOTAssetGroup *)assetGroup{
+      withAssetGroup:(LOTAssetGroup *)assetGroup {
 
   _layerName = [jsonDictionary[@"nm"] copy];
   _layerID = [jsonDictionary[@"ind"] copy];
@@ -156,7 +156,7 @@
   }
 }
 
-- (NSString*)description {
+- (NSString *)description {
     NSMutableString *text = [[super description] mutableCopy];
     [text appendFormat:@" %@ id: %d pid: %d frames: %d-%d", _layerName, (int)_layerID.integerValue, (int)_parentID.integerValue,
      (int)_inFrame.integerValue, (int)_outFrame.integerValue];

--- a/lottie-ios/Classes/Models/LOTShapeGroup.m
+++ b/lottie-ios/Classes/Models/LOTShapeGroup.m
@@ -93,7 +93,7 @@
   return nil;
 }
 
-- (NSString*)description {
+- (NSString *)description {
     NSMutableString *text = [[super description] mutableCopy];
     [text appendFormat:@" items: %@", self.items];
     return text;

--- a/lottie-ios/Classes/Private/LOTAnimatedControl.m
+++ b/lottie-ios/Classes/Private/LOTAnimatedControl.m
@@ -60,25 +60,25 @@
   [self checkStateChangedAndUpdate:NO];
 }
 
-- (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
   _priorState = self.state;
   [super touchesBegan:touches withEvent:event];
   [self checkStateChangedAndUpdate:NO];
 }
 
-- (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
+- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
   _priorState = self.state;
   [super touchesMoved:touches withEvent:event];
   [self checkStateChangedAndUpdate:NO];
 }
 
-- (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
   _priorState = self.state;
   [super touchesEnded:touches withEvent:event];
   [self checkStateChangedAndUpdate:NO];
 }
 
-- (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
   _priorState = self.state;
   [super touchesCancelled:touches withEvent:event];
   [self checkStateChangedAndUpdate:NO];
@@ -105,7 +105,7 @@
 #pragma mark - Private interface implementation
 
 - (void)checkStateChangedAndUpdate:(BOOL)forceUpdate {
-  if(self.state == _priorState && !forceUpdate) {
+  if (self.state == _priorState && !forceUpdate) {
     return;
   }
   _priorState = self.state;

--- a/lottie-ios/Classes/Private/LOTAnimatedSwitch.m
+++ b/lottie-ios/Classes/Private/LOTAnimatedSwitch.m
@@ -22,12 +22,12 @@
 }
 
 /// Convenience method to initialize a control from the Main Bundle by name
-+ (instancetype _Nonnull )switchNamed:(NSString * _Nonnull)toggleName {
++ (instancetype _Nonnull)switchNamed:(NSString * _Nonnull)toggleName {
   return [LOTAnimatedSwitch switchNamed:toggleName inBundle:[NSBundle mainBundle]];
 }
 
 /// Convenience method to initialize a control from the specified bundle by name
-+ (instancetype _Nonnull )switchNamed:(NSString * _Nonnull)toggleName inBundle:(NSBundle * _Nonnull)bundle {
++ (instancetype _Nonnull)switchNamed:(NSString * _Nonnull)toggleName inBundle:(NSBundle * _Nonnull)bundle {
   LOTComposition *composition = [LOTComposition animationNamed:toggleName inBundle:bundle];
   LOTAnimatedSwitch *animatedControl = [[LOTAnimatedSwitch alloc] initWithFrame:CGRectZero];
   if (composition) {

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -63,7 +63,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
       [self _initializeAnimationContainer];
       [self _setupWithSceneModel:laScene];
     } else {
-      dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
         NSData *animationData = [NSData dataWithContentsOfURL:url];
         if (!animationData) {
           return;
@@ -76,7 +76,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
         }
         
         LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:animationJSON withAssetBundle:[NSBundle mainBundle]];
-        dispatch_async(dispatch_get_main_queue(), ^(void){
+        dispatch_async(dispatch_get_main_queue(), ^(void) {
           [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:url.absoluteString];
           laScene.cacheKey = url.absoluteString;
           [self _initializeAnimationContainer];
@@ -248,7 +248,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
 }
 
 - (void)playToFrame:(nonnull NSNumber *)toFrame
-     withCompletion:(nullable LOTAnimationCompletionBlock)completion{
+     withCompletion:(nullable LOTAnimationCompletionBlock)completion {
   [self playFromFrame:_sceneModel.startFrame toFrame:toFrame withCompletion:completion];
 }
 
@@ -353,7 +353,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
   }
 }
 
--(void)setAnimationSpeed:(CGFloat)animationSpeed {
+- (void)setAnimationSpeed:(CGFloat)animationSpeed {
   _animationSpeed = animationSpeed;
   if (_isAnimationPlaying && _sceneModel) {
     NSNumber *frame = [_compContainer.presentationLayer.currentFrame copy];
@@ -364,14 +364,14 @@ static NSString * const kCompContainerAnimationKey = @"play";
 
 # pragma mark - External Methods - Cache
 
-- (void)setCacheEnable:(BOOL)cacheEnable{
+- (void)setCacheEnable:(BOOL)cacheEnable {
   _cacheEnable = cacheEnable;
   if (!self.sceneModel.cacheKey) {
     return;
   }
   if (cacheEnable) {
     [[LOTAnimationCache sharedCache] addAnimation:_sceneModel forKey:self.sceneModel.cacheKey];
-  }else {
+  } else {
     [[LOTAnimationCache sharedCache] removeAnimationForKey:self.sceneModel.cacheKey];
   }
 }

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimatedSwitch.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimatedSwitch.h
@@ -13,10 +13,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface LOTAnimatedSwitch : LOTAnimatedControl
 
 /// Convenience method to initialize a control from the Main Bundle by name
-+ (instancetype _Nonnull )switchNamed:(NSString * _Nonnull)toggleName;
++ (instancetype _Nonnull)switchNamed:(NSString * _Nonnull)toggleName;
 
 /// Convenience method to initialize a control from the specified bundle by name
-+ (instancetype _Nonnull )switchNamed:(NSString * _Nonnull)toggleName inBundle:(NSBundle * _Nonnull)bundle;
++ (instancetype _Nonnull)switchNamed:(NSString * _Nonnull)toggleName inBundle:(NSBundle * _Nonnull)bundle;
 
 
 /// The ON/OFF state of the control. Setting will toggle without animation

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationTransitionController.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationTransitionController.h
@@ -63,7 +63,7 @@
  @param bundle custom bundle to load animation and images, if no bundle is specified will load
  from mainBundle
  */
-- (instancetype _Nonnull )initWithAnimationNamed:(NSString *_Nonnull)animation
+- (instancetype _Nonnull)initWithAnimationNamed:(NSString *_Nonnull)animation
                                   fromLayerNamed:(NSString *_Nullable)fromLayer
                                     toLayerNamed:(NSString *_Nullable)toLayer
                          applyAnimationTransform:(BOOL)applyAnimationTransform

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -63,7 +63,7 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 @property (nonatomic, copy, nullable) LOTAnimationCompletionBlock completionBlock;
 
 /// Set the amimation data
-@property (nonatomic, strong, nonnull) LOTComposition *sceneModel;
+@property (nonatomic, strong, nullable) LOTComposition *sceneModel;
 
 /* 
  * Plays the animation from its current position to a specific progress. 

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTCircleAnimator.h
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTCircleAnimator.h
@@ -11,7 +11,7 @@
 
 @interface LOTCircleAnimator : LOTAnimatorNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                   shapeCircle:(LOTShapeCircle *_Nonnull)shapeCircle;
 
 @end

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTCircleAnimator.m
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTCircleAnimator.m
@@ -17,7 +17,7 @@ const CGFloat kLOTEllipseControlPointPercentage = 0.55228;
   BOOL _reversed;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                   shapeCircle:(LOTShapeCircle *_Nonnull)shapeCircle {
   self = [super initWithInputNode:inputNode keyName:shapeCircle.keyname];
   if (self) {

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPathAnimator.h
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPathAnimator.h
@@ -11,7 +11,7 @@
 
 @interface LOTPathAnimator : LOTAnimatorNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                   shapePath:(LOTShapePath *_Nonnull)shapePath;
 
 @end

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPathAnimator.m
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPathAnimator.m
@@ -14,7 +14,7 @@
   LOTPathInterpolator *_interpolator;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                   shapePath:(LOTShapePath *_Nonnull)shapePath {
   self = [super initWithInputNode:inputNode keyName:shapePath.keyname];
   if (self) {

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolygonAnimator.h
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolygonAnimator.h
@@ -11,7 +11,7 @@
 
 @interface LOTPolygonAnimator : LOTAnimatorNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                              shapePolygon:(LOTShapeStar *_Nonnull)shapeStar;
 
 @end

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolygonAnimator.m
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolygonAnimator.m
@@ -23,7 +23,7 @@ const CGFloat kPOLYGON_MAGIC_NUMBER = .25f;
   LOTNumberInterpolator *_rotationInterpolator;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                              shapePolygon:(LOTShapeStar *_Nonnull)shapeStar {
   self = [super initWithInputNode:inputNode keyName:shapeStar.keyname];
   if (self) {

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolystarAnimator.h
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolystarAnimator.h
@@ -11,7 +11,7 @@
 
 @interface LOTPolystarAnimator : LOTAnimatorNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                              shapeStar:(LOTShapeStar *_Nonnull)shapeStar;
 
 @end

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolystarAnimator.m
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolystarAnimator.m
@@ -24,7 +24,7 @@ const CGFloat kPOLYSTAR_MAGIC_NUMBER = .47829f;
   LOTNumberInterpolator *_rotationInterpolator;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                              shapeStar:(LOTShapeStar *_Nonnull)shapeStar {
   self = [super initWithInputNode:inputNode keyName:shapeStar.keyname];
   if (self) {

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTRoundedRectAnimator.h
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTRoundedRectAnimator.h
@@ -11,7 +11,7 @@
 
 @interface LOTRoundedRectAnimator : LOTAnimatorNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                 shapeRectangle:(LOTShapeRectangle *_Nonnull)shapeRectangle;
 
 

--- a/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTRoundedRectAnimator.m
+++ b/lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTRoundedRectAnimator.m
@@ -18,7 +18,7 @@
   BOOL _reversed;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                              shapeRectangle:(LOTShapeRectangle *_Nonnull)shapeRectangle {
   self = [super initWithInputNode:inputNode keyName:shapeRectangle.keyname];
   if (self) {

--- a/lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTValueInterpolator.h
+++ b/lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTValueInterpolator.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Used to dynamically update keyframe data.
 - (BOOL)setValue:(id)value atFrame:(NSNumber *)frame;
-- (id)keyframeDataForValue:(id)value;
+- (id _Nullable)keyframeDataForValue:(id)value;
 
 @property (nonatomic, weak, nullable) LOTKeyframe *leadingKeyframe;
 @property (nonatomic, weak, nullable) LOTKeyframe *trailingKeyframe;

--- a/lottie-ios/Classes/RenderSystem/LOTAnimatorNode.h
+++ b/lottie-ios/Classes/RenderSystem/LOTAnimatorNode.h
@@ -14,7 +14,7 @@ extern NSInteger indentation_level;
 @interface LOTAnimatorNode : NSObject
 
 /// Initializes the node with and optional intput node and keyname.
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                     keyName:(NSString *_Nullable)keyname;
 
 /// A dictionary of the value interpolators this node controls

--- a/lottie-ios/Classes/RenderSystem/LOTAnimatorNode.m
+++ b/lottie-ios/Classes/RenderSystem/LOTAnimatorNode.m
@@ -15,7 +15,7 @@ NSInteger indentation_level = 0;
 @implementation LOTAnimatorNode
 
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                     keyName:(NSString *_Nullable)keyname {
   self = [super init];
   if (self) {
@@ -37,15 +37,14 @@ NSInteger indentation_level = 0;
 
 - (BOOL)updateWithFrame:(NSNumber *_Nonnull)frame
       withModifierBlock:(void (^_Nullable)(LOTAnimatorNode * _Nonnull inputNode))modifier
-       forceLocalUpdate:(BOOL)forceUpdate{
+       forceLocalUpdate:(BOOL)forceUpdate {
   if ([_currentFrame isEqual:frame] && !forceUpdate) {
     return NO;
   }
-  NSString *name = NSStringFromClass([self class]);
-  if (ENABLE_DEBUG_LOGGING) [self logString:[NSString stringWithFormat:@"%@ %lu %@ Checking for update", name, (unsigned long)self.hash, self.keyname]];
+  if (ENABLE_DEBUG_LOGGING) [self logString:[NSString stringWithFormat:@"%lu %@ Checking for update", (unsigned long)self.hash, self.keyname]];
   BOOL localUpdate = [self needsUpdateForFrame:frame] || forceUpdate;
   if (localUpdate && ENABLE_DEBUG_LOGGING) {
-    [self logString:[NSString stringWithFormat:@"%@ %lu %@ Performing update", name, (unsigned long)self.hash, self.keyname]];
+    [self logString:[NSString stringWithFormat:@"%lu %@ Performing update", (unsigned long)self.hash, self.keyname]];
   }
   BOOL inputUpdated = [_inputNode updateWithFrame:frame
                                 withModifierBlock:modifier
@@ -75,7 +74,7 @@ NSInteger indentation_level = 0;
     [logString appendString:@"  "];
   }
   [logString appendString:string];
-  NSLog(@"%@", logString);
+  NSLog(@"%@ %@", NSStringFromClass([self class]), logString);
 }
 
 // TOBO BW Perf, make updates perform only when necessarry. Currently everything in a node is updated

--- a/lottie-ios/Classes/RenderSystem/LOTRenderNode.m
+++ b/lottie-ios/Classes/RenderSystem/LOTRenderNode.m
@@ -10,7 +10,7 @@
 
 @implementation LOTRenderNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                     keyName:(NSString * _Nullable)keyname {
   self = [super initWithInputNode:inputNode keyName:keyname];
   if (self) {

--- a/lottie-ios/Classes/RenderSystem/ManipulatorNodes/LOTTrimPathNode.h
+++ b/lottie-ios/Classes/RenderSystem/ManipulatorNodes/LOTTrimPathNode.h
@@ -11,7 +11,7 @@
 
 @interface LOTTrimPathNode : LOTAnimatorNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                   trimPath:(LOTShapeTrimPath *_Nonnull)trimPath;
 
 @end

--- a/lottie-ios/Classes/RenderSystem/ManipulatorNodes/LOTTrimPathNode.m
+++ b/lottie-ios/Classes/RenderSystem/ManipulatorNodes/LOTTrimPathNode.m
@@ -23,7 +23,7 @@
   CGFloat _offsetT;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                    trimPath:(LOTShapeTrimPath *_Nonnull)trimPath {
   self = [super initWithInputNode:inputNode keyName:trimPath.keyname];
   if (self) {

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTFillRenderer.h
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTFillRenderer.h
@@ -11,7 +11,7 @@
 
 @interface LOTFillRenderer : LOTRenderNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nonnull)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                   shapeFill:(LOTShapeFill *_Nonnull)fill;
 
 @end

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTFillRenderer.m
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTFillRenderer.m
@@ -18,8 +18,8 @@
   CALayer *centerPoint_DEBUG;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nonnull)inputNode
-                                  shapeFill:(LOTShapeFill *_Nonnull)fill {
+- (instancetype)initWithInputNode:(LOTAnimatorNode *)inputNode
+                                  shapeFill:(LOTShapeFill *)fill {
   self = [super initWithInputNode:inputNode keyName:fill.keyname];
   if (self) {
     colorInterpolator_ = [[LOTColorInterpolator alloc] initWithKeyframes:fill.color.keyframes];

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTGradientFillRender.h
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTGradientFillRender.h
@@ -11,7 +11,7 @@
 
 @interface LOTGradientFillRender : LOTRenderNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nonnull)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                           shapeGradientFill:(LOTShapeGradientFill *_Nonnull)fill;
 
 @end

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTGradientFillRender.m
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTGradientFillRender.m
@@ -32,8 +32,8 @@
   LOTNumberInterpolator *_opacityInterpolator;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nonnull)inputNode
-                          shapeGradientFill:(LOTShapeGradientFill *_Nonnull)fill {
+- (instancetype)initWithInputNode:(LOTAnimatorNode *)inputNode
+                          shapeGradientFill:(LOTShapeGradientFill *)fill {
   self = [super initWithInputNode:inputNode keyName:fill.keyname];
   if (self) {
     _gradientInterpolator = [[LOTArrayInterpolator alloc] initWithKeyframes:fill.gradient.keyframes];

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRenderGroup.h
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRenderGroup.h
@@ -10,7 +10,7 @@
 
 @interface LOTRenderGroup : LOTRenderNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode * _Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode * _Nullable)inputNode
                                    contents:(NSArray * _Nonnull)contents
                                     keyname:(NSString * _Nullable)keyname;
 

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRenderGroup.m
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRenderGroup.m
@@ -33,7 +33,7 @@
   LOTTransformInterpolator *_transformInterolator;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode * _Nullable)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode * _Nullable)inputNode
                                    contents:(NSArray * _Nonnull)contents
                                     keyname:(NSString * _Nullable)keyname {
   self = [super initWithInputNode:inputNode keyName:keyname];
@@ -81,7 +81,7 @@
       previousNode = rectAnimator;
     } else if ([item isKindOfClass:[LOTShapeCircle class]]) {
       LOTCircleAnimator *circleAnimator = [[LOTCircleAnimator alloc] initWithInputNode:previousNode
-                                                                           shapeCircle:(LOTShapeCircle*)item];
+                                                                           shapeCircle:(LOTShapeCircle *)item];
       previousNode = circleAnimator;
     } else if ([item isKindOfClass:[LOTShapeGroup class]]) {
       LOTShapeGroup *shapeGroup = (LOTShapeGroup *)item;
@@ -91,7 +91,7 @@
     } else if ([item isKindOfClass:[LOTShapeTransform class]]) {
       transform = (LOTShapeTransform *)item;
     } else if ([item isKindOfClass:[LOTShapeTrimPath class]]) {
-      LOTTrimPathNode *trim = [[LOTTrimPathNode alloc] initWithInputNode:previousNode trimPath:(LOTShapeTrimPath*)item];
+      LOTTrimPathNode *trim = [[LOTTrimPathNode alloc] initWithInputNode:previousNode trimPath:(LOTShapeTrimPath *)item];
       previousNode = trim;
     } else if ([item isKindOfClass:[LOTShapeStar class]]) {
       LOTShapeStar *star = (LOTShapeStar *)item;
@@ -163,7 +163,7 @@
   }
 }
 
--(void)setPathShouldCacheLengths:(BOOL)pathShouldCacheLengths {
+- (void)setPathShouldCacheLengths:(BOOL)pathShouldCacheLengths {
   [super setPathShouldCacheLengths:pathShouldCacheLengths];
   _rootNode.pathShouldCacheLengths = pathShouldCacheLengths;
 }

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRepeaterRenderer.h
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRepeaterRenderer.h
@@ -11,7 +11,7 @@
 
 @interface LOTRepeaterRenderer : LOTRenderNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nonnull)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                               shapeRepeater:(LOTShapeRepeater *_Nonnull)repeater;
 
 @end

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRepeaterRenderer.m
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRepeaterRenderer.m
@@ -23,8 +23,8 @@
   CALayer *centerPoint_DEBUG;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nonnull)inputNode
-                              shapeRepeater:(LOTShapeRepeater *_Nonnull)repeater {
+- (instancetype)initWithInputNode:(LOTAnimatorNode *)inputNode
+                              shapeRepeater:(LOTShapeRepeater *)repeater {
   self = [super initWithInputNode:inputNode keyName:repeater.keyname];
   if (self) {
     _transformInterpolator = [[LOTTransformInterpolator alloc] initWithPosition:repeater.position.keyframes

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTStrokeRenderer.h
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTStrokeRenderer.h
@@ -11,7 +11,7 @@
 
 @interface LOTStrokeRenderer : LOTRenderNode
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nonnull)inputNode
+- (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode *_Nullable)inputNode
                                 shapeStroke:(LOTShapeStroke *_Nonnull)stroke;
 
 

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTStrokeRenderer.m
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTStrokeRenderer.m
@@ -18,8 +18,8 @@
   NSArray *_dashPatternInterpolators;
 }
 
-- (instancetype _Nonnull )initWithInputNode:(LOTAnimatorNode *_Nonnull)inputNode
-                                shapeStroke:(LOTShapeStroke *_Nonnull)stroke {
+- (instancetype)initWithInputNode:(LOTAnimatorNode *)inputNode
+                                shapeStroke:(LOTShapeStroke *)stroke {
   self = [super initWithInputNode:inputNode keyName:stroke.keyname];
   if (self) {
     _colorInterpolator = [[LOTColorInterpolator alloc] initWithKeyframes:stroke.color.keyframes];


### PR DESCRIPTION
Hey guys! 

This PR aims to address a few formal issues of this project:
- [x] Fix static analyser warnings (e.g. unreachable code, unused variables, ...)
- [x] Fix memory-leaks (just a few, like CGPath-allocations)
- [x] Fix nullability-attributes (some interfaces stated non-null attributes that have been handled as optionals)
- [x] Fix general code-style (common things like `-(NSString*)` vs `- (NSString *)` etc)

Following to this PR, I would also like to introduce a unified code-style like we at Appcelerator do for our projects. Maybe Airbnb has an own style-guide for Obj-C so far, so that could easily be applied.

Let me know your feedback on the above changes!

P.S.: Big fan, using this SDK for the Titanium community and they love it 😙.