### PR TITLE
Fix alpha mask image rendering for gradients

### DIFF
--- a/lottie-swift/src/Private/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
@@ -64,7 +64,8 @@ class GradientFillRenderer: PassThroughOutputNode, Renderable {
                                     bytesPerRow: inContext.width,
                                     space: maskColorSpace,
                                     bitmapInfo: 0) else { return }
-      
+      let flipVertical = CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: CGFloat(maskContext.height))
+      maskContext.concatenate(flipVertical)
       maskContext.concatenate(inContext.ctm)
       if type == .linear {
         maskContext.drawLinearGradient(maskGradient, start: start, end: end, options: [.drawsAfterEndLocation, .drawsBeforeStartLocation])


### PR DESCRIPTION
From what I tested, the mask image is rendered vertically flipped. In previous attempt I had a symmetrical gradient, that's why inverting colors worked, but the real issue is not with colors of rendered mask image, but with that flipped coordinates.