### PR TITLE
Append the TextAnimatorNode as a child keypath

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/CompLayers/TextCompositionLayer.swift
+++ b/lottie-swift/src/Private/LayerContainers/CompLayers/TextCompositionLayer.swift
@@ -64,6 +64,10 @@ final class TextCompositionLayer: CompositionLayer {
     super.init(layer: textLayer, size: .zero)
     contentsLayer.addSublayer(self.textLayer)
     self.textLayer.masksToBounds = false
+
+    if let rootNode = rootNode {
+        childKeypaths.append(rootNode)
+    }
   }
   
   required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Appends the `TextAnimatorNode` as a child keypath of `TextCompositionLayer`
This allows for setting values on text animations. For example Fill Color, Stroke Color, Stroke Width, and Tracking.

Animation keypaths _before_ the change:
```
Lottie: Logging Animation Keypaths
Text Layer 1
Text Layer 1.Transform
Text Layer 1.Transform.Opacity
Text Layer 1.Transform.Rotation
Text Layer 1.Transform.Anchor Point
Text Layer 1.Transform.Scale
Text Layer 1.Transform.Position
```

Animation keypaths _after_ the change:
```
Lottie: Logging Animation Keypaths
Text Layer 1
Text Layer 1.Transform
Text Layer 1.Transform.Opacity
Text Layer 1.Transform.Rotation
Text Layer 1.Transform.Anchor Point
Text Layer 1.Transform.Scale
Text Layer 1.Transform.Position
Text Layer 1.Animation 1
Text Layer 1.Animation 1.Fill Color
```