### PR TITLE
Fix deprecated method workaround name

### DIFF
--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -220,7 +220,7 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 
 /*!
  @brief Sets the keyframe value for a specific After Effects property at a given time. NOTE: Deprecated. Use setValueDelegate:forKeypath:
- @discussion NOTE: Deprecated and non functioning. Use setValueCallback:forKeypath:
+ @discussion NOTE: Deprecated and non functioning. Use setValueDelegate:forKeypath:
  @param value Value is the color, point, or number object that should be set at given time
  @param keypath NSString . separate keypath The Keypath is a dot separated key path that specifies the location of the key to be set from the After Effects file. This will begin with the Layer Name. EG "Layer 1.Shape 1.Fill 1.Color"
  @param frame The frame is the frame to be set. If the keyframe exists it will be overwritten, if it does not exist a new linearly interpolated keyframe will be added

--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -160,7 +160,7 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
  @code
  LOTKeypath *keypath = [LOTKeypath keypathWithKeys:@"Layer 1", @"Ellipse 1", @"Stroke 1", @"Color", nil];
  LOTColorValueCallback *colorCallback = [LOTColorBlockCallback withColor:[UIColor redColor]];
- [animationView setValueCallback:colorCallback forKeypath:keypath];
+ [animationView setValueDelegate:colorCallback forKeypath:keypath];
  @endcode
 
  See the documentation for LOTValueDelegate to see how to create LOTValueCallbacks. A delegate can be any object that conforms to the LOTValueDelegate protocol, or one of the prebuilt delegate classes found in LOTBlockCallback, LOTInterpolatorCallback, and LOTValueCallback.


### PR DESCRIPTION
When I switched to a new version of the lottie-ios, I was a little bit confused, due to two suggested workarounds for a deprecated method.
