### PR TITLE
Adding missing public headers to the tvOS target

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1401C9DE21613A6C00D8B5FE /* LOTValueDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E4703A20000C9A000C97B5 /* LOTValueDelegate.h */; };
-		1401C9DF21613A7200D8B5FE /* LOTBlockCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 62ACB6BC20003027006EDE2D /* LOTBlockCallback.h */; };
-		1401C9E021613A9700D8B5FE /* LOTInterpolatorCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 62ACB6C3200030BB006EDE2D /* LOTInterpolatorCallback.h */; };
-		1401C9E121613A9C00D8B5FE /* LOTValueCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A62B481FE48220001A2C2F /* LOTValueCallback.h */; };
+		1401C9DE21613A6C00D8B5FE /* LOTValueDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E4703A20000C9A000C97B5 /* LOTValueDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1401C9DF21613A7200D8B5FE /* LOTBlockCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 62ACB6BC20003027006EDE2D /* LOTBlockCallback.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1401C9E021613A9700D8B5FE /* LOTInterpolatorCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 62ACB6C3200030BB006EDE2D /* LOTInterpolatorCallback.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1401C9E121613A9C00D8B5FE /* LOTValueCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A62B481FE48220001A2C2F /* LOTValueCallback.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2DBA19324CDD83B5F0F115B8 /* LOTAnimationView_Compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBA16351B4FA408937A16CE /* LOTAnimationView_Compat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48183C9C1E54E20B0039F121 /* CGGeometry+LOTAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 48183C9A1E54E20B0039F121 /* CGGeometry+LOTAdditions.h */; };
 		48183C9D1E54E20B0039F121 /* CGGeometry+LOTAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 48183C9A1E54E20B0039F121 /* CGGeometry+LOTAdditions.h */; };
@@ -1072,10 +1072,13 @@
 				8C53793A1FB471D100C1BC65 /* LOTNumberInterpolator.h in Headers */,
 				8C53793B1FB471D100C1BC65 /* LOTComposition.h in Headers */,
 				8C53793C1FB471D100C1BC65 /* LOTModels.h in Headers */,
+				1401C9E021613A9700D8B5FE /* LOTInterpolatorCallback.h in Headers */,
 				8C53793D1FB471D100C1BC65 /* LOTAnimationView.h in Headers */,
 				A874744E204EC2ED00E5C62C /* LOTKeypath.h in Headers */,
 				8C53793E1FB471D100C1BC65 /* UIColor+Expanded.h in Headers */,
+				1401C9DE21613A6C00D8B5FE /* LOTValueDelegate.h in Headers */,
 				1401C9DF21613A7200D8B5FE /* LOTBlockCallback.h in Headers */,
+				1401C9E121613A9C00D8B5FE /* LOTValueCallback.h in Headers */,
 				8C53793F1FB471D100C1BC65 /* LOTShapeFill.h in Headers */,
 				8C5379401FB471D100C1BC65 /* LOTTrimPathNode.h in Headers */,
 				8C5379411FB471D100C1BC65 /* LOTPolystarAnimator.h in Headers */,
@@ -1091,7 +1094,6 @@
 				8C53794B1FB471D100C1BC65 /* LOTKeyframe.h in Headers */,
 				8C53794C1FB471D100C1BC65 /* Lottie.h in Headers */,
 				8C53794D1FB471D100C1BC65 /* LOTShapeGroup.h in Headers */,
-				1401C9DE21613A6C00D8B5FE /* LOTValueDelegate.h in Headers */,
 				8C53794E1FB471D100C1BC65 /* LOTCircleAnimator.h in Headers */,
 				8C53794F1FB471D100C1BC65 /* LOTShapeTrimPath.h in Headers */,
 				8C5379501FB471D100C1BC65 /* LOTStrokeRenderer.h in Headers */,
@@ -1099,8 +1101,6 @@
 				8C5379521FB471D100C1BC65 /* LOTAssetGroup.h in Headers */,
 				8C5379531FB471D100C1BC65 /* LOTLayerGroup.h in Headers */,
 				8C5379541FB471D100C1BC65 /* LOTShapeRectangle.h in Headers */,
