### PR TITLE
Added fix for loading images from asset catalogue

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -167,9 +167,11 @@
     } else {
         NSString *imagePath = [asset.assetBundle pathForResource:asset.imageName ofType:nil];
         image = [UIImage imageWithContentsOfFile:imagePath];
-        if(!image) {
-            image = [UIImage imageNamed:asset.imageName inBundle: asset.assetBundle compatibleWithTraitCollection:nil];
-        }
+    }
+
+    //try loading from asset catalogue instead if all else fails
+    if (!image) {
+      image = [UIImage imageNamed:asset.imageName inBundle: asset.assetBundle compatibleWithTraitCollection:nil];
     }
     
     if (image) {


### PR DESCRIPTION
This fix is built from https://github.com/airbnb/lottie-ios/pull/596 but the check is moved down to catch more cases. In the past it will only look for the image from the asset catalogue only if the root directory was never specified (if users initialized the animation with `[LOTAnimationView animationWithFilePath]`, the root directory will always be filled out). 

This allows us to use the asset catalogue for multiple cases (which is great because the asset catalogue resizes the images for us !!)