### PR TITLE
Bump to 3.0.6

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - lottie-ios (3.0.5)
+  - lottie-ios (3.0.6)
 
 DEPENDENCIES:
   - lottie-ios (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  lottie-ios: 364ab2a5168e95ca4f0775b967fded860428ea04
+  lottie-ios: 4870ccbaca9c76caaca29f7b27edfde7b531bc48
 
 PODFILE CHECKSUM: d7d1d3df3df6c9862ab67dbbfb2f695895dc9d7b
 

--- a/Example/Pods/Local Podspecs/lottie-ios.podspec.json
+++ b/Example/Pods/Local Podspecs/lottie-ios.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-ios",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "summary": "A library to render native animations from bodymovin json. Now in Swift!",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!\n\nFor the first time, designers can create and ship beautiful animations without an engineer painstakingly recreating it be hand. Since the animation is backed by JSON they are extremely small in size but can be large in complexity! Animations can be played, resized, looped, sped up, slowed down, and even interactively scrubbed.",
   "homepage": "https://github.com/airbnb/lottie-ios",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/airbnb/lottie-ios.git",
-    "tag": "3.0.5"
+    "tag": "3.0.6"
   },
   "swift_version": "4.2",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - lottie-ios (3.0.5)
+  - lottie-ios (3.0.6)
 
 DEPENDENCIES:
   - lottie-ios (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  lottie-ios: 364ab2a5168e95ca4f0775b967fded860428ea04
+  lottie-ios: 4870ccbaca9c76caaca29f7b27edfde7b531bc48
 
 PODFILE CHECKSUM: d7d1d3df3df6c9862ab67dbbfb2f695895dc9d7b
 

--- a/Example/Pods/Target Support Files/lottie-ios-iOS/Info.plist
+++ b/Example/Pods/Target Support Files/lottie-ios-iOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.0.5</string>
+  <string>3.0.6</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/lottie-ios-macOS/Info.plist
+++ b/Example/Pods/Target Support Files/lottie-ios-macOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.0.5</string>
+  <string>3.0.6</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/lottie-ios-tvOS/Info.plist
+++ b/Example/Pods/Target Support Files/lottie-ios-tvOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.0.5</string>
+  <string>3.0.6</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -8,31 +8,31 @@
 
 Pod::Spec.new do |s|
   s.name             = 'lottie-ios'
-  s.version          = '3.0.5'
+  s.version          = '3.0.6'
   s.summary          = 'A library to render native animations from bodymovin json. Now in Swift!'
 
-s.description      = <<-DESC
+  s.description = <<-DESC
 Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!
 
 For the first time, designers can create and ship beautiful animations without an engineer painstakingly recreating it be hand. Since the animation is backed by JSON they are extremely small in size but can be large in complexity! Animations can be played, resized, looped, sped up, slowed down, and even interactively scrubbed.
-DESC
+  DESC
 
   s.homepage         = 'https://github.com/airbnb/lottie-ios'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.author           = { 'Brandon Withrow' => 'buba447@gmail.com' }
   s.source           = { :git => 'https://github.com/airbnb/lottie-ios.git', :tag => s.version.to_s }
-  
+
   s.swift_version = '4.2'
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
-  
+
   s.source_files = 'lottie-swift/src/**/*'
-  s.ios.source_files   = 'lottie-swift/iOS/*.swift'
-  s.ios.exclude_files   = 'lottie-swift/src/Public/MacOS/**/*'
-  s.tvos.exclude_files   = 'lottie-swift/src/Public/MacOS/**/*'
+  s.ios.source_files = 'lottie-swift/iOS/*.swift'
+  s.ios.exclude_files = 'lottie-swift/src/Public/MacOS/**/*'
+  s.tvos.exclude_files = 'lottie-swift/src/Public/MacOS/**/*'
   s.osx.exclude_files = 'lottie-swift/src/Public/iOS/**/*'
-  
+
   s.ios.frameworks = ['UIKit', 'CoreGraphics', 'QuartzCore']
   s.tvos.frameworks = ['UIKit', 'CoreGraphics', 'QuartzCore']
   s.osx.frameworks = ['AppKit', 'CoreGraphics', 'QuartzCore']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-ios",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This bumps Lottie to 3.0.6 and also reformats the podspec file using a Ruby linter. Let me know I should revert that change

@buba447 @Coeur 