### PR TITLE
Changed ACL for animationView to public in AnimatedControl

### DIFF
--- a/lottie-swift/src/Public/iOS/AnimatedControl.swift
+++ b/lottie-swift/src/Public/iOS/AnimatedControl.swift
@@ -30,6 +30,9 @@ open class AnimatedControl: UIControl {
   
   // MARK: Public
   
+  /// The animation view in which the animation is rendered.
+  public let animationView: AnimationView
+  
   /// The animation backing the animated control.
   public var animation: Animation? {
     didSet {
@@ -128,7 +131,6 @@ open class AnimatedControl: UIControl {
   
   // MARK: Private
   
-  let animationView: AnimationView
   var stateMap: [UInt : String] = [:]
   
   fileprivate func commonInit() {


### PR DESCRIPTION
There are numerous cases where properties of the `AnimationView` within an `AnimatedControl` need to be accessed. I needed to add a `textProvider` to add localized strings to a custom switch with labels for the different states.

Instead of exposing every single property separately (like it is done with the `animationSpeed` or setting the `valueProvider`), a more convenient way is to simply expose the `animationView` to the public.