### PR TITLE
Fixes issue in AnimatedSwitch when setting the same state

### DIFF
--- a/lottie-swift/src/Public/iOS/AnimatedSwitch.swift
+++ b/lottie-swift/src/Public/iOS/AnimatedSwitch.swift
@@ -96,6 +96,11 @@ final public class AnimatedSwitch: AnimatedControl {
   // MARK: Animation State
 
   func updateOnState(isOn: Bool, animated: Bool) {
+    // no need to update if the state isn't changing
+    guard isOn != _isOn else {
+      return
+    }
+
     _isOn = isOn
     var startProgress = isOn ? onStartProgress : offStartProgress
     var endProgress = isOn ? onEndProgress : offEndProgress


### PR DESCRIPTION
There is an issue in AnimatedSwitch right now where if you set isOn to the same value multiple times it doesn't seem to update properly. This fixes that issue.

@buba447 