### PR TITLE
Update accessibility label in every case

### DIFF
--- a/lottie-swift/src/Public/iOS/AnimatedSwitch.swift
+++ b/lottie-swift/src/Public/iOS/AnimatedSwitch.swift
@@ -133,6 +133,8 @@ final public class AnimatedSwitch: AnimatedControl {
         endProgress = previousStateStart
       }
     }
+
+    updateAccessibilityLabel()
     
     guard animated == true else {
       animationView.currentProgress = finalProgress
@@ -148,8 +150,6 @@ final public class AnimatedSwitch: AnimatedControl {
         self.animationView.currentProgress = finalProgress
       }
     }
-
-    updateAccessibilityLabel()
   }
   
   public override func endTracking(_ touch: UITouch?, with event: UIEvent?) {


### PR DESCRIPTION
Hello.

I did run today in a situation in which the `AnimatedSwitch` did not have the accessibility value set.

After looking into the code I saw that the value is only updated if the state is changed with an animation. So this does not happen in all cases (e.g. after initialization).

This PR moves the call of the `updateAccessibilityLabel()` method before the `guard` statement.