### PR TITLE
Rasterize _compContainer when not animating

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -190,6 +190,9 @@ static NSString * const kCompContainerAnimationKey = @"play";
 - (void)_removeCurrentAnimationIfNecessary {
   _isAnimationPlaying = NO;
   [_compContainer removeAllAnimations];
+  if (_shouldRasterizeWhenIdle) {
+    _compContainer.shouldRasterize = YES;
+  }
 }
 
 - (CGFloat)_progressForFrame:(NSNumber *)frame {
@@ -340,6 +343,9 @@ static NSString * const kCompContainerAnimationKey = @"play";
       animation.beginTime = CACurrentMediaTime() - (offset * 1 / _animationSpeed);
     }
     [_compContainer addAnimation:animation forKey:kCompContainerAnimationKey];
+    if (_shouldRasterizeWhenIdle) {
+      _compContainer.shouldRasterize = NO;
+    }
   }
   _isAnimationPlaying = YES;
 }
@@ -417,6 +423,15 @@ static NSString * const kCompContainerAnimationKey = @"play";
 
 - (void)forceDrawingUpdate {
   [self _layoutAndForceUpdate];
+}
+
+# pragma mark - External Methods - Idle Rasterization
+
+- (void)setShouldRasterizeWhenIdle:(BOOL)shouldRasterize {
+  _shouldRasterizeWhenIdle = shouldRasterize;
+  if (!_isAnimationPlaying) {
+    _compContainer.shouldRasterize = _shouldRasterizeWhenIdle;
+  }
 }
 
 # pragma mark - External Methods - Cache
@@ -618,6 +633,10 @@ static NSString * const kCompContainerAnimationKey = @"play";
   }
 }
 
+- (void)didMoveToWindow {
+    _compContainer.rasterizationScale = self.window.screen.scale;
+}
+
 - (void)setContentMode:(LOTViewContentMode)contentMode {
   [super setContentMode:contentMode];
   [self setNeedsLayout];
@@ -629,6 +648,10 @@ static NSString * const kCompContainerAnimationKey = @"play";
 }
 
 #else
+
+- (void)viewDidMoveToWindow {
+    _compContainer.rasterizationScale = self.window.screen.backingScaleFactor;
+}
     
 - (void)setCompletionBlock:(LOTAnimationCompletionBlock)completionBlock {
     if (completionBlock) {

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -73,6 +73,10 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 /// Set the animation data
 @property (nonatomic, strong, nullable) LOTComposition *sceneModel;
 
+/// Sets sholdRasterize to YES on the animation layer to improve compositioning performance when not animating.
+/// Defaults to YES
+@property (nonatomic, assign) BOOL shouldRasterizeWhenIdle;
+
 /* 
  * Plays the animation from its current position to a specific progress.
  * The animation will start from its current position.


### PR DESCRIPTION
This might be specific to my particular use case, but I've found that when displaying a lot of `LOTAnimationView` instances at the same time on a screen in a scroll view the scrolling frame rate is significantly reduced even though the animations are all stopped. This is because Lottie recreates the entire layer hierarchy of the original After Effects animation which can be arbitrarily complex. This results in a lot of strain to the device's GPU when compositing a lot of animation layers, which is especially noticeable during scrolling.

This PR introduces a new `shouldRasterizeWhenIdle` property defaulting to `YES` which sets `shouldRasterize` to `YES` on the underlying `_compContainer` layer whenever it is not animating. This results in the entire sublayer hierarchy being drawn once into a bitmap and then reused, effectively flattening the animation contents and reducing the GPU load to be comparable with rendering a regular image. There are also two new `didMoveToWindow`/`viewDidMoveToWindow` overrides for setting the `rasterizationScale` to match that of the current screen.

Rasterization is undesirable when actively resizing the `LOTAnimationView` instance, hence a separate property as a way to opt out of it, but I assume that the default value of `YES` should be more useful to most users of this library.

Since this behavior is pretty trivial to implement in the application code by either subclassing or wrapping a `LOTAnimationView` instance, I will be totally happy if this PR won't make it to the codebase.