### PR TITLE
UIToolbar and Safe Area overlapping fixed

### DIFF
--- a/Example/lottie-ios/AnimationExplorerViewController.m
+++ b/Example/lottie-ios/AnimationExplorerViewController.m
@@ -99,7 +99,11 @@ typedef enum : NSUInteger {
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
   CGRect b = self.view.bounds;
-  self.toolbar.frame = CGRectMake(0, b.size.height - 44, b.size.width, 44);
+  CGFloat safeAreaBottomInset = 0;
+  if (@available(iOS 11.0, *)) {
+    safeAreaBottomInset = self.view.safeAreaInsets.bottom;
+  }
+  self.toolbar.frame = CGRectMake(0, b.size.height - 44 - safeAreaBottomInset, b.size.width, 44);
   CGSize sliderSize = [self.slider sizeThatFits:b.size];
   sliderSize.height += 12;
   self.slider.frame = CGRectMake(10, CGRectGetMinY(self.toolbar.frame) - sliderSize.height, b.size.width - 20, sliderSize.height);


### PR DESCRIPTION
Including the safe area bottom insets in the height calculation of the UIToolbar to avoid an overlapping between the toolbar and the safe area