### PR TITLE
[bugfix] fix collision of images with same name in different bundles.…

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -144,8 +144,8 @@
         image = [UIImage imageWithContentsOfFile:imagePath];
       }
     } else {
-      NSArray *components = [asset.imageName componentsSeparatedByString:@"."];
-      image = [UIImage imageNamed:components.firstObject inBundle:asset.assetBundle compatibleWithTraitCollection:nil];
+        NSString *imagePath = [asset.assetBundle pathForResource:asset.imageName ofType:nil];
+        image = [UIImage imageWithContentsOfFile:imagePath];
     }
     
     if (image) {


### PR DESCRIPTION
images shared the same name from different bundles under the main bundle may not be always returned correctly when using `-[UIImage imageNamed:inBundle:compatibleWithTraitCollection:]`, especially when using lottie assets from more than one bundle in one viewController (which may due to Apple's cache mechanism).

Refers to issue: https://github.com/airbnb/lottie-ios/issues/295