### PR TITLE
refactor(TextCompositionLayer): Fix warning in TextCompositionLayer

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/CompLayers/TextCompositionLayer.swift
+++ b/lottie-swift/src/Private/LayerContainers/CompLayers/TextCompositionLayer.swift
@@ -115,7 +115,7 @@ final class TextCompositionLayer: CompositionLayer {
     
     let text = textDocument.value(frame: frame) as! TextDocument
     let anchorPoint = interpolatableAnchorPoint?.value(frame: frame) as! Vector3D
-    let scale = interpolatableScale?.value(frame: frame) as! Vector3D
+    interpolatableScale?.value(frame: frame)
     rootNode?.rebuildOutputs(frame: frame)
     
     let fillColor = rootNode?.textOutputNode.fillColor ?? text.fillColorData.cgColorValue

--- a/lottie-swift/src/Private/NodeRenderSystem/NodeProperties/ValueProviders/KeyframeInterpolator.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/NodeProperties/ValueProviders/KeyframeInterpolator.swift
@@ -67,9 +67,10 @@ final class KeyframeInterpolator<ValueType>: AnyValueProvider where ValueType: I
   
   fileprivate var lastUpdatedFrame: CGFloat?
   
+  @discardableResult
   func value(frame: CGFloat) -> Any {
     // First set the keyframe span for the frame.
-    self.updateSpanIndices(frame: frame)
+    updateSpanIndices(frame: frame)
     lastUpdatedFrame = frame
     // If only one keyframe return its value
     let progress: CGFloat


### PR DESCRIPTION
# Contains 

 - Fix warning related to unused property in TextCompositionLayer

 - Add `@discardableResult` to `value(frame: ) -> Any` function in KeyframeInterpolator

 - Delete redundant `self` in KeyframeInterpolator

# Description

This solves warning related to unused property in TextCompositionLayer. 
There will be no warnings left after this pull-request merge. 🎉 

![Screen Shot 2019-11-13 at 08 00 09](https://user-images.githubusercontent.com/19268363/68734822-c8f2d680-05ec-11ea-983d-2c9aae9a5a55.png)

PTAL @buba447 🚀 📱 