### PR TITLE
Fixed typos

### DIFF
--- a/lottie-ios/Classes/Extensions/UIColor+Expanded.m
+++ b/lottie-ios/Classes/Extensions/UIColor+Expanded.m
@@ -5,7 +5,7 @@
 /*
  
  Thanks to Poltras, Millenomi, Eridius, Nownot, WhatAHam, jberry,
- and everyone else who helped out but whose name is inadvertantly omitted
+ and everyone else who helped out but whose name is inadvertently omitted
  
  */
 

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -130,7 +130,7 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
  * Value is the color, point, or number object that should be set at given time
  *
  * @param keypath NSString . separate keypath
- * The Keypath is a dot seperated key path that specifies the location of the key to
+ * The Keypath is a dot separated key path that specifies the location of the key to
  * be set from the After Effects file. This will begin with the Layer Name.
  * EG "Layer 1.Shape 1.Fill 1.Color" 
  *
@@ -163,7 +163,7 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
     applyTransform:(BOOL)applyTransform;
 
 /**
- * Converts the given CGRect from the recieving animation view's coordinate space
+ * Converts the given CGRect from the receiving animation view's coordinate space
  * to the supplied layer's coordinate space
  * If layerName is null then the rect will be converted to the composition coordinate system.
  * This is helpful when adding custom subviews to a LOTAnimationView

--- a/lottie-ios/Classes/RenderSystem/LOTAnimatorNode.h
+++ b/lottie-ios/Classes/RenderSystem/LOTAnimatorNode.h
@@ -51,7 +51,7 @@ extern NSInteger indentation_level;
 /// Rebuild all outputs for the node. This is called after upstream updates have been performed.
 - (void)rebuildOutputs;
 
-/// Traverses children untill keypath is found and attempts to set the keypath to the value.
+/// Traverses children until keypath is found and attempts to set the keypath to the value.
 - (BOOL)setValue:(nonnull id)value
     forKeyAtPath:(nonnull NSString *)keypath
         forFrame:(nullable NSNumber *)frame;

--- a/lottie-ios/Classes/RenderSystem/LOTAnimatorNode.m
+++ b/lottie-ios/Classes/RenderSystem/LOTAnimatorNode.m
@@ -98,7 +98,7 @@ NSInteger indentation_level = 0;
   self.inputNode.pathShouldCacheLengths = pathShouldCacheLengths;
 }
 
-/// Traverses children untill keypath is found and attempts to set the keypath to the value.
+/// Traverses children until keypath is found and attempts to set the keypath to the value.
 - (BOOL)setValue:(nonnull id)value
     forKeyAtPath:(nonnull NSString *)keypath
         forFrame:(nullable NSNumber *)frame {


### PR DESCRIPTION
inadvertantly -> inadvertently
recieving -> receiving
seperated -> separated
untill -> until