### PR TITLE
Mark lottie as extension safe

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -1243,6 +1243,7 @@
 		62CA59C11E3C173B002D7188 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1263,6 +1264,7 @@
 		62CA59C21E3C173B002D7188 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
This marks the Lottie framework as extension safe (it already is).

This prevents warnings in targets that require extension-safe APIs.

https://github.com/airbnb/lottie-ios/issues/459
