### PR TITLE
Fixed animation loading from Asset Catalog

### DIFF
--- a/lottie-ios/Classes/Private/LOTComposition.m
+++ b/lottie-ios/Classes/Private/LOTComposition.m
@@ -32,6 +32,13 @@
   NSError *error;
   NSString *filePath = [bundle pathForResource:animationName ofType:@"json"];
   NSData *jsonData = [[NSData alloc] initWithContentsOfFile:filePath];
+  
+  if (@available(iOS 9.0, *)) {
+    if (!jsonData) {
+      jsonData = [[NSDataAsset alloc] initWithName:animationName].data;
+    }
+  }
+  
   NSDictionary  *JSONObject = jsonData ? [NSJSONSerialization JSONObjectWithData:jsonData
                                                                          options:0 error:&error] : nil;
   if (JSONObject && !error) {


### PR DESCRIPTION
This allows adding a data asset in the Asset Catalog with the animation JSON file and load it using the `animationNamed:` method.