### PR TITLE
If imagePath is nil then Load image resource from images.xcassets

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -160,8 +160,13 @@
         image = [UIImage imageWithContentsOfFile:imagePath];
       }
     } else {
-        NSString *imagePath = [asset.assetBundle pathForResource:asset.imageName ofType:nil];
-        image = [UIImage imageWithContentsOfFile:imagePath];
+        NSString * _Nullable imagePath = [asset.assetBundle pathForResource:asset.imageName ofType:nil];
+        
+        if (imagePath == nil) {
+            image = [UIImage imageNamed:asset.imageName];
+        } else {
+            image = [UIImage imageWithContentsOfFile:imagePath];
+        }
     }
     
     if (image) {


### PR DESCRIPTION
``` json
{"v":"5.1.7","fr":29.9700012207031,"ip":0,"op":40.0000016292334,"w":36,"h":36,"nm":"Comp 1","ddd":0,"assets":[{"id":"image_0","w":36,"h":36,"u":"images/","p":"img_0.png"}],"layers":[{"ddd":0,"ind":1,"ty":2,"nm":"ic_like.png","cl":"png","refId":"image_0","sr":1, .... }
```
In this case,
`NSString * imagePath  = [asset.assetBundle pathForResource:asset.imageName ofType:nil];`
imagePath is nil

> I don't know where is recommend image resource path, i try to move image resource any where in xcode project but still imagePath is nil

but, I think,  loading image resource using imageNamed method is more effectiveness
`image = [UIImage imageNamed:asset.imageName];`

thank you for reading my pull request.

