### PR TITLE
Support Require Only App-Extension-Safe API

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -2286,6 +2286,7 @@
 		486E83B8220A317C007CD915 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -2313,6 +2314,7 @@
 		486E83B9220A317C007CD915 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -2340,6 +2342,7 @@
 		486E84E8220A357D007CD915 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -2368,6 +2371,7 @@
 		486E84E9220A357D007CD915 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -2396,6 +2400,7 @@
 		486E856D220A3606007CD915 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -2425,6 +2430,7 @@
 		486E856E220A3606007CD915 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;


### PR DESCRIPTION
## Support Require Only App-Extension-Safe API

Hi 😄 .

I found a warning while developing my today extension app.
This warning only occurs when using Carthage. (cocoapods is fine.)
> warning: Linking against a dylib which is not safe for use in application extensions: /Carthage/Build/iOS/Lottie.framework/Lottie

I set `iOS` `macOS` `tvOS` targets `Require Only App-Extension-Safe API` build setting to Yes and then the build succeeded.
(`macOS` build succeeded with #880)

For more information, please refer to [Apple document](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW1)
> To configure an app extension target to use an embedded framework, set the target’s "Require Only App-Extension-Safe API" build setting to Yes. If you don’t, Xcode reminds you to do so by displaying the warning "linking against dylib not safe for use in application extensions".
