### PR TITLE
Fix out of bound when accessing points

### DIFF
--- a/lottie-swift/src/Private/Utility/Extensions/MathKit.swift
+++ b/lottie-swift/src/Private/Utility/Extensions/MathKit.swift
@@ -433,12 +433,13 @@ extension CGPoint: Interpolatable {
       }
       if accurateDistance < point.distance {
         closestPoint = closestPoint - 1
+        if closestPoint < 0 {
+          foundPoint = true
+          continue
+        }
         point = points[closestPoint]
         pointAmount = CGFloat(closestPoint) * step
         nextPointAmount = pointAmount + step
-        if closestPoint < 0 {
-          foundPoint = true
-        }
         continue
       }
       


### PR DESCRIPTION
Ensure `closestPoint < 0` is checked before accessing array with `closestPoint` as index