### PR TITLE
Find asset images from asset catalogs using UIImage imageNamed:.

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -162,6 +162,9 @@
     } else {
         NSString *imagePath = [asset.assetBundle pathForResource:asset.imageName ofType:nil];
         image = [UIImage imageWithContentsOfFile:imagePath];
+        if(!image) {
+            image = [UIImage imageNamed:asset.imageName inBundle: asset.assetBundle compatibleWithTraitCollection:nil];
+        }
     }
     
     if (image) {


### PR DESCRIPTION
This helps solve #580. `-setImageForAsset:` will search in asset catalogs using `UIImage +imageNamed:inBundle:compatibleWithTraitCollection:` if it didn't find the image elsewhere, like the image catalog or the filesystem or the bundle.