### PR TITLE
Fix alpha mask image rendering for gradients

### DIFF
--- a/lottie-swift/src/Private/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
@@ -43,7 +43,7 @@ class GradientFillRenderer: PassThroughOutputNode, Renderable {
       if alpha < 1 {
         drawMask = true
       }
-      if let color = CGColor(colorSpace: maskColorSpace, components: [1.0 - alpha, 1]) {
+      if let color = CGColor(colorSpace: maskColorSpace, components: [alpha, 1]) {
         alphaLocations.append(colors[i])
         alphaColors.append(color)
       }
@@ -64,7 +64,8 @@ class GradientFillRenderer: PassThroughOutputNode, Renderable {
                                     bytesPerRow: inContext.width,
                                     space: maskColorSpace,
                                     bitmapInfo: 0) else { return }
-      
+      let flipVertical = CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: CGFloat(maskContext.height))
+      maskContext.concatenate(flipVertical)
       maskContext.concatenate(inContext.ctm)
       if type == .linear {
         maskContext.drawLinearGradient(maskGradient, start: start, end: end, options: [.drawsAfterEndLocation, .drawsBeforeStartLocation])

--- a/lottie-swift/src/Private/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
@@ -43,7 +43,7 @@ class GradientFillRenderer: PassThroughOutputNode, Renderable {
       if alpha < 1 {
         drawMask = true
       }
-      if let color = CGColor(colorSpace: maskColorSpace, components: [alpha, 1]) {
+      if let color = CGColor(colorSpace: maskColorSpace, components: [1.0 - alpha, 1]) {
         alphaLocations.append(colors[i])
         alphaColors.append(color)
       }


### PR DESCRIPTION
The mask image colors on iOS and macOS (probably tvOS also, but I can't check that) should be inverted, so for alpha == 1 the actual color to draw should be black. This fix resolves #884