### PR TITLE
Fix bug that prevented precomp layers from clippng properly.

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/CompLayers/PreCompositionLayer.swift
+++ b/lottie-swift/src/Private/LayerContainers/CompLayers/PreCompositionLayer.swift
@@ -28,8 +28,8 @@ final class PreCompositionLayer: CompositionLayer {
     }
     self.frameRate = frameRate
     super.init(layer: precomp, size: CGSize(width: precomp.width, height: precomp.height))
-    masksToBounds = true
-    bounds = CGRect(origin: .zero, size: CGSize(width: precomp.width, height: precomp.height))
+    contentsLayer.masksToBounds = true
+    contentsLayer.bounds = CGRect(origin: .zero, size: CGSize(width: precomp.width, height: precomp.height))
     
     let layers = asset.layers.initializeCompositionLayers(assetLibrary: assetLibrary, layerImageProvider: layerImageProvider, textProvider: textProvider, frameRate: frameRate)
     


### PR DESCRIPTION
Fixes https://github.com/airbnb/lottie-ios/issues/1085

The clipping on the precomp layer was being reset. Moved clipping to internal layer.