### PR TITLE
Use ZippyJSONDecoder for JSON Decoding

### DIFF
--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -33,6 +33,7 @@ For the first time, designers can create and ship beautiful animations without a
   s.tvos.exclude_files = 'lottie-swift/src/Public/MacOS/**/*'
   s.osx.exclude_files = 'lottie-swift/src/Public/iOS/**/*'
 
+  s.dependency 'ZippyJSON', '1.2.1'
   s.ios.frameworks = ['UIKit', 'CoreGraphics', 'QuartzCore']
   s.tvos.frameworks = ['UIKit', 'CoreGraphics', 'QuartzCore']
   s.osx.frameworks = ['AppKit', 'CoreGraphics', 'QuartzCore']

--- a/lottie-swift/src/Public/Animation/AnimationPublic.swift
+++ b/lottie-swift/src/Public/Animation/AnimationPublic.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreGraphics
+import ZippyJSON
 
 public extension Animation {
   
@@ -43,7 +44,7 @@ public extension Animation {
     do {
       /// Decode animation.
       let json = try Data(contentsOf: url)
-      let animation = try JSONDecoder().decode(Animation.self, from: json)
+      let animation = try ZippyJSONDecoder().decode(Animation.self, from: json)
       animationCache?.setAnimation(animation, forKey: cacheKey)
       return animation
     } catch {
@@ -72,7 +73,7 @@ public extension Animation {
     do {
       /// Decode the animation.
       let json = try Data(contentsOf: URL(fileURLWithPath: filepath))
-      let animation = try JSONDecoder().decode(Animation.self, from: json)
+      let animation = try ZippyJSONDecoder().decode(Animation.self, from: json)
       animationCache?.setAnimation(animation, forKey: filepath)
       return animation
     } catch {
@@ -107,7 +108,7 @@ public extension Animation {
           return
         }
         do {
-          let animation = try JSONDecoder().decode(Animation.self, from: jsonData)
+          let animation = try ZippyJSONDecoder().decode(Animation.self, from: jsonData)
           DispatchQueue.main.async {
             animationCache?.setAnimation(animation, forKey: url.absoluteString)
             closure(animation)


### PR DESCRIPTION
Following discussion in https://github.com/airbnb/lottie-ios/issues/1117

ZippyJSONDecoder is a ~3-4x faster drop-in replacement of JSONDecoder