### PR TITLE
Fix method :-animationMovedToWindow judgment logic

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -826,8 +826,9 @@ final public class AnimationView: LottieView {
   }
   
   override func animationMovedToWindow() {
-    /// Don't update any state if both the `superview` and `window` is `nil`
-    guard window != nil && superview != nil else { return }
+    /// Don't update any state if the `superview`  is `nil`
+    /// When A viewA owns superViewB, it removes the superViewB from the window. At this point, viewA still owns superViewB and triggers the viewA method: -didmovetowindow
+    guard superview != nil else { return }
 
     if window != nil {
       updateAnimationForForegroundState()


### PR DESCRIPTION
Method :- logic bug in animationMovedToWindow:

> `guard window != nil && superview != nil else { return } `
>     `if window != nil {`
>     `updateAnimationForForegroundState()`
> `} else { `
>      `//  the following will never be executed, resulting in the current Lottie not recording the previous state`
>       `updateAnimationForBackgroundState()`
> `}`

It should be changed to:
> `guard superview != nil else { return }`
>     `if window != nil {`
>       `updateAnimationForForegroundState()`
>     `} else {`
>       `updateAnimationForBackgroundState()`
>    ` }`

Note: When A viewA owns superViewB, it removes the superViewB from the window. At this point, viewA still owns superViewB and triggers the viewA method: -didmovetowindow