### PR TITLE
Add basic support for base64 image asset URLs.

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -142,7 +142,12 @@
 - (void)_setImageForAsset:(LOTAsset *)asset {
   if (asset.imageName) {
     UIImage *image;
-    if (asset.rootDirectory.length > 0) {
+    if ([asset.imageName hasPrefix:@"data:"]) {
+      // Contents look like a data: URL. Ignore asset.imageDirectory and simply load the image directly.
+      NSURL *imageUrl = [NSURL URLWithString:asset.imageName];
+      NSData *imageData = [NSData dataWithContentsOfURL:imageUrl];
+      image = [UIImage imageWithData:imageData];
+    } else if (asset.rootDirectory.length > 0) {
       NSString *rootDirectory  = asset.rootDirectory;
       if (asset.imageDirectory.length > 0) {
         rootDirectory = [rootDirectory stringByAppendingPathComponent:asset.imageDirectory];


### PR DESCRIPTION
This allows us to bake raster images directly into JSON without relying on a separate `images/` directory or similar—basically, instead of JSON that says:

```"u": "image/", "p": "filename.png"```

we can instead say:

```"u": "", "p": "data:image/png;base64,…"```

Note that (due to the simple way images are handled in the browser) this works already in `lottie-web`, and I'm planning to send a similar PR to `lottie-android`.

Regarding the approach, I noticed was a significant amount of refactoring of `LOTAsset` etc. required to avail ourselves of the image cache in a sane way when image "names" come through as giant strings, so I opted for something quick and easy. I'm definitely open to alternative approaches that might be more robust if this approach seems problematic in terms of performance.