### PR TITLE
Fix:r2.1.4 Build error in Xcode8.x

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimatedSwitch.m
+++ b/lottie-ios/Classes/Private/LOTAnimatedSwitch.m
@@ -149,7 +149,7 @@
     // The touch has moved enough to register as its own gesture. Suppress the touch up toggle.
     _suppressToggle = YES;
   }
-  if (@available(iOS 9.0, *)) {
+  if (floor(NSFoundationVersionNumber) >= floor(NSFoundationVersionNumber_iOS_9_0)) {
       if ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:self.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft) {
           diff = diff * -1;
       }


### PR DESCRIPTION
Version check code in `LOTAnimatedSwitch.m` line 152, supported by Xcode 9.x
`  if (@available(iOS 9.0, *)) {`
only works in Xcode 9.x .
In Xcode 8.x it will cause build error.

> Unexpected '@' in program

So I changed it to old style.