### PR TITLE
Calling boolValue instead of converting NSNumber

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTCompositionContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTCompositionContainer.m
@@ -38,7 +38,7 @@
     if (ENABLE_DEBUG_SHAPES) {
       [self.wrapperLayer addSublayer:DEBUG_Center];
     }
-    if (layer.startFrame) {
+    if ([layer.startFrame boolValue]) {
       _frameOffset = layer.startFrame;
     } else {
       _frameOffset = @0;

--- a/lottie-ios/Classes/AnimatableLayers/LOTCompositionContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTCompositionContainer.m
@@ -38,7 +38,7 @@
     if (ENABLE_DEBUG_SHAPES) {
       [self.wrapperLayer addSublayer:DEBUG_Center];
     }
-    if ([layer.startFrame boolValue]) {
+    if (layer.startFrame != nil) {
       _frameOffset = layer.startFrame;
     } else {
       _frameOffset = @0;


### PR DESCRIPTION
Problem found with static analysis code of Xcode 9.3.
"Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue"