### PR TITLE
Fixes issue with layout changes being animated when it should be not.

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -718,6 +718,8 @@ final public class AnimationView: LottieView {
      UIView Animation does not implicitly set CAAnimation time or timing fuctions.
      If layout is changed in an animation we must get the current animation duration
      and timing function and then manually create a CAAnimation to match the UIView animation.
+     If layout is changed without animation, explicitly set animation duration to 0.0
+     inside CATransaction to avoid unwanted artifacts.
      */
 
     /// Check if any animation exist on the view's layer, and grab the duration and timing functions of the animation.
@@ -748,8 +750,12 @@ final public class AnimationView: LottieView {
       animationLayer.transform = xform
       animationLayer.add(group, forKey: animationKey)
     } else {
+      CATransaction.begin()
+      CATransaction.setAnimationDuration(0.0)
+      CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .linear))
       animationLayer.position = position
       animationLayer.transform = xform
+      CATransaction.commit()
     }
     
     if shouldForceUpdates {


### PR DESCRIPTION
This fixes a regression we noticed when updated from `lottie-ios` from `3.1.2` to `3.1.3` and above.

Please see the [breaking change in here](https://github.com/airbnb/lottie-ios/compare/3.1.2...3.1.3#diff-9e48c66544bf5009ef0f877f7d5f53d9L671).

In `3.1.2` the animation was always done inside `CATransaction`, and what's important, when it detected no animation was needed, it still used `CATransaction` but with duration set to `0.0`.

`3.1.3` removed the use of `CATransaction` in favor of `CAAnimation` which is fine for the case when animation being in progress was detected. But when no animation was detected, it was left with:
```
      animationLayer.position = position
      animationLayer.transform = xform
```
which in our case still caused an animation to be performed when it was not needed (maybe some iOS system default animation?).

In the attachment you can find movies showing how animation looks with and without the fix, when contained inside refresh control of a table view. 

[Animation-with-and-without-fix.zip](https://github.com/airbnb/lottie-ios/files/4009579/Animation-with-and-without-fix.zip)
