### PR TITLE
chore: fix cyclic build in lottie-ios repo itself [ch17530]

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -1229,9 +1229,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6445B0D2207E0D4D00D84F6A /* Build configuration list for PBXNativeTarget "LottieLibraryMacOS" */;
 			buildPhases = (
+				6445B0C3207E0D4D00D84F6A /* CopyFiles */,
 				6445B089207E0D4D00D84F6A /* Sources */,
 				6445B0C2207E0D4D00D84F6A /* Frameworks */,
-				6445B0C3207E0D4D00D84F6A /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -1246,9 +1246,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 84FE12F71E4C1485009B157C /* Build configuration list for PBXNativeTarget "LottieLibraryIOS" */;
 			buildPhases = (
+				84FE12ED1E4C1485009B157C /* CopyFiles */,
 				84FE12EB1E4C1485009B157C /* Sources */,
 				84FE12EC1E4C1485009B157C /* Frameworks */,
-				84FE12ED1E4C1485009B157C /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lottie-ios",
+  "name": "peerio-lottie-ios",
   "version": "2.5.2",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "peerio-lottie-ios",
+  "name": "lottie-ios",
   "version": "2.5.2",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!",
   "main": "index.js",


### PR DESCRIPTION
On our react-native project, LottieLibraryIOS intermittently produces errors when building on XCode. The error reads as following:

`Cyclic dependency in LottieLibraryIOS. Build may produce unreliable results`

Moving copy headers phase before compile sources seems to resolve the issue.