### PR TITLE
fix crash by addding @synthesize to [LOTLayerContainer display]

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -206,12 +206,14 @@
 }
 
 - (void)display {
-  LOTLayerContainer *presentation = self;
-  if (self.animationKeys.count &&
+  @synchronized(self) {
+    LOTLayerContainer *presentation = self;
+    if (self.animationKeys.count &&
       self.presentationLayer) {
-    presentation = (LOTLayerContainer *)self.presentationLayer;
+        presentation = (LOTLayerContainer *)self.presentationLayer;
+    }
+    [self displayWithFrame:presentation.currentFrame];
   }
-  [self displayWithFrame:presentation.currentFrame];
 }
 
 - (void)displayWithFrame:(NSNumber *)frame {


### PR DESCRIPTION
In our app, we use Lottie to do tab switch animations. We found a few crash logs happen in [LOTLayerContainer display] but in a webthread. This “display callback in webthread” can be  reproduced after UIWebView used in app, and iOS will call display on webthread and main thread alternately. So we add a @synthesize protection at each LOTLayerContainer object level in [LOTLayerContainer display]. And the crash never happen again at large scale.

[LOT_applyTransform crash #425](https://github.com/airbnb/lottie-ios/issues/425)