### PR TITLE
Medium typo

### DIFF
--- a/lottie-ios/Classes/Extensions/CGGeometry+LOTAdditions.h
+++ b/lottie-ios/Classes/Extensions/CGGeometry+LOTAdditions.h
@@ -87,7 +87,7 @@ CGPoint LOT_PointByLerpingPoints(CGPoint point1, CGPoint point2, CGFloat value);
 CGPoint LOT_PointInLine(CGPoint A, CGPoint B, CGFloat T);
 CGPoint LOT_PointInCubicCurve(CGPoint start, CGPoint cp1, CGPoint cp2, CGPoint end, CGFloat T);
 
-CGFloat LOT_CubicBezeirInterpolate(CGPoint P0, CGPoint P1, CGPoint P2, CGPoint P3, CGFloat x);
+CGFloat LOT_CubicBezierInterpolate(CGPoint P0, CGPoint P1, CGPoint P2, CGPoint P3, CGFloat x);
 CGFloat LOT_SolveCubic(CGFloat a, CGFloat b, CGFloat c, CGFloat d);
 CGFloat LOT_SolveQuadratic(CGFloat a, CGFloat b, CGFloat c);
 CGFloat LOT_Squared(CGFloat f);

--- a/lottie-ios/Classes/Extensions/CGGeometry+LOTAdditions.m
+++ b/lottie-ios/Classes/Extensions/CGGeometry+LOTAdditions.m
@@ -434,7 +434,7 @@ CGFloat LOT_Cubed(CGFloat f) { return f * f * f; }
 
 CGFloat LOT_CubicRoot(CGFloat f) { return powf(f, 1.0 / 3.0); }
 
-CGFloat LOT_CubicBezeirInterpolate(CGPoint P0, CGPoint P1, CGPoint P2, CGPoint P3, CGFloat x) {
+CGFloat LOT_CubicBezierInterpolate(CGPoint P0, CGPoint P1, CGPoint P2, CGPoint P3, CGFloat x) {
   CGFloat t;
   if (x == P0.x) {
     // Handle corner cases explicitly to prevent rounding errors

--- a/lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTValueInterpolator.m
+++ b/lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTValueInterpolator.m
@@ -147,17 +147,17 @@
     return 1;
   }
 
-  CGFloat progession = LOT_RemapValue(frame.floatValue, self.leadingKeyframe.keyframeTime.floatValue, self.trailingKeyframe.keyframeTime.floatValue, 0, 1);
+  CGFloat progression = LOT_RemapValue(frame.floatValue, self.leadingKeyframe.keyframeTime.floatValue, self.trailingKeyframe.keyframeTime.floatValue, 0, 1);
   
   if ((self.leadingKeyframe.outTangent.x != self.leadingKeyframe.outTangent.y ||
       self.trailingKeyframe.inTangent.x != self.trailingKeyframe.inTangent.y) &&
       (!LOT_CGPointIsZero(self.leadingKeyframe.outTangent) &&
        !LOT_CGPointIsZero(self.trailingKeyframe.inTangent))) {
     // Bezier Time Curve
-    progession = LOT_CubicBezeirInterpolate(CGPointMake(0, 0), self.leadingKeyframe.outTangent, self.trailingKeyframe.inTangent, CGPointMake(1, 1), progession);
+    progression = LOT_CubicBezierInterpolate(CGPointMake(0, 0), self.leadingKeyframe.outTangent, self.trailingKeyframe.inTangent, CGPointMake(1, 1), progression);
   }
   
-  return progession;
+  return progression;
 }
 
 - (void)setValueDelegate:(id<LOTValueDelegate> _Nonnull)delegate {

--- a/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRenderGroup.m
+++ b/lottie-ios/Classes/RenderSystem/RenderNodes/LOTRenderGroup.m
@@ -30,7 +30,7 @@
   LOTBezierPath *_localPath;
   BOOL _rootNodeHasUpdate;
   LOTNumberInterpolator *_opacityInterpolator;
-  LOTTransformInterpolator *_transformInterolator;
+  LOTTransformInterpolator *_transformInterpolator;
 }
 
 - (instancetype _Nonnull)initWithInputNode:(LOTAnimatorNode * _Nullable)inputNode
@@ -47,18 +47,18 @@
 }
 
 - (NSDictionary *)valueInterpolators {
-  if (_opacityInterpolator && _transformInterolator) {
+  if (_opacityInterpolator && _transformInterpolator) {
     return @{@"Opacity" : _opacityInterpolator,
-             @"Position" : _transformInterolator.positionInterpolator,
-             @"Scale" : _transformInterolator.scaleInterpolator,
-             @"Rotation" : _transformInterolator.scaleInterpolator,
-             @"Anchor Point" : _transformInterolator.anchorInterpolator,
+             @"Position" : _transformInterpolator.positionInterpolator,
+             @"Scale" : _transformInterpolator.scaleInterpolator,
+             @"Rotation" : _transformInterpolator.scaleInterpolator,
+             @"Anchor Point" : _transformInterpolator.anchorInterpolator,
              // Deprecated
              @"Transform.Opacity" : _opacityInterpolator,
-             @"Transform.Position" : _transformInterolator.positionInterpolator,
-             @"Transform.Scale" : _transformInterolator.scaleInterpolator,
-             @"Transform.Rotation" : _transformInterolator.scaleInterpolator,
-             @"Transform.Anchor Point" : _transformInterolator.anchorInterpolator
+             @"Transform.Position" : _transformInterpolator.positionInterpolator,
+             @"Transform.Scale" : _transformInterpolator.scaleInterpolator,
+             @"Transform.Rotation" : _transformInterpolator.scaleInterpolator,
+             @"Transform.Anchor Point" : _transformInterpolator.anchorInterpolator
              };
   }
   return nil;
@@ -122,7 +122,7 @@
   }
   if (transform) {
     _opacityInterpolator = [[LOTNumberInterpolator alloc] initWithKeyframes:transform.opacity.keyframes];
-    _transformInterolator = [[LOTTransformInterpolator alloc] initWithPosition:transform.position.keyframes
+    _transformInterpolator = [[LOTTransformInterpolator alloc] initWithPosition:transform.position.keyframes
                                                                       rotation:transform.rotation.keyframes
                                                                         anchor:transform.anchor.keyframes
                                                                          scale:transform.scale.keyframes];
@@ -132,7 +132,7 @@
 
 - (BOOL)needsUpdateForFrame:(NSNumber *)frame {
   return ([_opacityInterpolator hasUpdateForFrame:frame] ||
-          [_transformInterolator hasUpdateForFrame:frame] ||
+          [_transformInterpolator hasUpdateForFrame:frame] ||
           _rootNodeHasUpdate);
 
 }
@@ -149,8 +149,8 @@
   if (_opacityInterpolator) {
     self.containerLayer.opacity = [_opacityInterpolator floatValueForFrame:self.currentFrame];
   }
-  if (_transformInterolator) {
-    CATransform3D xform = [_transformInterolator transformForFrame:self.currentFrame];
+  if (_transformInterpolator) {
+    CATransform3D xform = [_transformInterpolator transformForFrame:self.currentFrame];
     self.containerLayer.transform = xform;
     
     CGAffineTransform appliedXform = CATransform3DGetAffineTransform(xform);


### PR DESCRIPTION
Average impact changes:

* LOT_CubicBezeirInterpolate is a public declaration, so you may want to deprecate it before renaming it...
* _transformInterolator is a private declaration, so it should be OK to rename directly