### PR TITLE
Add TargetConditionals.h

### DIFF
--- a/lottie-ios/Classes/MacCompatability/CALayer+Compat.h
+++ b/lottie-ios/Classes/MacCompatability/CALayer+Compat.h
@@ -3,6 +3,8 @@
 // Copyright (c) 2017 Airbnb. All rights reserved.
 //
 
+#include <TargetConditionals.h>
+
 #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>

--- a/lottie-ios/Classes/MacCompatability/CALayer+Compat.m
+++ b/lottie-ios/Classes/MacCompatability/CALayer+Compat.m
@@ -3,6 +3,8 @@
 // Copyright (c) 2017 Airbnb. All rights reserved.
 //
 
+#include <TargetConditionals.h>
+
 #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 #import "CALayer+Compat.h"
 

--- a/lottie-ios/Classes/MacCompatability/LOTPlatformCompat.h
+++ b/lottie-ios/Classes/MacCompatability/LOTPlatformCompat.h
@@ -9,7 +9,7 @@
 #ifndef LOTPlatformCompat_h
 #define LOTPlatformCompat_h
 
-#import "TargetConditionals.h"
+#include <TargetConditionals.h>
 
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
 

--- a/lottie-ios/Classes/MacCompatability/NSValue+Compat.h
+++ b/lottie-ios/Classes/MacCompatability/NSValue+Compat.h
@@ -3,6 +3,8 @@
 // Copyright (c) 2017 Airbnb. All rights reserved.
 //
 
+#include <TargetConditionals.h>
+
 #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 #import <Foundation/Foundation.h>
 

--- a/lottie-ios/Classes/MacCompatability/NSValue+Compat.m
+++ b/lottie-ios/Classes/MacCompatability/NSValue+Compat.m
@@ -3,6 +3,8 @@
 // Copyright (c) 2017 Airbnb. All rights reserved.
 //
 
+#include <TargetConditionals.h>
+
 #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 #import "NSValue+Compat.h"
 

--- a/lottie-ios/Classes/MacCompatability/UIBezierPath.h
+++ b/lottie-ios/Classes/MacCompatability/UIBezierPath.h
@@ -28,7 +28,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+#include <TargetConditionals.h>
+
+#if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 

--- a/lottie-ios/Classes/MacCompatability/UIBezierPath.m
+++ b/lottie-ios/Classes/MacCompatability/UIBezierPath.m
@@ -28,7 +28,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+#include <TargetConditionals.h>
+
+#if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 #import "UIBezierPath.h"
 
 @implementation UIBezierPath {

--- a/lottie-ios/Classes/MacCompatability/UIColor.h
+++ b/lottie-ios/Classes/MacCompatability/UIColor.h
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Airbnb. All rights reserved.
 //
 
+#include <TargetConditionals.h>
+
 #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>

--- a/lottie-ios/Classes/MacCompatability/UIColor.m
+++ b/lottie-ios/Classes/MacCompatability/UIColor.m
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Airbnb. All rights reserved.
 //
 
+#include <TargetConditionals.h>
+
 #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
 #import "UIColor.h"
 #import <AppKit/AppKit.h>


### PR DESCRIPTION
Many files were referencing macros defined by TargetConditionals before
including it.

Also updates one macro from the deprecated TARGET_IPHONE_SIMULATOR to
TARGET_OS_SIMULATOR.