### PR TITLE
Fix warnings in Xcode 10.2

### DIFF
--- a/lottie-swift/src/Private/Utility/Debugging/LayerDebugging.swift
+++ b/lottie-swift/src/Private/Utility/Debugging/LayerDebugging.swift
@@ -38,7 +38,7 @@ class DebugLayer: CALayer {
 
 public extension CALayer {
   
-  public func logLayerTree(withIndent: Int = 0) {
+  func logLayerTree(withIndent: Int = 0) {
     var string = ""
     for _ in 0...withIndent {
       string = string + "  "

--- a/lottie-swift/src/Private/Utility/Primitives/VectorsExtensions.swift
+++ b/lottie-swift/src/Private/Utility/Primitives/VectorsExtensions.swift
@@ -143,11 +143,11 @@ extension Vector3D: Codable {
 }
 
 public extension Vector3D {
-  public var pointValue: CGPoint {
+  var pointValue: CGPoint {
     return CGPoint(x: x, y: y)
   }
   
-  public var sizeValue: CGSize {
+  var sizeValue: CGSize {
     return CGSize(width: x, height: y)
   }
 }

--- a/lottie-swift/src/Public/Animation/AnimationPublic.swift
+++ b/lottie-swift/src/Public/Animation/AnimationPublic.swift
@@ -81,7 +81,7 @@ public extension Animation {
   }
   
   /// A closure for an Animation download. The closure is passed `nil` if there was an error.
-  public typealias DownloadClosure = (Animation?) -> Void
+  typealias DownloadClosure = (Animation?) -> Void
   
   /**
    Loads a Lottie animation asynchronously from the URL.
@@ -134,7 +134,7 @@ public extension Animation {
    
    Returns the Progress Time for the marker named. Returns nil if no marker found.
    */
-  public func progressTime(forMarker named: String) -> AnimationProgressTime? {
+  func progressTime(forMarker named: String) -> AnimationProgressTime? {
     guard let markers = markerMap, let marker = markers[named] else {
       return nil
     }
@@ -151,7 +151,7 @@ public extension Animation {
    
    Returns the Frame Time for the marker named. Returns nil if no marker found.
    */
-  public func frameTime(forMarker named: String) -> AnimationFrameTime? {
+  func frameTime(forMarker named: String) -> AnimationFrameTime? {
     guard let markers = markerMap, let marker = markers[named] else {
       return nil
     }
@@ -159,37 +159,37 @@ public extension Animation {
   }
   
   /// Converts Frame Time (Seconds * Framerate) into Progress Time (0 to 1).
-  public func progressTime(forFrame frameTime: AnimationFrameTime) -> AnimationProgressTime {
+  func progressTime(forFrame frameTime: AnimationFrameTime) -> AnimationProgressTime {
     return ((frameTime - startFrame) / (endFrame - startFrame)).clamp(0, 1)
   }
   
   /// Converts Progress Time (0 to 1) into Frame Time (Seconds * Framerate)
-  public func frameTime(forProgress progressTime: AnimationProgressTime) -> AnimationFrameTime {
+  func frameTime(forProgress progressTime: AnimationProgressTime) -> AnimationFrameTime {
     return ((endFrame - startFrame) * progressTime) + startFrame
   }
   
   /// Converts Frame Time (Seconds * Framerate) into Time (Seconds)
-  public func time(forFrame frameTime: AnimationFrameTime) -> TimeInterval {
+  func time(forFrame frameTime: AnimationFrameTime) -> TimeInterval {
     return Double(frameTime - startFrame) / framerate
   }
   
   /// Converts Time (Seconds) into Frame Time (Seconds * Framerate)
-  public func frameTime(forTime time: TimeInterval) -> AnimationFrameTime {
+  func frameTime(forTime time: TimeInterval) -> AnimationFrameTime {
     return CGFloat(time * framerate) + startFrame
   }
   
   /// The duration in seconds of the animation.
-  public var duration: TimeInterval {
+  var duration: TimeInterval {
     return Double(endFrame - startFrame) / framerate
   }
   
   /// The natural bounds in points of the animation.
-  public var bounds: CGRect {
+  var bounds: CGRect {
     return CGRect(x: 0, y: 0, width: width, height: height)
   }
   
   /// The natural size in points of the animation.
-  public var size: CGSize {
+  var size: CGSize {
     return CGSize(width: width, height: height)
   }
 }

--- a/lottie-swift/src/Public/Animation/AnimationViewInitializers.swift
+++ b/lottie-swift/src/Public/Animation/AnimationViewInitializers.swift
@@ -19,7 +19,7 @@ public extension AnimationView {
    - Parameter imageProvider: An image provider for the animation's image data.
    If none is supplied Lottie will search in the supplied bundle for images.
    */
-  public convenience init(name: String,
+  convenience init(name: String,
                           bundle: Bundle = Bundle.main,
                           imageProvider: AnimationImageProvider? = nil,
                           animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache) {
@@ -35,7 +35,7 @@ public extension AnimationView {
    - Parameter imageProvider: An image provider for the animation's image data.
    If none is supplied Lottie will search in the supplied filepath for images.
    */
-  public convenience init(filePath: String,
+  convenience init(filePath: String,
                           imageProvider: AnimationImageProvider? = nil,
                           animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache) {
     let animation = Animation.filepath(filePath, animationCache: animationCache)
@@ -51,7 +51,7 @@ public extension AnimationView {
    If none is supplied Lottie will search in the main bundle for images.
    - Parameter closure: A closure to be called when the animation has loaded.
    */
-  public convenience init(url: URL,
+  convenience init(url: URL,
                           imageProvider: AnimationImageProvider? = nil,
                           closure: @escaping AnimationView.DownloadClosure,
                           animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache) {
@@ -74,7 +74,7 @@ public extension AnimationView {
     }
   }
   
-  public typealias DownloadClosure = (Error?) -> Void
+  typealias DownloadClosure = (Error?) -> Void
   
 }
 

--- a/lottie-swift/src/Public/AnimationCache/LRUAnimationCache.swift
+++ b/lottie-swift/src/Public/AnimationCache/LRUAnimationCache.swift
@@ -24,7 +24,7 @@ public class LRUAnimationCache: AnimationCacheProvider {
   }
   
   /// The global shared Cache.
-  static let sharedCache = LRUAnimationCache()
+  public static let sharedCache = LRUAnimationCache()
   
   /// The size of the cache.
   public var cacheSize: Int = 100

--- a/lottie-swift/src/Public/iOS/UIColorExtension.swift
+++ b/lottie-swift/src/Public/iOS/UIColorExtension.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public extension UIColor {
   
-  public var lottieColorValue: Color {
+  var lottieColorValue: Color {
     var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
     getRed(&r, green: &g, blue: &b, alpha: &a)
     return Color(r: Double(r), g: Double(g), b: Double(b), a: Double(a))


### PR DESCRIPTION
This fixes warnings in Xcode 10.2 related to access modifiers

@buba447 @Coeur 