### PR TITLE
Nil out completion block once animation finishes

### DIFF
--- a/lottie-swift/src/Private/Utility/Helpers/AnimationContext.swift
+++ b/lottie-swift/src/Private/Utility/Helpers/AnimationContext.swift
@@ -46,7 +46,7 @@ class AnimationCompletionDelegate: NSObject, CAAnimationDelegate {
   var ignoreDelegate: Bool = false
   var animationState: AnimationContextState = .playing
   
-  let completionBlock: LottieCompletionBlock?
+  var completionBlock: LottieCompletionBlock?
   
   public func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
     guard ignoreDelegate == false else { return }
@@ -57,9 +57,8 @@ class AnimationCompletionDelegate: NSObject, CAAnimationDelegate {
         animationLayer.currentFrame = (anim as! CABasicAnimation).toValue as! CGFloat
       }
     }
-    if let completionBlock = completionBlock {
-      completionBlock(flag)
-    }
+    completionBlock?(flag)
+    completionBlock = nil
   }
   
 }


### PR DESCRIPTION
We were having issues where this completion block was being called multiple times. My assumption is that it should be getting niled out after it's called once, but let me know if I'm mistaken.