### PR TITLE
fix issue in CompoundBezierPath

### DIFF
--- a/lottie-swift/src/Private/Utility/Primitives/CompoundBezierPath.swift
+++ b/lottie-swift/src/Private/Utility/Primitives/CompoundBezierPath.swift
@@ -131,10 +131,11 @@ struct CompoundBezierPath {
         /// Full Path is inside of trim. Add full path.
         compoundPath = compoundPath.addPath(path: path)
       } else {
-        let trimPath = path.trim(fromLength: trim.start > pathStartPosition ? (trim.start - pathStartPosition) : 0,
+        if let trimPath = path.trim(fromLength: trim.start > pathStartPosition ? (trim.start - pathStartPosition) : 0,
                                  toLength: trim.end < pathEndPosition ? (trim.end - pathStartPosition) : path.length,
-                                 offsetLength: 0)[0]
-        compoundPath = compoundPath.addPath(path: trimPath)
+                                 offsetLength: 0).first {
+            compoundPath = compoundPath.addPath(path: trimPath)
+        }
       }
 
       


### PR DESCRIPTION
The changed code follows defensive programming, and does not change the behaviour of the original code in any way - I hope you will accept this change 😄 

After upgrading from Lottie 2 to Lottie 3, our testers reported crashes that were hard to reproduce. Luckily I managed to get it to crash in the debugger, and found out that this was the cause.