### PR TITLE
Fix animation completion when app moves to background

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -764,13 +764,16 @@ final public class AnimationView: LottieView {
       case .pause:
         removeCurrentAnimation()
       case .pauseAndRestore:
-        currentContext.closure.ignoreDelegate = true
+        currentContext.closure.ignoreDelegate = !waitingToPlayAimation
         removeCurrentAnimation()
         /// Keep the stale context around for when the app enters the foreground.
         self.animationContext = currentContext
       case .forceFinish:
         removeCurrentAnimation()
         updateAnimationFrame(currentContext.playTo)
+      }
+      if waitingToPlayAimation, backgroundBehavior != .pauseAndRestore {
+        currentContext.closure.completionBlock?(true)
       }
     }
   }


### PR DESCRIPTION
**Issue:**

While the animation view is waiting to play animation and app moves to background and the comes to foreground... play completion block were not getting called.

**Fix**

These are the scenario when Animationview is waiting to play animation and app moves to background  --> foreground

- for `backgroundBehavior == .pauseAndRestore`: call the completion block after restoring the context and playing animation
- for other state call completion immediately