### PR TITLE
Specify data collection practices of this SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ If you have doubts, please, check the following links:
 
 After successfully retrieved the package and added it to your project, just import `Lottie` and you can get the full benefits of it.
 
+-----
+
 ### Objective-C Support
 
 As of 3.0 Lottie has been completely rewritten in Swift! 
@@ -108,3 +110,7 @@ The official objective c branch can be found here:
 Also check out the documentation regarding it here: 
 
 [iOS Migration](http://airbnb.io/lottie/#/ios-migration)
+
+### Data collection
+
+The Lottie SDK does not collect any data. We provide this notice to help you fill out [App Privacy Details](https://developer.apple.com/app-store/app-privacy-details/).


### PR DESCRIPTION
Apple is requiring application to publish "nutrition facts" related to data privacy.

Lottie is a widely used SDK.

Let's make it easy for consumers of Lottie to know how including Lottie in their application affects what they need to report to Apple.

The good news is that it should have no effect!

While I was here I made a line break above `### Objective-C Support`. This section was technically below `## Installing Lottie` so this seemed like a nice clarification.