### PR TITLE
Add isAnimationQueued to determine if animation will start when this view is added to a window

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -110,6 +110,11 @@ final public class AnimationView: LottieView {
     return animationLayer?.animation(forKey: activeAnimationName) != nil
   }
   
+  /// Returns `true` if the animation will start playing when this view is added to a window.
+  public var isAnimationQueued: Bool {
+    return animationContext != nil && waitingToPlayAnimation
+  }
+  
   /// Sets the loop behavior for `play` calls. Defaults to `playOnce`
   public var loopMode: LottieLoopMode = .playOnce {
     didSet {


### PR DESCRIPTION
In Lottie v2, isAnimationPlaying would return true if the animation isn't playing, but would start as soon as the view is added to a window. In Lottie v3, isAnimationPlaying returns true only if an animation is actually playing.

Rather than modify how isAnimationPlaying works, I've added isAnimationQueued to detect the state where the animation isn't playing, but will when the view is added to a window. This allows the app I work on to upgrade from Lottie v2 to v3 and preserve the existing behaviour.