### PR TITLE
imageLayer.image no changes when imageForAsset is nil

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/Utility/LayerImageProvider.swift
+++ b/lottie-swift/src/Private/LayerContainers/Utility/LayerImageProvider.swift
@@ -41,8 +41,9 @@ final class LayerImageProvider {
   
   func reloadImages() {
     for imageLayer in imageLayers {
-      if let asset = imageAssets[imageLayer.imageReferenceID] {
-        imageLayer.image = imageProvider.imageForAsset(asset: asset)
+      if let asset = imageAssets[imageLayer.imageReferenceID],
+        let image = imageProvider.imageForAsset(asset: asset) {
+        imageLayer.image = image
       }
     }
   }


### PR DESCRIPTION
issue: https://github.com/airbnb/lottie-ios/issues/1266


Lottie assets could have some resources that AnimationImageProvider doesn't have.
also Android Lottie checks if the AnimationImageProvider have or not.