### PR TITLE
fix: KeyframeGroup encoding problem

### DIFF
--- a/lottie-swift/src/Private/Model/Keyframes/KeyframeGroup.swift
+++ b/lottie-swift/src/Private/Model/Keyframes/KeyframeGroup.swift
@@ -88,18 +88,17 @@ final class KeyframeGroup<T>: Codable where T: Codable, T: Interpolatable {
       try container.encode(keyframe.value, forKey: .keyframeData)
     } else {
       var keyframeContainer = container.nestedUnkeyedContainer(forKey: .keyframeData)
-      
-      for i in 1..<keyframes.endIndex {
-        let keyframe = keyframes[i-1]
-        let nextKeyframe = keyframes[i]
+
+      for i in 0..<keyframes.endIndex {
+        let keyframe = keyframes[i]
         let keyframeData = KeyframeData<T>(startValue: keyframe.value,
-                                                  endValue: nextKeyframe.value,
-                                                  time: Double(keyframe.time),
-                                                  hold: keyframe.isHold ? 1 : nil,
-                                                  inTangent: nextKeyframe.inTangent,
-                                                  outTangent: keyframe.outTangent,
-                                                  spatialInTangent: nil,
-                                                  spatialOutTangent: nil)
+                                           endValue: keyframe.value,
+                                           time: Double(keyframe.time),
+                                           hold: keyframe.isHold ? 1 : nil,
+                                           inTangent: keyframe.inTangent,
+                                           outTangent: keyframe.outTangent,
+                                           spatialInTangent: nil,
+                                           spatialOutTangent: nil)
         try keyframeContainer.encode(keyframeData)
       }
     }


### PR DESCRIPTION
I noticed encoding and decoding is not symetric. And this caused my animation cannot be played after JSONEncoder.encoding and JSONDecoder.decoding.

```swift
// HOW TO REPRODUCE
let animation1 = Animation.named("discover_tab_xyz_animation", animationCache: nil)
guard let animationData = try? JSONEncoder().encode(animation1) else { return }
guard let animation = try? JSONDecoder().decode(Animation.self, from: animationData) else { return }
self.logoView.animationView.animation = animation
self.logoView.animationView.play(fromProgress: 0, toProgress: 1, loopMode: .playOnce, completion: nil) // can't play properly
```

I don't see the necessary that `encode` has to "borrow" some keys here when encoding. If there's a reason I don't know, the for-loop could also be changed to

```swift
for i in 0..<keyframes.endIndex {
  let keyframe = keyframes[i]
  var nextKeyframe: Keyframe<T>? = nil
  if keyframes.count > (i + 1) {
    let nextKeyframe = keyframes[i + 1]
  }
  let keyframeData = KeyframeData<T>(startValue: keyframe.value,
                                   endValue: nextKeyframe?.value,
                                   time: Double(keyframe.time),
                                   hold: keyframe.isHold ? 1 : nil,
                                   inTangent: nextKeyframe?.inTangent,
                                   outTangent: keyframe.outTangent,
                                   spatialInTangent: nil,
                                   spatialOutTangent: nil)
  try keyframeContainer.encode(keyframeData)
}
```