### PR TITLE
Fix: remove flush

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/AnimationContainer.swift
+++ b/lottie-swift/src/Private/LayerContainers/AnimationContainer.swift
@@ -193,7 +193,14 @@ final class AnimationContainer: CALayer {
   
   public override func display() {
     guard Thread.isMainThread else { return }
-    var newFrame: CGFloat = self.presentation()?.currentFrame ?? self.currentFrame
+    var newFrame: CGFloat
+    if let animationKeys = self.animationKeys(),
+      !animationKeys.isEmpty {
+      newFrame = self.presentation()?.currentFrame ?? self.currentFrame
+    } else {
+      // We ignore the presentation's frame if there's no animation in the layer.
+      newFrame = self.currentFrame
+    }
     if respectAnimationFrameRate {
       newFrame = floor(newFrame)
     }

--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -389,7 +389,6 @@ final public class AnimationView: LottieView {
   public func stop() {
     removeCurrentAnimation()
     currentFrame = 0
-    CATransaction.flush()
   }
   
   /**


### PR DESCRIPTION
I found a [pull request](https://github.com/airbnb/lottie-ios/pull/1157) to fix AnimationView stop problem. It says `stop()` not working and adds `CATransaction.flush()` in the stop method to fix it.

In my opinion, adding flush in this function is not a good way to fix it, because it will cause all the UI elements to render (or layout). and may lead to some [crash problem](https://github.com/airbnb/lottie-ios/issues/1254).

After reading the animation source code, I finally found the reason why animation couldn't revert to the first frame after `stop()` is that `AnimationContainer.display()` is still called once after stopping, and at this time the AnimationContainer gets the `currentFrame` of the copy value in `presentation()`, which is not zero at this time, to resolve this problem, I think we can check if the animation exists. If the AnimationContainer does not have an animation, then its presentation is meaningless and we should not use the value of the `curerntFrame` in the presentation. Since the `needsDisplay(forKey:)` in AnimationContainer for Lottie-customized key will always return true, we don't need to worry about the display function not called.

and here comes my pull request.