### PR TITLE
Fix convenience class methods of public classes

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimatedSwitch.m
+++ b/lottie-ios/Classes/Private/LOTAnimatedSwitch.m
@@ -23,13 +23,13 @@
 
 /// Convenience method to initialize a control from the Main Bundle by name
 + (instancetype _Nonnull)switchNamed:(NSString * _Nonnull)toggleName {
-  return [LOTAnimatedSwitch switchNamed:toggleName inBundle:[NSBundle mainBundle]];
+  return [self switchNamed:toggleName inBundle:[NSBundle mainBundle]];
 }
 
 /// Convenience method to initialize a control from the specified bundle by name
 + (instancetype _Nonnull)switchNamed:(NSString * _Nonnull)toggleName inBundle:(NSBundle * _Nonnull)bundle {
   LOTComposition *composition = [LOTComposition animationNamed:toggleName inBundle:bundle];
-  LOTAnimatedSwitch *animatedControl = [[LOTAnimatedSwitch alloc] initWithFrame:CGRectZero];
+  LOTAnimatedSwitch *animatedControl = [[self alloc] initWithFrame:CGRectZero];
   if (composition) {
     [animatedControl setAnimationComp:composition];
     animatedControl.bounds = composition.compBounds;

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -37,7 +37,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
 
 + (nonnull instancetype)animationNamed:(nonnull NSString *)animationName inBundle:(nonnull NSBundle *)bundle {
   LOTComposition *comp = [LOTComposition animationNamed:animationName inBundle:bundle];
-  return [[LOTAnimationView alloc] initWithModel:comp inBundle:bundle];
+  return [[self alloc] initWithModel:comp inBundle:bundle];
 }
 
 + (nonnull instancetype)animationFromJSON:(nonnull NSDictionary *)animationJSON {
@@ -46,12 +46,12 @@ static NSString * const kCompContainerAnimationKey = @"play";
 
 + (nonnull instancetype)animationFromJSON:(nullable NSDictionary *)animationJSON inBundle:(nullable NSBundle *)bundle {
   LOTComposition *comp = [LOTComposition animationFromJSON:animationJSON inBundle:bundle];
-  return [[LOTAnimationView alloc] initWithModel:comp inBundle:bundle];
+  return [[self alloc] initWithModel:comp inBundle:bundle];
 }
 
 + (nonnull instancetype)animationWithFilePath:(nonnull NSString *)filePath {
   LOTComposition *comp = [LOTComposition animationWithFilePath:filePath];
-  return [[LOTAnimationView alloc] initWithModel:comp inBundle:[NSBundle mainBundle]];
+  return [[self alloc] initWithModel:comp inBundle:[NSBundle mainBundle]];
 }
 
 # pragma mark - Initializers

--- a/lottie-ios/Classes/Private/LOTBlockCallback.m
+++ b/lottie-ios/Classes/Private/LOTBlockCallback.m
@@ -11,7 +11,7 @@
 @implementation LOTColorBlockCallback
 
 + (instancetype)withBlock:(LOTColorValueCallbackBlock)block {
-  LOTColorBlockCallback *colorCallback = [[LOTColorBlockCallback alloc] init];
+  LOTColorBlockCallback *colorCallback = [[self alloc] init];
   colorCallback.callback = block;
   return colorCallback;
 }
@@ -25,7 +25,7 @@
 @implementation LOTNumberBlockCallback
 
 + (instancetype)withBlock:(LOTNumberValueCallbackBlock)block {
-  LOTNumberBlockCallback *numberCallback = [[LOTNumberBlockCallback alloc] init];
+  LOTNumberBlockCallback *numberCallback = [[self alloc] init];
   numberCallback.callback = block;
   return numberCallback;
 }
@@ -39,7 +39,7 @@
 @implementation LOTPointBlockCallback
 
 + (instancetype)withBlock:(LOTPointValueCallbackBlock)block {
-  LOTPointBlockCallback *callback = [[LOTPointBlockCallback alloc] init];
+  LOTPointBlockCallback *callback = [[self alloc] init];
   callback.callback = block;
   return callback;
 }
@@ -53,7 +53,7 @@
 @implementation LOTSizeBlockCallback
 
 + (instancetype)withBlock:(LOTSizeValueCallbackBlock)block {
-  LOTSizeBlockCallback *callback = [[LOTSizeBlockCallback alloc] init];
+  LOTSizeBlockCallback *callback = [[self alloc] init];
   callback.callback = block;
   return callback;
 }
@@ -67,7 +67,7 @@
 @implementation LOTPathBlockCallback
 
 + (instancetype)withBlock:(LOTPathValueCallbackBlock)block {
-  LOTPathBlockCallback *callback = [[LOTPathBlockCallback alloc] init];
+  LOTPathBlockCallback *callback = [[self alloc] init];
   callback.callback = block;
   return callback;
 }

--- a/lottie-ios/Classes/Private/LOTComposition.m
+++ b/lottie-ios/Classes/Private/LOTComposition.m
@@ -35,7 +35,7 @@
   NSDictionary  *JSONObject = jsonData ? [NSJSONSerialization JSONObjectWithData:jsonData
                                                                          options:0 error:&error] : nil;
   if (JSONObject && !error) {
-    LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:JSONObject withAssetBundle:bundle];
+    LOTComposition *laScene = [[self alloc] initWithJSON:JSONObject withAssetBundle:bundle];
     [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:animationName];
     laScene.cacheKey = animationName;
     return laScene;
@@ -57,7 +57,7 @@
   NSDictionary  *JSONObject = jsonData ? [NSJSONSerialization JSONObjectWithData:jsonData
                                                                          options:0 error:&error] : nil;
   if (JSONObject && !error) {
-    LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:JSONObject withAssetBundle:[NSBundle mainBundle]];
+    LOTComposition *laScene = [[self alloc] initWithJSON:JSONObject withAssetBundle:[NSBundle mainBundle]];
     laScene.rootDirectory = [filePath stringByDeletingLastPathComponent];
     [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:animationName];
     laScene.cacheKey = animationName;
@@ -73,7 +73,7 @@
 }
 
 + (nonnull instancetype)animationFromJSON:(nullable NSDictionary *)animationJSON inBundle:(nullable NSBundle *)bundle {
-  return [[LOTComposition alloc] initWithJSON:animationJSON withAssetBundle:bundle];
+  return [[self alloc] initWithJSON:animationJSON withAssetBundle:bundle];
 }
 
 #pragma mark - Initializer

--- a/lottie-ios/Classes/Private/LOTInterpolatorCallback.m
+++ b/lottie-ios/Classes/Private/LOTInterpolatorCallback.m
@@ -12,7 +12,7 @@
 @implementation LOTFloatInterpolatorCallback
 
 + (instancetype _Nonnull)withFromFloat:(CGFloat)fromFloat toFloat:(CGFloat)toFloat {
-  LOTFloatInterpolatorCallback *interpolator = [[LOTFloatInterpolatorCallback alloc] init];
+  LOTFloatInterpolatorCallback *interpolator = [[self alloc] init];
   interpolator.fromFloat = fromFloat;
   interpolator.toFloat = toFloat;
   return interpolator;
@@ -26,7 +26,7 @@
 @implementation LOTPointInterpolatorCallback
 
 + (instancetype _Nonnull)withFromPoint:(CGPoint)fromPoint toPoint:(CGPoint)toPoint {
-  LOTPointInterpolatorCallback *interpolator = [[LOTPointInterpolatorCallback alloc] init];
+  LOTPointInterpolatorCallback *interpolator = [[self alloc] init];
   interpolator.fromPoint = fromPoint;
   interpolator.toPoint = toPoint;
   return interpolator;
@@ -40,7 +40,7 @@
 @implementation LOTSizeInterpolatorCallback
 
 + (instancetype)withFromSize:(CGSize)fromSize toSize:(CGSize)toSize {
-  LOTSizeInterpolatorCallback *interpolator = [[LOTSizeInterpolatorCallback alloc] init];
+  LOTSizeInterpolatorCallback *interpolator = [[self alloc] init];
   interpolator.fromSize = fromSize;
   interpolator.toSize = toSize;
   return interpolator;

--- a/lottie-ios/Classes/Private/LOTKeypath.m
+++ b/lottie-ios/Classes/Private/LOTKeypath.m
@@ -19,7 +19,7 @@ NSString *const kLOTKeypathEnd = @"LOTENDKEYPATH";
 }
 
 + (nonnull LOTKeypath *)keypathWithString:(nonnull NSString *)keypath {
-  return [[LOTKeypath alloc] initWithKeys:[keypath componentsSeparatedByString:@"."]];
+  return [[self alloc] initWithKeys:[keypath componentsSeparatedByString:@"."]];
 }
 
 + (nonnull LOTKeypath *)keypathWithKeys:(nonnull NSString *)firstKey, ... {
@@ -31,7 +31,7 @@ NSString *const kLOTKeypathEnd = @"LOTENDKEYPATH";
     [keys addObject:arg];
   }
   va_end(args);
-  return [[LOTKeypath alloc] initWithKeys:keys];
+  return [[self alloc] initWithKeys:keys];
 }
 
 - (instancetype)initWithKeys:(NSArray *)keys {

--- a/lottie-ios/Classes/Private/LOTValueCallback.m
+++ b/lottie-ios/Classes/Private/LOTValueCallback.m
@@ -11,7 +11,7 @@
 @implementation LOTColorValueCallback
 
 + (instancetype _Nonnull)withCGColor:(CGColorRef _Nonnull)color {
-  LOTColorValueCallback *colorCallback = [[LOTColorValueCallback alloc] init];
+  LOTColorValueCallback *colorCallback = [[self alloc] init];
   colorCallback.colorValue = color;
   return colorCallback;
 }
@@ -25,7 +25,7 @@
 @implementation LOTNumberValueCallback
 
 + (instancetype _Nonnull)withFloatValue:(CGFloat)numberValue {
-  LOTNumberValueCallback *numberCallback = [[LOTNumberValueCallback alloc] init];
+  LOTNumberValueCallback *numberCallback = [[self alloc] init];
   numberCallback.numberValue = numberValue;
   return numberCallback;
 }
@@ -39,7 +39,7 @@
 @implementation LOTPointValueCallback
 
 + (instancetype _Nonnull)withPointValue:(CGPoint)pointValue {
-  LOTPointValueCallback *callback = [[LOTPointValueCallback alloc] init];
+  LOTPointValueCallback *callback = [[self alloc] init];
   callback.pointValue = pointValue;
   return callback;
 }
@@ -53,7 +53,7 @@
 @implementation LOTSizeValueCallback
 
 + (instancetype _Nonnull)withPointValue:(CGSize)sizeValue {
-  LOTSizeValueCallback *callback = [[LOTSizeValueCallback alloc] init];
+  LOTSizeValueCallback *callback = [[self alloc] init];
   callback.sizeValue = sizeValue;
   return callback;
 }
@@ -67,7 +67,7 @@
 @implementation LOTPathValueCallback
 
 + (instancetype _Nonnull)withCGPath:(CGPathRef _Nonnull)path {
-  LOTPathValueCallback *callback = [[LOTPathValueCallback alloc] init];
+  LOTPathValueCallback *callback = [[self alloc] init];
   callback.pathValue = path;
   return callback;
 }


### PR DESCRIPTION
Lots of the classes the framework exposes publicly offer convenience class methods for their instantiation. Unfortunately those class methods don’t create instances of their respective instancetype as declared, but create instances of hardcoded classes.

This means subclasses cannot take advantage of those convenience methods without introducing bugs. When using an instance that is expected to inherit from the subclass but does in fact inherit from the superclass, calling methods of the subclass will throw an exception. Furthermore, it’s not possible to add variables to those instances without causing a buffer overflow.

While it is possible to work around this using the Objective-C runtime, it would cause unnecessary overhead. As the return type of those class methods is declared as instancetype, it is expected that they return an instance of the current class, self.