-				1401C9E121613A9C00D8B5FE /* LOTValueCallback.h in Headers */,
-				1401C9E021613A9700D8B5FE /* LOTInterpolatorCallback.h in Headers */,
 				8C5379551FB471D100C1BC65 /* LOTPolygonAnimator.h in Headers */,
 				8C5379561FB471D100C1BC65 /* LOTShapeStroke.h in Headers */,
 				8C5379571FB471D100C1BC65 /* LOTValueInterpolator.h in Headers */,

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1401C9DE21613A6C00D8B5FE /* LOTValueDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E4703A20000C9A000C97B5 /* LOTValueDelegate.h */; };
+		1401C9DF21613A7200D8B5FE /* LOTBlockCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 62ACB6BC20003027006EDE2D /* LOTBlockCallback.h */; };
+		1401C9E021613A9700D8B5FE /* LOTInterpolatorCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 62ACB6C3200030BB006EDE2D /* LOTInterpolatorCallback.h */; };
+		1401C9E121613A9C00D8B5FE /* LOTValueCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A62B481FE48220001A2C2F /* LOTValueCallback.h */; };
 		2DBA19324CDD83B5F0F115B8 /* LOTAnimationView_Compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DBA16351B4FA408937A16CE /* LOTAnimationView_Compat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48183C9C1E54E20B0039F121 /* CGGeometry+LOTAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 48183C9A1E54E20B0039F121 /* CGGeometry+LOTAdditions.h */; };
 		48183C9D1E54E20B0039F121 /* CGGeometry+LOTAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 48183C9A1E54E20B0039F121 /* CGGeometry+LOTAdditions.h */; };
@@ -1071,6 +1075,7 @@
 				8C53793D1FB471D100C1BC65 /* LOTAnimationView.h in Headers */,
 				A874744E204EC2ED00E5C62C /* LOTKeypath.h in Headers */,
 				8C53793E1FB471D100C1BC65 /* UIColor+Expanded.h in Headers */,
+				1401C9DF21613A7200D8B5FE /* LOTBlockCallback.h in Headers */,
 				8C53793F1FB471D100C1BC65 /* LOTShapeFill.h in Headers */,
 				8C5379401FB471D100C1BC65 /* LOTTrimPathNode.h in Headers */,
 				8C5379411FB471D100C1BC65 /* LOTPolystarAnimator.h in Headers */,
@@ -1086,6 +1091,7 @@
 				8C53794B1FB471D100C1BC65 /* LOTKeyframe.h in Headers */,
 				8C53794C1FB471D100C1BC65 /* Lottie.h in Headers */,
 				8C53794D1FB471D100C1BC65 /* LOTShapeGroup.h in Headers */,
+				1401C9DE21613A6C00D8B5FE /* LOTValueDelegate.h in Headers */,
 				8C53794E1FB471D100C1BC65 /* LOTCircleAnimator.h in Headers */,
 				8C53794F1FB471D100C1BC65 /* LOTShapeTrimPath.h in Headers */,
 				8C5379501FB471D100C1BC65 /* LOTStrokeRenderer.h in Headers */,
@@ -1093,6 +1099,8 @@
 				8C5379521FB471D100C1BC65 /* LOTAssetGroup.h in Headers */,
 				8C5379531FB471D100C1BC65 /* LOTLayerGroup.h in Headers */,
 				8C5379541FB471D100C1BC65 /* LOTShapeRectangle.h in Headers */,
+				1401C9E121613A9C00D8B5FE /* LOTValueCallback.h in Headers */,
+				1401C9E021613A9700D8B5FE /* LOTInterpolatorCallback.h in Headers */,
 				8C5379551FB471D100C1BC65 /* LOTPolygonAnimator.h in Headers */,
 				8C5379561FB471D100C1BC65 /* LOTShapeStroke.h in Headers */,
 				8C5379571FB471D100C1BC65 /* LOTValueInterpolator.h in Headers */,


### PR DESCRIPTION
The following 4 headers were missing from the tvOS target:
LOTValueDelegate.h
LOTBlockCallback.h
LOTInterpolatorCallback.h
LOTValueCallback.h

This prevented building any app tvOS targets that had a dependency on Lottie_tvOS