### PR TITLE
Fix matching parent's animation if it's not a simple CABasicAnimation

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -717,34 +717,34 @@ final public class AnimationView: LottieView {
      If layout is changed without animation, explicitly set animation duration to 0.0
      inside CATransaction to avoid unwanted artifacts.
      */
-
-    /// Check if any animation exist on the view's layer, and grab the duration and timing functions of the animation.
+    /// Check if any animation exist on the view's layer, and match it.
     if let key = viewLayer?.animationKeys()?.first, let animation = viewLayer?.animation(forKey: key) {
       // The layout is happening within an animation block. Grab the animation data.
       
-      let animationKey = "LayoutAnimation"
-      animationLayer.removeAnimation(forKey: animationKey)
+      let positionKey = "LayoutPositionAnimation"
+      let transformKey = "LayoutTransformAnimation"
+      animationLayer.removeAnimation(forKey: positionKey)
+      animationLayer.removeAnimation(forKey: transformKey)
       
-      let positionAnimation = CABasicAnimation(keyPath: "position")
+      let positionAnimation = animation.copy() as? CABasicAnimation ?? CABasicAnimation(keyPath: "position")
+      positionAnimation.keyPath = "position"
+      positionAnimation.isAdditive = false
       positionAnimation.fromValue = animationLayer.position
       positionAnimation.toValue = position
-      let xformAnimation = CABasicAnimation(keyPath: "transform")
+      positionAnimation.isRemovedOnCompletion = true
+      
+      let xformAnimation = animation.copy() as? CABasicAnimation ?? CABasicAnimation(keyPath: "transform")
+      xformAnimation.keyPath = "transform"
+      xformAnimation.isAdditive = false
       xformAnimation.fromValue = animationLayer.transform
       xformAnimation.toValue = xform
-      
-      let group = CAAnimationGroup()
-      group.animations = [positionAnimation, xformAnimation]
-      group.duration = animation.duration
-      group.fillMode = .both
-      group.timingFunction = animation.timingFunction
-      if animation.beginTime > 0 {
-        group.beginTime = CACurrentMediaTime() + animation.beginTime
-      }
-      group.isRemovedOnCompletion = true
+      xformAnimation.isRemovedOnCompletion = true
       
       animationLayer.position = position
       animationLayer.transform = xform
-      animationLayer.add(group, forKey: animationKey)
+      animationLayer.anchorPoint = layer.anchorPoint
+      animationLayer.add(positionAnimation, forKey: positionKey)
+      animationLayer.add(xformAnimation, forKey: transformKey)
     } else {
       CATransaction.begin()
       CATransaction.setAnimationDuration(0.0)


### PR DESCRIPTION
This fixes https://github.com/airbnb/lottie-ios/issues/1161
It solves the issue by copying the view's animation and changing all the relevant parameters to make the layer's animations. This way the animation class keeps being the view's animation instance class (like CASpringAnimation)

Here's the behavior with the fix. AnimationView background is painted yellow to highlight it:
![Screen Recording 2020-03-28 at 13 10 40](https://user-images.githubusercontent.com/11080704/77827685-de792080-70f5-11ea-9244-ffe86a85de8f.gif)

And here's with Slow Animations turned on:
![Screen Recording 2020-03-28 at 13 10 40_1](https://user-images.githubusercontent.com/11080704/77827694-ecc73c80-70f5-11ea-9edc-4d328da47b19.gif)
