### PR TITLE
Improve animation view

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -820,6 +820,11 @@ final public class AnimationView: LottieView {
   }
   
   override func animationMovedToWindow() {
+    /// Don't update any state if both the `superview` and `window` is `nil`
+    guard window != nil && superview != nil else {
+      return
+    }
+
     if window != nil {
       updateAnimationForForegroundState()
     } else {

--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -821,9 +821,7 @@ final public class AnimationView: LottieView {
   
   override func animationMovedToWindow() {
     /// Don't update any state if both the `superview` and `window` is `nil`
-    guard window != nil && superview != nil else {
-      return
-    }
+    guard window != nil && superview != nil else { return }
 
     if window != nil {
       updateAnimationForForegroundState()

--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -618,10 +618,6 @@ final public class AnimationView: LottieView {
     commonInit()
   }
   
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-  
   // MARK: - Public (UIView Overrides)
   
   override public var intrinsicContentSize: CGSize {


### PR DESCRIPTION
- Remove `removeObserver` call in `AnimationView.deinit`
- Add guard to `animationMovedToWindow()` to ensure that state change don't happen to orphan `AnimationView`'s

Reference issue: #1113 