### PR TITLE
Factoring the gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,11 @@
-Example/Pods/Pods.xcodeproj/xcuserdata/
-Example/lottie-ios.xcworkspace/xcuserdata/
-Example/lottie-ios.xcodeproj/xcuserdata/
-LottieExamples/LottieExamples.xcodeproj/xcuserdata/
-LottieExamples.xcworkspace/xcuserdata/
-Lottie/Lottie.xcodeproj/xcuserdata/
-UserInterfaceState.xcuserstate
-xample/lottie-ios.xcodeproj/xcuserdata
-Lottie.xcodeproj/xcuserdata/
-Example/lottie-ios.xcworkspace/xcuserdata/
-Example/lottie-ios.xcodeproj/xcuserdata/
+# Xcode
+xcuserdata/
+
+# AppCode
 .idea/
+
+# other
 build/
-Lottie-Screenshot/Lottie-Screenshot.xcworkspace/xcuserdata/
-Lottie-Screenshot/Lottie-Screenshot.xcodeproj/xcuserdata/
-Lottie-Screenshot/Pods/Pods.xcodeproj/xcuserdata/
-Example/.DS_Store
-Example/lottie-ios.xcodeproj/xcuserdata
-Example/lottie-ios.xcodeproj/xcuserdata
-Example-Swift/Pods/Pods.xcodeproj/xcuserdata/
-Example-Swift/Lottie-Example-Swift.xcodeproj/xcuserdata/
+
+# macOS
 .DS_Store


### PR DESCRIPTION
A .gitignore file format allows to factor some patterns.
Note that `build/` could safely be removed, but I left it for now. It was only needed for VERY OLD versions of Xcode, as I documented on https://github.com/github/gitignore/blob/master/Global/Xcode.gitignore