### PR TITLE
Fix bug for unknown shape types

### DIFF
--- a/Example/lottie-swift/ViewController.swift
+++ b/Example/lottie-swift/ViewController.swift
@@ -146,16 +146,16 @@ class ViewController: UIViewController {
   
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-//    animationView.play(fromProgress: 0,
-//                       toProgress: 1,
-//                       loopMode: LottieLoopMode.playOnce,
-//                       completion: { (finished) in
-//                        if finished {
-//                          print("Animation Complete")
-//                        } else {
-//                          print("Animation cancelled")
-//                        }
-//    })
+    animationView.play(fromProgress: 0,
+                       toProgress: 1,
+                       loopMode: LottieLoopMode.playOnce,
+                       completion: { (finished) in
+                        if finished {
+                          print("Animation Complete")
+                        } else {
+                          print("Animation cancelled")
+                        }
+    })
     
   }
   

--- a/lottie-swift/src/Private/Model/Layers/LayerModel.swift
+++ b/lottie-swift/src/Private/Model/Layers/LayerModel.swift
@@ -36,6 +36,10 @@ public enum LayerType: Int, Codable {
   case null
   case shape
   case text
+  
+  public init(from decoder: Decoder) throws {
+    self = try LayerType(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .null
+  }
 }
 
 public enum MatteType: Int, Codable {

--- a/lottie-swift/src/Private/Model/ShapeItems/ShapeItem.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/ShapeItem.swift
@@ -61,6 +61,11 @@ enum ShapeType: String, Codable {
   case stroke = "st"
   case trim = "tm"
   case transform = "tr"
+  case unknown
+  
+  public init(from decoder: Decoder) throws {
+    self = try ShapeType(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+  }
 }
 
 /// An item belonging to a Shape Layer

--- a/lottie-swift/src/Private/NodeRenderSystem/Extensions/ItemsExtension.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/Extensions/ItemsExtension.swift
@@ -21,7 +21,7 @@ extension Array where Element == ShapeItem {
     var nodeTree = NodeTree()
 
     for item in self {
-      guard item.hidden == false else { continue }
+      guard item.hidden == false, item.type != .unknown else { continue }
       if let fill = item as? Fill {
         let node = FillNode(parentNode: nodeTree.rootNode, fill: fill)
         nodeTree.rootNode = node

--- a/lottie-swift/src/Public/Animation/AnimationPublic.swift
+++ b/lottie-swift/src/Public/Animation/AnimationPublic.swift
@@ -48,6 +48,7 @@ public extension Animation {
       return animation
     } catch {
       /// Decoding error.
+      print(error)
       return nil
     }
   }


### PR DESCRIPTION
Fixes a bug that caused animations with unknown or unsupported shape types to return nil.
Now unknown shape types are skipped and the animation is played anyways.

https://github.com/airbnb/lottie-ios/issues/1038
And probably others.