### PR TITLE
Added performance update for layer visibility

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/CompLayers/CompositionLayer.swift
+++ b/lottie-swift/src/Private/LayerContainers/CompLayers/CompositionLayer.swift
@@ -108,10 +108,13 @@ class CompositionLayer: CALayer, KeypathSearchable {
   
   final func displayWithFrame(frame: CGFloat, forceUpdates: Bool) {
     transformNode.updateTree(frame, forceUpdates: forceUpdates)
-    displayContentsWithFrame(frame: frame, forceUpdates: forceUpdates)
-    maskLayer?.updateWithFrame(frame: frame, forceUpdates: forceUpdates)
-    contentsLayer.transform = transformNode.globalTransform
     let layerVisible = frame.isInRangeOrEqual(inFrame, outFrame)
+    /// Only update contents if current time is within the layers time bounds.
+    if layerVisible {
+      displayContentsWithFrame(frame: frame, forceUpdates: forceUpdates)
+      maskLayer?.updateWithFrame(frame: frame, forceUpdates: forceUpdates)
+    }
+    contentsLayer.transform = transformNode.globalTransform
     contentsLayer.opacity = transformNode.opacity
     contentsLayer.isHidden = !layerVisible
     layerDelegate?.frameUpdated(frame: frame)

--- a/lottie-swift/src/Private/LayerContainers/Utility/CompositionLayersInitializer.swift
+++ b/lottie-swift/src/Private/LayerContainers/Utility/CompositionLayersInitializer.swift
@@ -18,7 +18,11 @@ extension Array where Element == LayerModel {
     var childLayers = [LayerModel]()
     
     for layer in self {
-      if let shapeLayer = layer as? ShapeLayerModel {
+      if layer.hidden == true {
+        let genericLayer = NullCompositionLayer(layer: layer)
+        compositionLayers.append(genericLayer)
+        layerMap[layer.index] = genericLayer
+      } else if let shapeLayer = layer as? ShapeLayerModel {
         let shapeContainer = ShapeCompositionLayer(shapeLayer: shapeLayer)
         compositionLayers.append(shapeContainer)
         layerMap[layer.index] = shapeContainer

--- a/lottie-swift/src/Private/Model/Layers/LayerModel.swift
+++ b/lottie-swift/src/Private/Model/Layers/LayerModel.swift
@@ -107,6 +107,8 @@ class LayerModel: Codable {
   /// The type of matte if any.
   let matte: MatteType?
   
+  let hidden: Bool
+  
   private enum CodingKeys : String, CodingKey {
     case name = "nm"
     case index = "ind"
@@ -121,6 +123,7 @@ class LayerModel: Codable {
     case masks = "masksProperties"
     case timeStretch = "sr"
     case matte = "tt"
+    case hidden = "hd"
   }
   
   required init(from decoder: Decoder) throws {
@@ -138,5 +141,6 @@ class LayerModel: Codable {
     self.masks = try container.decodeIfPresent([Mask].self, forKey: .masks)
     self.timeStretch = try container.decodeIfPresent(Double.self, forKey: .timeStretch) ?? 1
     self.matte = try container.decodeIfPresent(MatteType.self, forKey: .matte)
+    self.hidden = try container.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
   }
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/ShapeItem.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/ShapeItem.swift
@@ -72,15 +72,19 @@ class ShapeItem: Codable {
   /// The type of shape
   let type: ShapeType
   
+  let hidden: Bool
+  
   private enum CodingKeys : String, CodingKey {
     case name = "nm"
     case type = "ty"
+    case hidden = "hd"
   }
   
   required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: ShapeItem.CodingKeys.self)
     self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? "Layer"
     self.type = try container.decode(ShapeType.self, forKey: .type)
+    self.hidden = try container.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
   }
 
 }

--- a/lottie-swift/src/Private/NodeRenderSystem/Extensions/ItemsExtension.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/Extensions/ItemsExtension.swift
@@ -21,6 +21,7 @@ extension Array where Element == ShapeItem {
     var nodeTree = NodeTree()
 
     for item in self {
+      guard item.hidden == false else { continue }
       if let fill = item as? Fill {
         let node = FillNode(parentNode: nodeTree.rootNode, fill: fill)
         nodeTree.rootNode = node


### PR DESCRIPTION
This stops the render tree from evaluating hidden nodes and layers during animation runtime. Additionally hidden layers will not allocate their shape nodes, since a layer cannot be turned from hidden to visible.
This should increase performance.

Related to https://github.com/airbnb/lottie-ios/issues/871