### PR TITLE
Fix for bug that caused animation to not play in certain circumstances

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -693,6 +693,12 @@ final public class AnimationView: LottieView {
     }
   }
   
+  override func animationMovedToWindow() {
+    if let context = self.animationContext {
+      self.addNewAnimationForContext(context)
+    }
+  }
+  
   /// Stops the current in flight animation and freezes the animation in its current state.
   fileprivate func removeCurrentAnimation() {
     guard animationContext != nil else { return }
@@ -729,6 +735,9 @@ final public class AnimationView: LottieView {
     }
     
     self.animationContext = animationContext
+    
+    guard self.window != nil else { return }
+    
     animationID = animationID + 1
     activeAnimationName = AnimationView.animationName + String(animationID)
     

--- a/lottie-swift/src/Public/MacOS/LottieView.swift
+++ b/lottie-swift/src/Public/MacOS/LottieView.swift
@@ -40,6 +40,15 @@ public class LottieView: NSView {
     
   }
   
+  func animationMovedToWindow() {
+    
+  }
+  
+  public override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    animationMovedToWindow()
+  }
+  
   func commonInit() {
     self.wantsLayer = true
   }

--- a/lottie-swift/src/Public/iOS/LottieView.swift
+++ b/lottie-swift/src/Public/iOS/LottieView.swift
@@ -20,6 +20,15 @@ open class LottieView: UIView {
 
   }
   
+  func animationMovedToWindow() {
+    
+  }
+  
+  open override func didMoveToWindow() {
+    super.didMoveToWindow()
+    animationMovedToWindow()
+  }
+  
   var screenScale: CGFloat {
     return UIScreen.main.scale
   }


### PR DESCRIPTION
If `play` was called before the animation had moved to the window, then play would be cancelled. 