### PR TITLE
Fix Swift performance issues. Remove renderScale and contentsScale

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/CompLayers/CompositionLayer.swift
+++ b/lottie-swift/src/Private/LayerContainers/CompLayers/CompositionLayer.swift
@@ -143,7 +143,7 @@ class CompositionLayer: CALayer, KeypathSearchable {
   }
   
   func updateRenderScale() {
-    self.contentsScale = self.renderScale
+    /// To be overridden by subclass
   }
 }
 

--- a/lottie-swift/src/Private/NodeRenderSystem/RenderLayers/ShapeContainerLayer.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/RenderLayers/ShapeContainerLayer.swift
@@ -66,7 +66,6 @@ class ShapeContainerLayer: CALayer {
   }
   
   func updateRenderScale() {
-    self.contentsScale = self.renderScale
     renderLayers.forEach( { $0.renderScale = renderScale } )
   }
   

--- a/lottie-swift/src/Private/NodeRenderSystem/RenderLayers/ShapeRenderLayer.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/RenderLayers/ShapeRenderLayer.swift
@@ -87,9 +87,4 @@ final class ShapeRenderLayer: ShapeContainerLayer {
     }
     renderer.render(ctx)
   }
-  
-  override func updateRenderScale() {
-    super.updateRenderScale()
-    shapeLayer.contentsScale = self.renderScale
-  }
 }


### PR DESCRIPTION
Related to #1325 #895 #1060 #1314 (and possibly others)

lottie-swift sets `layer.contentsScale` on every sublayer. ObjC didn't do that and this seems to explain the performance regression from 2.x to 3.x. Removing that code, I haven't found any regressions whatsoever while at the same time fixing the performance issues.

Profiling these changes gave the following insights:
* Swift contentsScale 3.0: ~70% CPU Utilization
* **Swift contentScale 1.0: ~40% CPU Utilization**
* ObjC (defaults to scale 1.0): ~37% CPU Utilization