### PR TITLE
Add method to CompatibleAnimationView to change color values

### DIFF
--- a/lottie-swift/src/Private/Utility/Primitives/ColorExtension.swift
+++ b/lottie-swift/src/Private/Utility/Primitives/ColorExtension.swift
@@ -69,13 +69,13 @@ extension Color {
   }
   
   var cgColorValue: CGColor {
-    var colorspace : CGColorSpace?
-
+    let colorspace : CGColorSpace
     if #available(iOS 9.3, *) {
-        // Always use P3 colorspace for now
-        colorspace = CGColorSpace.init(name: CGColorSpace.displayP3)
+      // Always use P3 colorspace for now
+      colorspace = CGColorSpace.init(name: CGColorSpace.displayP3) ?? CGColorSpaceCreateDeviceRGB()
+    } else {
+      colorspace = CGColorSpaceCreateDeviceRGB()
     }
-
-    return CGColor(colorSpace: colorspace ?? CGColorSpaceCreateDeviceRGB(), components: [CGFloat(r), CGFloat(g), CGFloat(b), CGFloat(a)]) ?? Color.clearColor
+    return CGColor(colorSpace: colorspace, components: [CGFloat(r), CGFloat(g), CGFloat(b), CGFloat(a)]) ?? Color.clearColor
   }
 }

--- a/lottie-swift/src/Private/Utility/Primitives/ColorExtension.swift
+++ b/lottie-swift/src/Private/Utility/Primitives/ColorExtension.swift
@@ -69,6 +69,13 @@ extension Color {
   }
   
   var cgColorValue: CGColor {
-    return CGColor(colorSpace: CGColorSpaceCreateDeviceRGB(), components: [CGFloat(r), CGFloat(g), CGFloat(b), CGFloat(a)]) ?? Color.clearColor
+    var colorspace : CGColorSpace?
+
+    if #available(iOS 9.3, *) {
+        // Always use P3 colorspace for now
+        colorspace = CGColorSpace.init(name: CGColorSpace.displayP3)
+    }
+
+    return CGColor(colorSpace: colorspace ?? CGColorSpaceCreateDeviceRGB(), components: [CGFloat(r), CGFloat(g), CGFloat(b), CGFloat(a)]) ?? Color.clearColor
   }
 }

--- a/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -217,14 +217,16 @@ public final class CompatibleAnimationView: UIView {
     var blue: CGFloat = 0
     var alpha: CGFloat = 0
 
-    var colorspace : CGColorSpace?
+    var colorspace : CGColorSpace
 
     if #available(iOS 9.3, *) {
-        // Always use P3 colorspace for now
-        colorspace = CGColorSpace.init(name: CGColorSpace.displayP3)
+      // Always use P3 colorspace for now
+      colorspace = CGColorSpace.init(name: CGColorSpace.displayP3) ?? CGColorSpaceCreateDeviceRGB()
+    } else {
+      colorspace = CGColorSpaceCreateDeviceRGB()
     }
 
-    let convertedColor = color.cgColor.converted(to: colorspace ?? CGColorSpaceCreateDeviceRGB(), intent: .defaultIntent, options: nil)
+    let convertedColor = color.cgColor.converted(to: colorspace, intent: .defaultIntent, options: nil)
 
     if let components = convertedColor?.components, components.count == 4 {
       red = components[0]

--- a/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -210,6 +210,19 @@ public final class CompatibleAnimationView: UIView {
   }
 
   @objc
+  public func setColorValue(_ color: UIColor, forKeypath keypath: CompatibleAnimationKeypath)
+  {
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+    let valueProvider = ColorValueProvider(Color(r: Double(red), g: Double(green), b: Double(blue), a: Double(alpha)))
+    animationView.setValueProvider(valueProvider, keypath: keypath.animationKeypath)
+  }
+
+  @objc
   public func addSubview(
     _ subview: AnimationSubview,
     forLayerAt keypath: CompatibleAnimationKeypath)

--- a/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -216,7 +216,24 @@ public final class CompatibleAnimationView: UIView {
     var green: CGFloat = 0
     var blue: CGFloat = 0
     var alpha: CGFloat = 0
-    color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+    var colorspace : CGColorSpace?
+
+    if #available(iOS 9.3, *) {
+        // Always use P3 colorspace for now
+        colorspace = CGColorSpace.init(name: CGColorSpace.displayP3)
+    }
+
+    let convertedColor = color.cgColor.converted(to: colorspace ?? CGColorSpaceCreateDeviceRGB(), intent: .defaultIntent, options: nil)
+
+    if let components = convertedColor?.components, components.count == 4 {
+      red = components[0]
+      green = components[1]
+      blue = components[2]
+      alpha = components[3]
+    } else {
+      color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+    }
 
     let valueProvider = ColorValueProvider(Color(r: Double(red), g: Double(green), b: Double(blue), a: Double(alpha)))
     animationView.setValueProvider(valueProvider, keypath: keypath.animationKeypath)

--- a/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/lottie-swift/src/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -240,6 +240,17 @@ public final class CompatibleAnimationView: UIView {
   }
 
   @objc
+  public func getColorValue(for keypath: CompatibleAnimationKeypath, atFrame: CGFloat) -> UIColor?
+  {
+    let value = animationView.getValue(for: keypath.animationKeypath, atFrame: atFrame)
+    guard let colorValue = value as? Color else {
+        return nil;
+    }
+
+    return UIColor(red: CGFloat(colorValue.r), green: CGFloat(colorValue.g), blue: CGFloat(colorValue.b), alpha: CGFloat(colorValue.a))
+  }
+
+  @objc
   public func addSubview(
     _ subview: AnimationSubview,
     forLayerAt keypath: CompatibleAnimationKeypath)


### PR DESCRIPTION
This PR adds a method to `CompatibleAnimationView` that makes it possible to change color values from Objective-C. The Objective-C compatibility wrapper misses the methods to set value providers. I assume this is because it'd require adding wrappers for the value providers which require Swift closures.

Why does it matter?
In a project that is mainly Objective-C we wanted to use Lottie for `UIBarButtonItem` instances that animate. However, when a modal view is presented those buttons wouldn't dim correctly when the `tintAdjustmentMode` was set to `UIViewTintAdjustmentModeAutomatic`. With this simple change it's possible to tint the animations with the correct tint color.

It'd be easy to add other methods for these static value providers (e.g. float, size and point), but color was the only one we needed.