### PR TITLE
Improve setAnimation: methods with Bundle parameter

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -287,10 +287,24 @@ static NSString * const kCompContainerAnimationKey = @"play";
   [self _initializeAnimationContainer];
   [self _setupWithSceneModel:comp];
 }
+  
+- (void)setAnimationNamed:(NSString *)animationName inBundle:(NSBundle *)bundle {
+  LOTComposition *comp = [LOTComposition animationNamed:animationName inBundle:bundle];
+  
+  [self _initializeAnimationContainer];
+  [self _setupWithSceneModel:comp];
+}
 
 - (void)setAnimationFromJSON:(nonnull NSDictionary *)animationJSON {
   LOTComposition *comp = [LOTComposition animationFromJSON:animationJSON];
 
+  [self _initializeAnimationContainer];
+  [self _setupWithSceneModel:comp];
+}
+  
+- (void)setAnimationFromJSON:(NSDictionary *)animationJSON inBundle:(NSBundle *)bundle {
+  LOTComposition *comp = [LOTComposition animationFromJSON:animationJSON inBundle:bundle];
+  
   [self _initializeAnimationContainer];
   [self _setupWithSceneModel:comp];
 }

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -42,9 +42,15 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 
 /// Load animation by name from the default bundle. Use when loading LOTAnimationView via Interface Builder.
 - (void)setAnimationNamed:(nonnull NSString *)animationName NS_SWIFT_NAME(setAnimation(named:));
+  
+/// Load animation by name from a specific bundle.
+- (void)setAnimationNamed:(nonnull NSString *)animationName inBundle:(nullable NSBundle *)bundle  NS_SWIFT_NAME(setAnimation(named:bundle:));
 
 /// Load animation from a JSON dictionary
 - (void)setAnimationFromJSON:(nonnull NSDictionary *)animationJSON NS_SWIFT_NAME(setAnimation(json:));
+
+/// Load animation from a JSON dictionary from a specific bundle
+- (void)setAnimationFromJSON:(nonnull NSDictionary *)animationJSON inBundle:(nullable NSBundle *)bundle NS_SWIFT_NAME(setAnimation(json:bundle:));
 
 /// Flag is YES when the animation is playing
 @property (nonatomic, readonly) BOOL isAnimationPlaying;


### PR DESCRIPTION
Actually, the `setAnimation:named` and `setAnimationFromJSON:` are loading animations only from the main Bundle.

It is a nonsense because we can init a `LOTAnimationView` from the main **or** a custom Bundle.
To improve it, this light PR simply add **`setAnimation` variants with Bundle parameter.** : 

`- (void)setAnimationNamed:(NSString *)animationName inBundle:(NSBundle *)bundle;`

`- (void)setAnimationFromJSON:(NSDictionary *)animationJSON inBundle:(NSBundle *)bundle;`

