### PR TITLE
Resolve stop() not rewinding animation visually

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -734,7 +734,9 @@ final public class AnimationView: LottieView {
     CATransaction.setDisableActions(true)
     animationLayer?.currentFrame = newFrame
     CATransaction.commit()
-    animationLayer?.forceDisplayUpdate()
+    CATransaction.setCompletionBlock {
+        self.animationLayer?.forceDisplayUpdate()
+    }
   }
   
   @objc override func animationWillMoveToBackground() {


### PR DESCRIPTION
Trying to resolve #970

`forceDisplayUpdate` is called too soon
the `CATransaction` has not finished doing the transaction yet (just committed and not done yet) therefore the `forceDisplayUpdate()` called too soon, so I propose to force display on the completion block of the CATransaction
This results when we're trying to draw, `CALyer.presentation()` still holds old value of `currentFrame`