### PR TITLE
Add support for modifying renderScale

### DIFF
--- a/lottie-swift/src/Public/Animation/AnimationView.swift
+++ b/lottie-swift/src/Public/Animation/AnimationView.swift
@@ -74,6 +74,19 @@ final public class AnimationView: LottieView {
       }
     }
   }
+
+  /**
+   Sets the rendering scale to use for animations. If set to nil, the render scale will be
+   set to the screen scale.
+
+   The default is set to nil, which maps to the screen scale, but setting the value to 1
+   can increase performance without significant decrease to the quality of the rendering.
+   */
+  public var renderScale: CGFloat? = nil {
+    didSet {
+      animationLayer?.renderScale = self.renderScale ?? self.screenScale
+    }
+  }
   
   /**
    Describes the behavior of an AnimationView when the app is moved to the background.
@@ -815,7 +828,7 @@ final public class AnimationView: LottieView {
     }
     
     let animationLayer = AnimationContainer(animation: animation, imageProvider: imageProvider, textProvider: textProvider, fontProvider: fontProvider)
-    animationLayer.renderScale = self.screenScale
+    animationLayer.renderScale = self.renderScale ?? self.screenScale
     viewLayer?.addSublayer(animationLayer)
     self.animationLayer = animationLayer
     reloadImages()


### PR DESCRIPTION
This fixes the issues in #1325 by allowing the render scale to be set by the caller. Setting the render scale to 1 appears to significantly improve performance of animations with little visible changes in quality.

Allowing this to be set by the caller seemed to be the safest path forward, as it won't change existing behavior at all. An optional value was used to allow for the default setting of "self.screenScale" to be accessed properly, as it's not 100% clear that the self access for default values would be availble.

In testing some of our most complex animations, this resolved the issues seen related to performance changes between Lottie 2.x and Lottie 3.x.