### PR TITLE
Fixed a deprecation warning where some protocols were inheriting from class instead of AnyObject per Xcode's suggestion

### DIFF
--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'lottie-ios'
-  s.version          = '3.2.1'
+  s.version          = '3.2.2'
   s.summary          = 'A library to render native animations from bodymovin json. Now in Swift!'
 
   s.description = <<-DESC

--- a/lottie-swift/src/Private/LayerContainers/CompLayers/CompositionLayer.swift
+++ b/lottie-swift/src/Private/LayerContainers/CompLayers/CompositionLayer.swift
@@ -147,7 +147,7 @@ class CompositionLayer: CALayer, KeypathSearchable {
   }
 }
 
-protocol CompositionLayerDelegate: class {
+protocol CompositionLayerDelegate: AnyObject {
   func frameUpdated(frame: CGFloat)
 }
 

--- a/lottie-swift/src/Private/NodeRenderSystem/NodeProperties/Protocols/AnyValueContainer.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/NodeProperties/Protocols/AnyValueContainer.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreGraphics
 
 /// The container for the value of a property.
-protocol AnyValueContainer: class {
+protocol AnyValueContainer: AnyObject {
   
   /// The stored value of the container
   var value: Any { get }

--- a/lottie-swift/src/Private/NodeRenderSystem/Protocols/AnimatorNode.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/Protocols/AnimatorNode.swift
@@ -39,7 +39,7 @@ protocol NodeOutput {
  if the node needs an update for the current frame.
  
  */
-protocol AnimatorNode: class, KeypathSearchable {
+protocol AnimatorNode: AnyObject, KeypathSearchable {
   
   /**
    The available properties of the Node.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-ios",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I was updating my iOS app to be able to run on Xcode 12.5 (beta) and noticed that Apple is now flagging the use of class inherited protocols as deprecated in favor of inheriting from AnyObject. In my iOS app, we flag warnings as errors so now our app won't compile. I wanted to be able to pitch in and help modernize the code so I went ahead and fixed this deprecation here.

<img width="1136" alt="Screen Shot 2021-02-10 at 1 40 35 PM" src="https://user-images.githubusercontent.com/1315688/107576119-934cec80-6ba5-11eb-8977-6f813ee17d22.png">

After a little bit of research, I came across this forum Swift.org [post](https://forums.swift.org/t/class-only-protocols-class-vs-anyobject/11507/4) which seems to point to the discussion where this deprecation discussion started.