### PR TITLE
Fix broken animation during scrolling

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -227,7 +227,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
       _completionBlock = _completionBlockToRestoreWhenAttachedToWindow;
       _completionBlockToRestoreWhenAttachedToWindow = nil;
       
-      [self performSelector:@selector(_restoreState) withObject:nil afterDelay:0];
+      [self performSelector:@selector(_restoreState) withObject:nil afterDelay:0 inModes:@[NSRunLoopCommonModes]];
     }
   } else {
     // The view is being detached, capture information that need to be restored later.


### PR DESCRIPTION
Use NSRunLoopCommonModes when calling -performSelector:
This way we make sure that _restore state is called when user scrolls. This fixes a case when -playToFrame:withCompletion: method is called during cell reuse.