### PR TITLE
Add basic SwiftPM manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Lottie",
+    // platforms: [.iOS("9.0"), .macOS("10.10"), tvOS("9.0"), .watchOS("2.0")],
+    products: [
+        .library(name: "Lottie", targets: ["Lottie"])
+    ],
+    targets: [
+        .target(
+            name: "Lottie",
+            path: "lottie-swift/src"
+        )
+    ]
+)


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.