### PR TITLE
Fix issue with Text Layer Anchor Points

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/CompLayers/TextCompositionLayer.swift
+++ b/lottie-swift/src/Private/LayerContainers/CompLayers/TextCompositionLayer.swift
@@ -52,8 +52,6 @@ final class TextCompositionLayer: CompositionLayer {
   
   let rootNode: TextAnimatorNode?
   let textDocument: KeyframeInterpolator<TextDocument>?
-  let interpolatableAnchorPoint: KeyframeInterpolator<Vector3D>?
-  let interpolatableScale: KeyframeInterpolator<Vector3D>?
   
   let textLayer: DisabledTextLayer = DisabledTextLayer()
   let textStrokeLayer: DisabledTextLayer = DisabledTextLayer()
@@ -68,11 +66,6 @@ final class TextCompositionLayer: CompositionLayer {
     self.textDocument = KeyframeInterpolator(keyframes: textLayer.text.keyframes)
     
     self.textProvider = textProvider
-    
-    // TODO: this has to be somewhere that can be interpolated
-    // TODO: look for inspiration from other composite layer
-    self.interpolatableAnchorPoint = KeyframeInterpolator(keyframes: textLayer.transform.anchorPoint.keyframes)
-    self.interpolatableScale = KeyframeInterpolator(keyframes: textLayer.transform.scale.keyframes)
     
     super.init(layer: textLayer, size: .zero)
     contentsLayer.addSublayer(self.textLayer)
@@ -97,9 +90,6 @@ final class TextCompositionLayer: CompositionLayer {
     
     self.textProvider = DefaultTextProvider()
     
-    self.interpolatableAnchorPoint = nil
-    self.interpolatableScale = nil
-    
     super.init(layer: layer)
   }
   
@@ -114,9 +104,7 @@ final class TextCompositionLayer: CompositionLayer {
     guard documentUpdate == true || animatorUpdate == true else { return }
     
     let text = textDocument.value(frame: frame) as! TextDocument
-    let anchorPoint = interpolatableAnchorPoint?.value(frame: frame) as! Vector3D
-    
-    interpolatableScale?.value(frame: frame)
+
     rootNode?.rebuildOutputs(frame: frame)
     
     let fillColor = rootNode?.textOutputNode.fillColor ?? text.fillColorData.cgColorValue
@@ -176,9 +164,8 @@ final class TextCompositionLayer: CompositionLayer {
     case .center:
       textAnchor = CGPoint(x: size.width * 0.5, y: baselinePosition)
     }
-    let anchor = textAnchor + anchorPoint.pointValue
-    let normalizedAnchor = CGPoint(x: anchor.x.remap(fromLow: 0, fromHigh: size.width, toLow: 0, toHigh: 1),
-                                   y: anchor.y.remap(fromLow: 0, fromHigh: size.height, toLow: 0, toHigh: 1))
+    let normalizedAnchor = CGPoint(x: textAnchor.x.remap(fromLow: 0, fromHigh: size.width, toLow: 0, toHigh: 1),
+                                   y: textAnchor.y.remap(fromLow: 0, fromHigh: size.height, toLow: 0, toHigh: 1))
     
     if textStrokeLayer.isHidden == false {
       if text.strokeOverFill ?? false {


### PR DESCRIPTION
Some old code that doubled anchor point values was sitting in Text Layer. This removes that code and fixes the anchor points for text layers.