### PR TITLE
Early return nil if animationName is nil to prevent a crashing issue

### DIFF
--- a/lottie-ios/Classes/Private/LOTComposition.m
+++ b/lottie-ios/Classes/Private/LOTComposition.m
@@ -21,6 +21,9 @@
 }
 
 + (nullable instancetype)animationNamed:(nonnull NSString *)animationName inBundle:(nonnull NSBundle *)bundle {
+  if (!animationName) {
+    return nil;
+  }
   NSArray *components = [animationName componentsSeparatedByString:@"."];
   animationName = components.firstObject;
   


### PR DESCRIPTION
Since `animation` [here](https://github.com/airbnb/lottie-ios/blob/master/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h#L41) is marked as nullable, it can be technically nil, which cases a crash in LRU cache.