### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ let package = Package(
        .iOS(.v12),
   ],
   dependencies: [
-    .package(url: "https://github.com/airbnb/lottie-ios.git", from: "3.1.2")
+    .package(name: "Lottie", url: "https://github.com/airbnb/lottie-ios.git", from: "3.2.1")
   ],
   targets: [
     .target(name: "YourTestProject", dependencies: ["Lottie"])


### PR DESCRIPTION
Xcode raises this error:

`dependency 'Lottie' in target 'SampleTarget' requires explicit declaration; provide the name of the package dependency with '.package(name: "Lottie", url: "https://github.com/airbnb/lottie-ios.git", from: "3.2.1")'`

In order to prevent it you should set the package's name