### PR TITLE
Initialize compatibleAnimation property within init

### DIFF
--- a/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -42,6 +42,7 @@ public final class CompatibleAnimationView: UIView {
   @objc
   init(compatibleAnimation: CompatibleAnimation) {
     animationView = AnimationView(animation: compatibleAnimation.animation)
+    self.compatibleAnimation = compatibleAnimation
     super.init(frame: .zero)
     commonInit()
   }


### PR DESCRIPTION
After init method `compatibleAnimation` is `nil`, but `animationView.animation` is not `nil`.