### PR TITLE
Fix macOS & tvOS builds

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		25D5437422307C8B00ED90FA /* CompatibleAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5436E22306E2D00ED90FA /* CompatibleAnimationView.swift */; };
 		25D5437522307C8C00ED90FA /* CompatibleAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5436E22306E2D00ED90FA /* CompatibleAnimationView.swift */; };
 		4866743322249C0600258C00 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866743222249C0600258C00 /* TextCompositionLayer.swift */; };
-		4866743422249C0600258C00 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866743222249C0600258C00 /* TextCompositionLayer.swift */; };
 		4866743522249C0600258C00 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866743222249C0600258C00 /* TextCompositionLayer.swift */; };
 		4866743622249C0600258C00 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866743222249C0600258C00 /* TextCompositionLayer.swift */; };
 		4866743722249C0600258C00 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866743222249C0600258C00 /* TextCompositionLayer.swift */; };
@@ -285,7 +284,6 @@
 		486E88A5220B78F4007CD915 /* PointValueProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486E871E220B78BF007CD915 /* PointValueProvider.swift */; };
 		486E88A6220B78F4007CD915 /* CompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486E8722220B78BF007CD915 /* CompositionLayer.swift */; };
 		486E88A7220B78F4007CD915 /* NullCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486E8723220B78BF007CD915 /* NullCompositionLayer.swift */; };
-		486E88A8220B78F4007CD915 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486E8724220B78BF007CD915 /* TextCompositionLayer.swift */; };
 		486E88A9220B78F4007CD915 /* SolidCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486E8725220B78BF007CD915 /* SolidCompositionLayer.swift */; };
 		486E88AA220B78F4007CD915 /* PreCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486E8726220B78BF007CD915 /* PreCompositionLayer.swift */; };
 		486E88AB220B78F4007CD915 /* ImageCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486E8727220B78BF007CD915 /* ImageCompositionLayer.swift */; };
@@ -1655,7 +1653,6 @@
 				486E881C220B78E4007CD915 /* AnimationPublic.swift in Sources */,
 				486E881D220B78E4007CD915 /* AnimationImageProvider.swift in Sources */,
 				486E881E220B78E4007CD915 /* FilepathImageProvider.swift in Sources */,
-				4866743422249C0600258C00 /* TextCompositionLayer.swift in Sources */,
 				486E881F220B78E4007CD915 /* AnimatedSwitch.swift in Sources */,
 				486E8820220B78E4007CD915 /* BundleImageProvider.swift in Sources */,
 				486E8821220B78E4007CD915 /* UIColorExtension.swift in Sources */,
@@ -1795,7 +1792,6 @@
 				486E88A5220B78F4007CD915 /* PointValueProvider.swift in Sources */,
 				486E88A6220B78F4007CD915 /* CompositionLayer.swift in Sources */,
 				486E88A7220B78F4007CD915 /* NullCompositionLayer.swift in Sources */,
-				486E88A8220B78F4007CD915 /* TextCompositionLayer.swift in Sources */,
 				486E88A9220B78F4007CD915 /* SolidCompositionLayer.swift in Sources */,
 				486E88AA220B78F4007CD915 /* PreCompositionLayer.swift in Sources */,
 				486E88AB220B78F4007CD915 /* ImageCompositionLayer.swift in Sources */,

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -2291,9 +2291,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = VM8ZLJG6JZ;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2307,6 +2307,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.airbnb.Lottie-iOS";
 				PRODUCT_NAME = Lottie;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2317,9 +2318,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = VM8ZLJG6JZ;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2333,6 +2334,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.airbnb.Lottie-iOS";
 				PRODUCT_NAME = Lottie;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2343,9 +2345,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = VM8ZLJG6JZ;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2358,6 +2360,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.airbnb.Lottie-tvOS";
 				PRODUCT_NAME = Lottie;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;
@@ -2370,9 +2373,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = VM8ZLJG6JZ;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2385,6 +2388,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.airbnb.Lottie-tvOS";
 				PRODUCT_NAME = Lottie;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;
@@ -2396,11 +2400,11 @@
 		486E856D220A3606007CD915 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = VM8ZLJG6JZ;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2415,6 +2419,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.airbnb.Lottie-macOS";
 				PRODUCT_NAME = Lottie;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;
@@ -2424,11 +2429,11 @@
 		486E856E220A3606007CD915 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = VM8ZLJG6JZ;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2443,6 +2448,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.airbnb.Lottie-macOS";
 				PRODUCT_NAME = Lottie;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;


### PR DESCRIPTION
Hi.

Found and fixed some build issues:

1. Removed codesigning
2. `TextCompositionLayer.swift` was duplicated in compile sources twice in tvOS and macOS targets