### PR TITLE
Fix AnimationView.Stop()

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -373,6 +373,7 @@ final public class AnimationView: LottieView {
   public func stop() {
     removeCurrentAnimation()
     currentFrame = 0
+    CATransaction.flush()
   }
   
   /**

--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -809,12 +809,12 @@ final public class AnimationView: LottieView {
   /// Updates the animation frame. Does not affect any current animations
   func updateAnimationFrame(_ newFrame: CGFloat) {
     CATransaction.begin()
-    CATransaction.setDisableActions(true)
-    animationLayer?.currentFrame = newFrame
-    CATransaction.commit()
     CATransaction.setCompletionBlock {
         self.animationLayer?.forceDisplayUpdate()
     }
+    CATransaction.setDisableActions(true)
+    animationLayer?.currentFrame = newFrame
+    CATransaction.commit()
   }
   
   @objc override func animationWillMoveToBackground() {


### PR DESCRIPTION
This fixes https://github.com/airbnb/lottie-ios/issues/970. That issue was not actually resolved.

And also fixes https://github.com/airbnb/lottie-ios/issues/975

Before this change, calling stop() on an AnimationView that is playing did not work properly. It would not return to the first frame of the animation. And when it did, it would "reverse" the animation.

The reversing is because [this PR](https://github.com/airbnb/lottie-ios/pull/974) put CATransaction.setCompletionBlock _outside_ the CATransaction begin/commit block. CATransaction.setCompletionBlock needs to occur between CATransaction.begin and CATransaction.commit.

This PR moves that setCompletionBlock to the correct place.

After moving that code block, the animation would still not return to frame 0 when stop is called, but when a subsequent animation is play()'d, the animation would return to frame 0 _without reversing_.

It seemed clear to me, based on this behaviour, that some of the CATransaction stuff or the setNeedsDisplay() system is not working properly.

To remedy this, I have put a flush() in stop().

This fixes the problem. But I realize that the flush shouldnt need to be there. There are some deeper bugs in lottie-ios, but _at least this fixes the symptom_.

Tagging @buba447 @dcramps @ferico55 @thedrick 