### PR TITLE
Fix animation not playing when dynamically using negative speeds

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -959,7 +959,7 @@ final public class AnimationView: LottieView {
     layerAnimation.isRemovedOnCompletion = false
     if timeOffset != 0 {
       let currentLayerTime = viewLayer?.convertTime(CACurrentMediaTime(), from: nil) ?? 0
-      layerAnimation.beginTime = currentLayerTime - (timeOffset * 1 / Double(animationSpeed))
+      layerAnimation.beginTime = currentLayerTime - (timeOffset * 1 / Double(abs(animationSpeed)))
     }
     layerAnimation.delegate = animationContext.closure
     animationContext.closure.animationLayer = animationlayer


### PR DESCRIPTION
Basically when I was giving **dynamic** negative animation speeds, through **lottie-react-native**, the animation wouldn't play at all.

After debugging it through **lottie-react-native** and **lottie-ios** I found out the issue was on not using the absolute value on the calculation of **layerAnimation.beginTime**.

After making this change, the animation would start to play in reverse again.