### PR TITLE
fix: empty layerID causes crash

### DIFF
--- a/lottie-ios/Classes/Models/LOTLayerGroup.m
+++ b/lottie-ios/Classes/Models/LOTLayerGroup.m
@@ -38,7 +38,9 @@
                                       withAssetGroup:assetGroup
                                        withFramerate:framerate];
     [layers addObject:layer];
-    modelMap[layer.layerID] = layer;
+    if(layer.layerID) {
+      modelMap[layer.layerID] = layer;
+    }
     if (layer.referenceID) {
       referenceMap[layer.referenceID] = layer;
     }


### PR DESCRIPTION
If the layerID is not set, the app would crash.