### PR TITLE
Stop animation before leaving screen to prevent freezing

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -562,7 +562,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
   } else {
     // The view is being detached, capture information that need to be restored later.
     if (_isAnimationPlaying) {
-        [self stop];
+        [self pause];
       _shouldRestoreStateWhenAttachedToWindow = YES;
       _completionBlockToRestoreWhenAttachedToWindow = _completionBlock;
       _completionBlock = nil;

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -562,6 +562,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
   } else {
     // The view is being detached, capture information that need to be restored later.
     if (_isAnimationPlaying) {
+        [self stop];
       _shouldRestoreStateWhenAttachedToWindow = YES;
       _completionBlockToRestoreWhenAttachedToWindow = _completionBlock;
       _completionBlock = nil;


### PR DESCRIPTION
I believe that when the view is being detached, if the current animation is not stopped, it will not properly re-enter the window. In order for the animation to continue when the a new window enters, it should be stopped.

I tested this with a few examples, and it functioned correctly when entering and re-entering the window from a detached view.