### PR TITLE
Fixed an issue where animations would get delayed

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -336,7 +336,9 @@ static NSString * const kCompContainerAnimationKey = @"play";
     animation.delegate = self;
     animation.removedOnCompletion = NO;
     if (offset != 0) {
-      animation.beginTime = CACurrentMediaTime() - (offset * 1 / _animationSpeed);
+      CFTimeInterval currentTime = CACurrentMediaTime();
+      CFTimeInterval currentLayerTime = [self.layer convertTime:currentTime fromLayer:nil];
+      animation.beginTime = currentLayerTime - (offset * 1 / _animationSpeed);
     }
     [_compContainer addAnimation:animation forKey:kCompContainerAnimationKey];
     _compContainer.shouldRasterize = NO;


### PR DESCRIPTION
There seems to be an issue where over-time animations can get delayed. The delay can be multiple seconds and forever-growing.

The issue may be related to `snapshotView(afterScreenUpdates:)` when parameter is set to `true`:
https://github.com/airbnb/lottie-ios/issues/355#issuecomment-321823104

The app where this issue is happening is also using the snapshot API a lot, and when called continuously, the animation will get more-and-more delayed over time.

I do not know why `snapshotView` causes this issue (under the assumption that it does), but a wild (and uneducated) guess is that it could be related to [pausing animations](https://developer.apple.com/library/content/qa/qa1673/_index.html) during a snapshot.

Nevertheless, it seems that the fix makes sense to do anyway. From the book "iOS Core Animation - Advanced Techniques:"
> Each `CALayer` and `CAAnimation` instance has its own _local_ concept of time, which may differ from global time depending on the `beginTime`, `timeOffset`, and `speed` properties of the parent objects in the layer/animation hierarchy.

Since `CACurrentMediaTime()` is global, I don't think a `LOTAnimationView` can assume that its parents will always be in the global time too.

I am far from an "animation expert" though, so if this is wrong or anyone has better insights, I would love to hear it all!

This has been fixed before:
https://github.com/airbnb/lottie-ios/pull/297/commits/52186053cae29f6d1997d8b39e0c8eef82fd4ca8

And mentioned in many issues:
https://github.com/airbnb/lottie-ios/issues/355
https://github.com/airbnb/lottie-ios/issues/373
https://github.com/airbnb/lottie-ios/issues/380

