### PR TITLE
Fix initializer chain

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -57,9 +57,8 @@ static NSString * const kCompContainerAnimationKey = @"play";
 # pragma mark - Initializers
 
 - (instancetype)initWithContentsOfURL:(NSURL *)url {
-  self = [super initWithFrame:CGRectZero];
+  self = [self initWithFrame:CGRectZero];
   if (self) {
-    [self _commonInit];
     LOTComposition *laScene = [[LOTAnimationCache sharedCache] animationForKey:url.absoluteString];
     if (laScene) {
       laScene.cacheKey = url.absoluteString;
@@ -92,18 +91,17 @@ static NSString * const kCompContainerAnimationKey = @"play";
 }
 
 - (instancetype)initWithModel:(LOTComposition *)model inBundle:(NSBundle *)bundle {
-  self = [super initWithFrame:model.compBounds];
+  self = [self initWithFrame:model.compBounds];
   if (self) {
     _bundle = bundle;
-    [self _commonInit];
     [self _initializeAnimationContainer];
     [self _setupWithSceneModel:model];
   }
   return self;
 }
 
-- (instancetype)init {
-  self = [super init];
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
   if (self) {
     [self _commonInit];
   }


### PR DESCRIPTION
This is somewhat minor and easy to work around at the call site, but I stumbled upon this and thought I'd submit a PR.

Currently, `LOTAnimationView` does not override `UIView`/`NSView`'s  `initWithFrame:` designated initializer at all, but _does_ override `init`. This results in a correctly initialized instance when using `init`, and in a somewhat weird state (mainly due to `animationSpeed` remaining at `0`) when using `initWithFrame:`. Since `init` will call through to `initWithFrame:` anyway, it makes more sense to override `initWithFrame:` instead, which is exactly what I did in this PR.

`initWithContentsOfURL:` and `initWithModel:inBundle` are now also funneled through the overridden `initWithFrame:` to reduce code duplication to a small extent.