### PR TITLE
Fix a crash when loadding an invalid JSON file from remote.

### DIFF
--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -73,7 +73,7 @@ static NSString * const kCompContainerAnimationKey = @"play";
         NSError *error;
         NSDictionary  *animationJSON = [NSJSONSerialization JSONObjectWithData:animationData
                                                                        options:0 error:&error];
-        if (error || !animationJSON) {
+        if (error || !animationJSON || ![animationJSON isKindOfClass:[NSDictionary class]]) {
           return;
         }
         

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -71,11 +71,13 @@ static NSString * const kCompContainerAnimationKey = @"play";
           return;
         }
         NSError *error;
-        NSDictionary  *animationJSON = [NSJSONSerialization JSONObjectWithData:animationData
+        id jsonObject = [NSJSONSerialization JSONObjectWithData:animationData
                                                                        options:0 error:&error];
-        if (error || !animationJSON || ![animationJSON isKindOfClass:[NSDictionary class]]) {
+        if (error || !jsonObject || ![jsonObject isKindOfClass:[NSDictionary class]]) {
           return;
         }
+          
+        NSDictionary * animationJSON = (NSDictionary *) jsonObject;
         
         LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:animationJSON withAssetBundle:[NSBundle mainBundle]];
         dispatch_async(dispatch_get_main_queue(), ^(void) {


### PR DESCRIPTION
When we load an invalid JSON file from remote url(by mistake) such as:

```json
[
    {
        "menu": "operation",
        "content": "Text",
        "icon": ""
    },
    {
        "menu": "operation",
        "content": "Text",
        "icon": ""
    },
    {
        "menu": "operation",
        "content": "Text",
        "icon": ""
    }
]
```

This would lead to a crash because of this piece of code:

```objectivec
dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
  NSData *animationData = [NSData dataWithContentsOfURL:url];
  if (!animationData) {
    return;
  }
  NSError *error;
    
  /// In this case, animationJSON would be decoded as an `NSArray` instead of `NSDictionary`
  NSDictionary  *animationJSON = [NSJSONSerialization JSONObjectWithData:animationData
                                                                 options:0 error:&error];
  if (error || !animationJSON) {
    return;
  }
  
  /// `initWithJSON` would call `NSNumber *width = jsonDictionary[@"w"];`, which will lead to a crash.
  LOTComposition *laScene = [[LOTComposition alloc] initWithJSON:animationJSON withAssetBundle:[NSBundle mainBundle]];
  dispatch_async(dispatch_get_main_queue(), ^(void) {
    [[LOTAnimationCache sharedCache] addAnimation:laScene forKey:url.absoluteString];
    laScene.cacheKey = url.absoluteString;
    [self _initializeAnimationContainer];
    [self _setupWithSceneModel:laScene];
  });
});
```