### PR TITLE
Fixes zero based CALayer for Precomposition.

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/CompLayers/PreCompositionLayer.swift
+++ b/lottie-swift/src/Private/LayerContainers/CompLayers/PreCompositionLayer.swift
@@ -28,8 +28,9 @@ final class PreCompositionLayer: CompositionLayer {
     }
     self.frameRate = frameRate
     super.init(layer: precomp, size: CGSize(width: precomp.width, height: precomp.height))
+    bounds = CGRect(origin: .zero, size: CGSize(width: precomp.width, height: precomp.height))
     contentsLayer.masksToBounds = true
-    contentsLayer.bounds = CGRect(origin: .zero, size: CGSize(width: precomp.width, height: precomp.height))
+    contentsLayer.bounds = bounds
     
     let layers = asset.layers.initializeCompositionLayers(assetLibrary: assetLibrary, layerImageProvider: layerImageProvider, textProvider: textProvider, frameRate: frameRate)
     


### PR DESCRIPTION
Our team had a number of animations that were partially drawing that were working before. Narrowed down the commit that broke to 6ede9ee. Because the bounds were not set before hand, all of the layers bounds are set to zero. This brings back not setting the bounds before the layers are configured in order to avoid clipping.