### PR TITLE
Fix Analyser warning in LOTRadialGradientLayer

### DIFF
--- a/lottie-ios/Classes/Extensions/LOTRadialGradientLayer.m
+++ b/lottie-ios/Classes/Extensions/LOTRadialGradientLayer.m
@@ -50,15 +50,14 @@
 }
 
 - (void)drawInContext:(CGContextRef)ctx {
-  NSInteger numberOfLocations = self.locations.count;
-  NSInteger numberOfComponents = 0;
-  CGColorSpaceRef colorSpace = NULL;
-  
-  if (self.colors.count) {
-    CGColorRef colorRef = (__bridge CGColorRef)[self.colors objectAtIndex:0];
-    numberOfComponents = CGColorGetNumberOfComponents(colorRef);
-    colorSpace = CGColorGetColorSpace(colorRef);
+  if (self.colors.count == 0) {
+    return;
   }
+    
+  NSInteger numberOfLocations = self.locations.count;
+  CGColorRef colorRef = (__bridge CGColorRef)[self.colors objectAtIndex:0];
+  NSInteger numberOfComponents = CGColorGetNumberOfComponents(colorRef);
+  CGColorSpaceRef colorSpace = CGColorGetColorSpace(colorRef);
   
   CGPoint origin = self.startPoint;
   CGFloat radius = LOT_PointDistanceFromPoint(self.startPoint, self.endPoint);


### PR DESCRIPTION
The static analyser (using Xcode 9.2) was complaining about `gradientComponents` being a variable length array with the possibility of having 0 length. This could occur with `numberOfComponents` keeping the value of 0 if no colours exist. Having a VLA with size 0 causes undefined behaviour.

The change is to bypass rendering the LOTRadialGradientLayer if there are no colours provided, as it doesn't make sense to render anything without a colour, and to presume a default colour may not be the right solution.