### PR TITLE
[ObjC] added base64 image support to macOS, lowered deployment target to 10.9

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -1327,6 +1327,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 62CA59AE1E3C173B002D7188;
@@ -1948,7 +1949,7 @@
 				INFOPLIST_FILE = Lottie/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SDKROOT = macosx;
@@ -1968,7 +1969,7 @@
 				INFOPLIST_FILE = Lottie/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SDKROOT = macosx;

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -23,7 +23,7 @@ For the first time, designers can create and ship beautiful animations without a
   s.source           = { :git => 'https://github.com/airbnb/lottie-ios.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.10'
+  s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
 
   s.source_files = 'lottie-ios/Classes/**/*'

--- a/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
+++ b/lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.m
@@ -186,7 +186,15 @@
 
 - (void)_setImageForAsset:(LOTAsset *)asset {
   if (asset.imageName) {
-    NSImage *image = [NSImage imageNamed:[asset.imageName stringByDeletingPathExtension]];
+    NSImage *image;
+    if ([asset.imageName hasPrefix:@"data:"]) {
+      // Contents look like a data: URL. Ignore asset.imageDirectory and simply load the image directly.
+      NSURL *imageUrl = [NSURL URLWithString:asset.imageName];
+      NSData *imageData = [NSData dataWithContentsOfURL:imageUrl];
+      image = [[NSImage alloc] initWithData:imageData];
+    } else {
+      image = [NSImage imageNamed:[asset.imageName stringByDeletingPathExtension]];
+    }
     if (image == nil) {
       if (asset.rootDirectory.length > 0 && asset.imageDirectory.length > 0) {
         NSString *imagePath = [[asset.rootDirectory stringByAppendingPathComponent:asset.imageDirectory] stringByAppendingPathComponent:asset.imageName];


### PR DESCRIPTION
I beleive that the deployment target could be also lowered on the 3.x version