### PR TITLE
.index is deprecated in favor of .firstIndex

### DIFF
--- a/lottie-swift/src/Public/AnimationCache/LRUAnimationCache.swift
+++ b/lottie-swift/src/Public/AnimationCache/LRUAnimationCache.swift
@@ -33,7 +33,7 @@ public class LRUAnimationCache: AnimationCacheProvider {
     guard let animation = cacheMap[forKey] else {
       return nil
     }
-    if let index = lruList.index(of: forKey) {
+    if let index = lruList.firstIndex(of: forKey) {
       lruList.remove(at: index)
       lruList.append(forKey)
     }


### PR DESCRIPTION
This change is compatible with Swift 4 and it solves a warning in Xcode 10.2.