### PR TITLE
Fix duplicate reference to TextCompositionLayer.swift in project

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -13,10 +13,8 @@
 		25D5437322307C8800ED90FA /* CompatibleAnimationKeypath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D543702230787900ED90FA /* CompatibleAnimationKeypath.swift */; };
 		25D5437422307C8B00ED90FA /* CompatibleAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5436E22306E2D00ED90FA /* CompatibleAnimationView.swift */; };
 		25D5437522307C8C00ED90FA /* CompatibleAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5436E22306E2D00ED90FA /* CompatibleAnimationView.swift */; };
-		4866743322249C0600258C00 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866743222249C0600258C00 /* TextCompositionLayer.swift */; };
-		4866743522249C0600258C00 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866743222249C0600258C00 /* TextCompositionLayer.swift */; };
-		4866743622249C0600258C00 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866743222249C0600258C00 /* TextCompositionLayer.swift */; };
-		4866743722249C0600258C00 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866743222249C0600258C00 /* TextCompositionLayer.swift */; };
+		37A137F42265AF5B00E371E5 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486E8724220B78BF007CD915 /* TextCompositionLayer.swift */; };
+		37A137F52265AF5C00E371E5 /* TextCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486E8724220B78BF007CD915 /* TextCompositionLayer.swift */; };
 		4866744122249C4E00258C00 /* TextAnimatorNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866744022249C4E00258C00 /* TextAnimatorNode.swift */; };
 		4866744222249C4E00258C00 /* TextAnimatorNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866744022249C4E00258C00 /* TextAnimatorNode.swift */; };
 		4866744322249C4E00258C00 /* TextAnimatorNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4866744022249C4E00258C00 /* TextAnimatorNode.swift */; };
@@ -634,7 +632,6 @@
 /* Begin PBXFileReference section */
 		25D5436E22306E2D00ED90FA /* CompatibleAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibleAnimationView.swift; sourceTree = "<group>"; };
 		25D543702230787900ED90FA /* CompatibleAnimationKeypath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibleAnimationKeypath.swift; sourceTree = "<group>"; };
-		4866743222249C0600258C00 /* TextCompositionLayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextCompositionLayer.swift; sourceTree = "<group>"; };
 		4866744022249C4E00258C00 /* TextAnimatorNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextAnimatorNode.swift; sourceTree = "<group>"; };
 		486E8395220A3038007CD915 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		486E83B2220A317C007CD915 /* Lottie.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Lottie.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -995,7 +992,6 @@
 				486E8727220B78BF007CD915 /* ImageCompositionLayer.swift */,
 				486E8728220B78BF007CD915 /* ShapeCompositionLayer.swift */,
 				486E8729220B78BF007CD915 /* MaskContainerLayer.swift */,
-				4866743222249C0600258C00 /* TextCompositionLayer.swift */,
 			);
 			path = CompLayers;
 			sourceTree = "<group>";
@@ -1522,7 +1518,6 @@
 				486E87A3220B78D1007CD915 /* AnimationPublic.swift in Sources */,
 				486E87A4220B78D1007CD915 /* AnimationImageProvider.swift in Sources */,
 				486E87A5220B78D1007CD915 /* FilepathImageProvider.swift in Sources */,
-				4866743322249C0600258C00 /* TextCompositionLayer.swift in Sources */,
 				486E87A6220B78D1007CD915 /* AnimatedSwitch.swift in Sources */,
 				486E87A7220B78D1007CD915 /* BundleImageProvider.swift in Sources */,
 				486E87A8220B78D1007CD915 /* UIColorExtension.swift in Sources */,
@@ -1589,6 +1584,7 @@
 				486E87E4220B78D1007CD915 /* RenderNode.swift in Sources */,
 				486E87E5220B78D1007CD915 /* AnimatorNode.swift in Sources */,
 				25D543712230787900ED90FA /* CompatibleAnimationKeypath.swift in Sources */,
+				37A137F52265AF5C00E371E5 /* TextCompositionLayer.swift in Sources */,
 				486E87E6220B78D1007CD915 /* Ellipse.swift in Sources */,
 				486E87E7220B78D1007CD915 /* Trim.swift in Sources */,
 				486E87E8220B78D1007CD915 /* ShapeItem.swift in Sources */,
@@ -1875,8 +1871,8 @@
 				486E88F9220B78F4007CD915 /* AnimatorNodeDebugging.swift in Sources */,
 				486E88FA220B78F4007CD915 /* CGFloatExtensions.swift in Sources */,
 				486E88FB220B78F4007CD915 /* AnimationKeypathExtension.swift in Sources */,
-				4866743522249C0600258C00 /* TextCompositionLayer.swift in Sources */,
 				486E88FC220B78F4007CD915 /* MathKit.swift in Sources */,
+				37A137F42265AF5B00E371E5 /* TextCompositionLayer.swift in Sources */,
 				486E88FD220B78F4007CD915 /* StringExtensions.swift in Sources */,
 				486E88FE220B78F4007CD915 /* BezierPath.swift in Sources */,
 				486E88FF220B78F4007CD915 /* CompoundBezierPath.swift in Sources */,
@@ -1909,7 +1905,6 @@
 				486E890A220B78FF007CD915 /* AnimationPublic.swift in Sources */,
 				486E890B220B78FF007CD915 /* AnimationImageProvider.swift in Sources */,
 				486E890C220B78FF007CD915 /* FilepathImageProvider.swift in Sources */,
-				4866743622249C0600258C00 /* TextCompositionLayer.swift in Sources */,
 				486E890D220B78FF007CD915 /* AnimatedSwitch.swift in Sources */,
 				486E890E220B78FF007CD915 /* BundleImageProvider.swift in Sources */,
 				486E890F220B78FF007CD915 /* UIColorExtension.swift in Sources */,
@@ -2133,7 +2128,6 @@
 				486E89E7220B790E007CD915 /* AnimatorNodeDebugging.swift in Sources */,
 				486E89E8220B790E007CD915 /* CGFloatExtensions.swift in Sources */,
 				486E89E9220B790E007CD915 /* AnimationKeypathExtension.swift in Sources */,
-				4866743722249C0600258C00 /* TextCompositionLayer.swift in Sources */,
 				486E89EA220B790E007CD915 /* MathKit.swift in Sources */,
 				486E89EB220B790E007CD915 /* StringExtensions.swift in Sources */,
 				486E89EC220B790E007CD915 /* BezierPath.swift in Sources */,


### PR DESCRIPTION
TextCompositionLayer.swift was included twice in the project, for overlapping targets.