### PR TITLE
public font list and fonts

### DIFF
--- a/lottie-swift/src/Private/Model/Animation.swift
+++ b/lottie-swift/src/Private/Model/Animation.swift
@@ -48,7 +48,7 @@ public class Animation: Codable {
   let glyphs: [Glyph]?
   
   /// The list of fonts used for text rendering
-  let fonts: FontList?
+  public let fonts: FontList?
   
   /// Asset Library
   let assetLibrary: AssetLibrary?

--- a/lottie-swift/src/Private/Model/Text/Font.swift
+++ b/lottie-swift/src/Private/Model/Text/Font.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class Font: Codable {
+public class Font: Codable {
   
   let name: String
   let familyName: String
@@ -24,9 +24,9 @@ class Font: Codable {
 }
 
 /// A list of fonts
-class FontList: Codable {
+public class FontList: Codable {
   
-  let fonts: [Font]
+  public let fonts: [Font]
   
   enum CodingKeys : String, CodingKey {
     case fonts = "list"


### PR DESCRIPTION
- making fonts public allows for much better debugging as well as font injection at run time allowing for the font to be changed between animation runs assuming the animation view is re-inited