### PR TITLE
Fix bug with background behavior / didMoveToWindow

### DIFF
--- a/lottie-swift/src/Private/Utility/Helpers/AnimationContext.swift
+++ b/lottie-swift/src/Private/Utility/Helpers/AnimationContext.swift
@@ -28,6 +28,12 @@ struct AnimationContext {
 
 }
 
+enum AnimationContextState {
+  case playing
+  case cancelled
+  case complete
+}
+
 class AnimationCompletionDelegate: NSObject, CAAnimationDelegate {
   
   init(completionBlock: LottieCompletionBlock?) {
@@ -38,10 +44,13 @@ class AnimationCompletionDelegate: NSObject, CAAnimationDelegate {
   var animationLayer: AnimationContainer?
   var animationKey: String?
   var ignoreDelegate: Bool = false
+  var animationState: AnimationContextState = .playing
+  
   let completionBlock: LottieCompletionBlock?
   
   public func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
     guard ignoreDelegate == false else { return }
+    animationState = flag ? .complete : .cancelled
     if let animationLayer = animationLayer, let key = animationKey {
       animationLayer.removeAnimation(forKey: key)
       if flag {


### PR DESCRIPTION
This fixes some bugs with playing and background behavior.

The backgroundBehavior was only being set/reset when the application moved from foreground to background. This adds support for the animation moving in and out of window as well. Additionally there were some bugs that would cause long dead animations to be re-added when the animation came in and out of view. 

https://github.com/airbnb/lottie-ios/issues/912 and https://github.com/airbnb/lottie-ios/issues/907