### PR TITLE
macOS. Fix `'LottieContentMode' has no member 'rawValue'` compile error

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -608,9 +608,12 @@ final public class AnimationView: LottieView {
       position.x = bounds.maxX - animation.bounds.midX
       position.y = bounds.maxY - animation.bounds.midY
       xform = CATransform3DIdentity
+      
+      #if os(iOS) || os(tvOS)
     @unknown default:
       print("unsupported contentMode: \(contentMode.rawValue); please update lottie-ios")
       xform = CATransform3DIdentity
+      #endif
     }
     animationLayer.position = position
     animationLayer.transform = xform


### PR DESCRIPTION
Hi.

#868 brought compile error to macOS target, cause `LottieContentMode` is not `RawRepresentable`.
Error: `Value of type 'LottieContentMode' has no member 'rawValue'`. https://github.com/airbnb/lottie-ios/blob/84009f19580f9ad770a3b706e1ddfefc8a7a87e6/lottie-swift/src/Public/Animation/AnimationView.swift#L612

There is no need in `@unknown default`  check of `LottieContentMode` on macOS target.