### PR TITLE
Switch covers known cases, but 'UIView.ContentMode' may have additional unknown values

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -608,6 +608,9 @@ final public class AnimationView: LottieView {
       position.x = bounds.maxX - animation.bounds.midX
       position.y = bounds.maxY - animation.bounds.midY
       xform = CATransform3DIdentity
+    @unknown default:
+      print("unsupported contentMode: \(contentMode.rawValue); please update lottie-ios")
+      xform = CATransform3DIdentity
     }
     animationLayer.position = position
     animationLayer.transform = xform


### PR DESCRIPTION
Xcode warning:
>Switch covers known cases, but 'UIView.ContentMode' may have additional unknown values, possibly added in future versions

Two possible behaviors to choose from:
- [ ] we `fatalError("unsupported contentMode; please update lottie-ios")`
- [x] we fallback nicely by doing nothing for this unknown contentMode, and we just print out that an update is needed.
