### PR TITLE
lottie 3 currently only builds as a Swift 4.2 or 5.0 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lottie for iOS, macOS (and [Android](https://github.com/airbnb/lottie-android) and [React Native](https://github.com/airbnb/lottie-react-native))
 [![Version](https://img.shields.io/cocoapods/v/lottie-ios.svg?style=flat)](https://cocoapods.org/pods/lottie-ios)[![License](https://img.shields.io/cocoapods/l/lottie-ios.svg?style=flat)](https://cocoapods.org/pods/lottie-ios)[![Platform](https://img.shields.io/cocoapods/p/lottie-ios.svg?style=flat)](https://cocoapods.org/pods/lottie-ios)
->  ==**Announcement**==: As of 3.0 Lottie has been completely rewritten in Swift 4.0! For Objective-C support please use Lottie 2.5.3. Read Migration doc [Here](/Documentation/MIGRATING.md)
+>  ==**Announcement**==: As of 3.0 Lottie has been completely rewritten in Swift 4.2! For Objective-C support please use Lottie 2.5.3. Read Migration doc [Here](/Documentation/MIGRATING.md).
 
 Lottie is a mobile library for Android and iOS that natively renders vector based animations and art in realtime with minimal code.
 
@@ -56,7 +56,7 @@ Here is just a small sampling of the power of Lottie
 - [Contributing](#contributing)
 - [Issues or Feature Requests?](#issues-or-feature-requests)
 ## Installing Lottie
-Lottie supports [CocoaPods](https://cocoapods.org/) and  [Carthage](https://github.com/Carthage/Carthage) (Both dynamic and static). Lottie is written in ***Swift 4.0***
+Lottie supports [CocoaPods](https://cocoapods.org/) and [Carthage](https://github.com/Carthage/Carthage) (Both dynamic and static). Lottie is written in ***Swift 4.2***.
 ### Github Repo
 
 You can pull the [Lottie Github Repo](https://github.com/airbnb/lottie-ios/) and include the Lottie.xcodeproj to build a dynamic or static library.


### PR DESCRIPTION
While you can integrate Lottie 3 in an app using Swift 3.2, Swift 4.0, Swift 4.2, Swift 5.0 or even pure Objective-C, the target itself of Lottie 3 requires to be set as Swift 4.2 or Swift 5.0.

If you were to attempt to build Lottie 3 as Swift 4.0, you would get a lot of errors like:
- you'd need to use `kCAMediaTimingFunctionLinear` instead of `CAMediaTimingFunctionName.linear`
- you'd need to use `NSNotification.Name.UIApplicationWillEnterForeground` instead of `UIApplication.willEnterForegroundNotification`
- etc.

We could build a compatibility layer for Swift 4.0, but I don't think it's needed, especially when [Apple enforces Xcode 10.1 as the minimum Xcode version allowed for iOS apps starting March 27](https://developer.apple.com/ios/submit/).