### PR TITLE
Fix for completion block not being restored when animation re-attached to window

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -253,9 +253,10 @@ static NSString * const kCompContainerAnimationKey = @"play";
   } else {
     // The view is being detached, capture information that need to be restored later.
     if (_isAnimationPlaying) {
+      LOTAnimationCompletionBlock completion = _completionBlock;
       [self pause];
       _shouldRestoreStateWhenAttachedToWindow = YES;
-      _completionBlockToRestoreWhenAttachedToWindow = _completionBlock;
+      _completionBlockToRestoreWhenAttachedToWindow = completion;
       _completionBlock = nil;
     }
   }


### PR DESCRIPTION
Remember completion block to restore before it is nilled.
Fix for issue #746 https://github.com/airbnb/lottie-ios/issues/746