### PR TITLE
Fix LRUAnimationCache to evict cached items

### DIFF
--- a/lottie-swift/src/Public/AnimationCache/LRUAnimationCache.swift
+++ b/lottie-swift/src/Public/AnimationCache/LRUAnimationCache.swift
@@ -44,7 +44,10 @@ public class LRUAnimationCache: AnimationCacheProvider {
     cacheMap[forKey] = animation
     lruList.append(forKey)
     if lruList.count > cacheSize {
-      lruList.remove(at: 0)
+      let removed = lruList.remove(at: 0)
+      if removed != forKey {
+        cacheMap[removed] = nil
+      }
     }
   }
   


### PR DESCRIPTION
This bug fix ensures that items stored in `cacheMap` are also removed when an entry from `lruList` is removed.