### PR TITLE
Add ability to set a new JSON on an existing animation

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -229,6 +229,13 @@ static NSString * const kCompContainerAnimationKey = @"play";
   [self _setupWithSceneModel:comp];
 }
 
+- (void)setAnimationFromJSON:(nonnull NSDictionary *)animationJSON {
+  LOTComposition *comp = [LOTComposition animationFromJSON:animationJSON];
+
+  [self _initializeAnimationContainer];
+  [self _setupWithSceneModel:comp];
+}
+
 # pragma mark - External Methods - Model
 
 - (void)setSceneModel:(LOTComposition *)sceneModel {

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -43,6 +43,9 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 /// Load animation by name from the default bundle. Use when loading LOTAnimationView via Interface Builder.
 - (void)setAnimationNamed:(nonnull NSString *)animationName NS_SWIFT_NAME(setAnimation(named:));
 
+/// Load animation from a JSON dictionary
+- (void)setAnimationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(setAnimation(json:));
+
 /// Flag is YES when the animation is playing
 @property (nonatomic, readonly) BOOL isAnimationPlaying;
 


### PR DESCRIPTION
I've added a new interface method to the LOTAnimationView that allows changing the animation through a JSON string, not just a name (as the current implementation allows).

```
- (void)setAnimationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(setAnimation(json:));
```