### PR TITLE
Support image in the disk for MacOS

### DIFF
--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -188,6 +188,12 @@
   if (asset.imageName) {
     NSArray *components = [asset.imageName componentsSeparatedByString:@"."];
     NSImage *image = [NSImage imageNamed:components.firstObject];
+    if (image == nil) {
+      if (asset.rootDirectory.length > 0 && asset.imageDirectory.length > 0) {
+        NSString *imagePath = [[asset.rootDirectory stringByAppendingPathComponent:asset.imageDirectory] stringByAppendingPathComponent:asset.imageName];
+        image = [[NSImage alloc] initWithContentsOfFile:imagePath];
+      }
+    }
     if (image) {
       NSWindow *window = [NSApp mainWindow];
       CGFloat desiredScaleFactor = [window backingScaleFactor];


### PR DESCRIPTION
Currently, lottie for MacOS only support image in the Application Assets.
This commit add local image support