### PR TITLE
Update Package.swift base platform to match podspec

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Lottie",
-    platforms: [.iOS(.v12)],
-    // platforms: [.iOS("9.0"), .macOS("10.10"), tvOS("9.0"), .watchOS("2.0")],
+    platforms: [.iOS(.v9), /*.macOS(.v10_10), */.tvOS(.v9), .watchOS(.v2)],
     products: [
         .library(name: "Lottie", targets: ["Lottie"])
     ],


### PR DESCRIPTION
Take back the support to iOS 9.0, tvOS 9.0, and watchOS 2.0. For adding support to build macOS requires some structural changes in the files so commented it out for not.