### PR TITLE
add @available check to silence warning for userInterfaceLayoutDirect…

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimatedSwitch.m
+++ b/lottie-ios/Classes/Private/LOTAnimatedSwitch.m
@@ -149,8 +149,10 @@
     // The touch has moved enough to register as its own gesture. Suppress the touch up toggle.
     _suppressToggle = YES;
   }
-  if ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft) {
-    diff = diff * -1;
+  if (@available(iOS 9.0, *)) {
+      if ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft) {
+          diff = diff * -1;
+      }
   }
   if (_on) {
     diff = diff * -1;


### PR DESCRIPTION
# What
Silences compile-time availability check warnings for iOS 9.0 UIKit APIs.

# Why 
Xcode 9 gives the following compile-time warnings in `LotAnimationSwitch.m`:
> 'userInterfaceLayoutDirectionForSemanticContentAttribute:' is only available on iOS 9.0 or newer. Enclose 'userInterfaceLayoutDirectionForSemanticContentAttribute:' in an @available check to silence this warning

and 

> 'semanticContentAttribute' is only available on iOS 9.0 or newer. Enclose 'semanticContentAttribute' in an @available check to silence this warning

These warnings are still shown even with the ` NS_AVAILABLE_IOS(9_0);` macro in UIKit's `UIView` header.

# How
By enclosing 'userInterfaceLayoutDirectionForSemanticContentAttribute:' in an iOS 9.0 availability check, new to Objective-C as described in [llvm clang release docs](http://releases.llvm.org/5.0.0/tools/clang/docs/ReleaseNotes.html#major-new-features).