### PR TITLE
Xcode warning fix

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationTransitionController.m
+++ b/lottie-ios/Classes/Private/LOTAnimationTransitionController.m
@@ -118,7 +118,7 @@
   
   [tranistionAnimationView_ playWithCompletion:^(BOOL animationFinished) {
     toVC.view.hidden = false;
-    [tranistionAnimationView_ removeFromSuperview];
+    [self->tranistionAnimationView_ removeFromSuperview];
     [transitionContext completeTransition:animationFinished];
   }];
 }

--- a/lottie-ios/Classes/RenderSystem/ManipulatorNodes/LOTTrimPathNode.m
+++ b/lottie-ios/Classes/RenderSystem/ManipulatorNodes/LOTTrimPathNode.m
@@ -63,7 +63,7 @@
     if ([inputNode isKindOfClass:[LOTPathAnimator class]] ||
         [inputNode isKindOfClass:[LOTCircleAnimator class]] ||
         [inputNode isKindOfClass:[LOTRoundedRectAnimator class]]) {
-      [inputNode.localPath trimPathFromT:_startT toT:_endT offset:_offsetT];
+      [inputNode.localPath trimPathFromT:self->_startT toT:self->_endT offset:self->_offsetT];
     }
     if (modifier) {
       modifier(inputNode);


### PR DESCRIPTION
Fix Xcode warning `block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior`