### PR TITLE
Xcode Asset Catalogue support for image resources

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -162,8 +162,16 @@
     } else {
         NSString *imagePath = [asset.assetBundle pathForResource:asset.imageName ofType:nil];
         image = [UIImage imageWithContentsOfFile:imagePath];
-        if(!image) {
+        if (!image) {
             image = [UIImage imageNamed:asset.imageName inBundle: asset.assetBundle compatibleWithTraitCollection:nil];
+        }
+
+        if (!image) {
+            // Try to get the image from an xcasset catalogue
+            NSData *data = [[NSDataAsset alloc] initWithName: asset.imageName].data;
+            if (data) {
+                image = [UIImage imageWithData: data];
+            }
         }
     }
     


### PR DESCRIPTION
If needed, attempts to load images without a directory from an xcasset catalogue.