### PR TITLE
Fix warnings with Swift 5.4

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/CompLayers/CompositionLayer.swift
+++ b/lottie-swift/src/Private/LayerContainers/CompLayers/CompositionLayer.swift
@@ -147,7 +147,7 @@ class CompositionLayer: CALayer, KeypathSearchable {
   }
 }
 
-protocol CompositionLayerDelegate: class {
+protocol CompositionLayerDelegate: AnyObject {
   func frameUpdated(frame: CGFloat)
 }
 

--- a/lottie-swift/src/Private/NodeRenderSystem/NodeProperties/Protocols/AnyValueContainer.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/NodeProperties/Protocols/AnyValueContainer.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreGraphics
 
 /// The container for the value of a property.
-protocol AnyValueContainer: class {
+protocol AnyValueContainer: AnyObject {
   
   /// The stored value of the container
   var value: Any { get }

--- a/lottie-swift/src/Private/NodeRenderSystem/Protocols/AnimatorNode.swift
+++ b/lottie-swift/src/Private/NodeRenderSystem/Protocols/AnimatorNode.swift
@@ -39,7 +39,7 @@ protocol NodeOutput {
  if the node needs an update for the current frame.
  
  */
-protocol AnimatorNode: class, KeypathSearchable {
+protocol AnimatorNode: AnyObject, KeypathSearchable {
   
   /**
    The available properties of the Node.


### PR DESCRIPTION
These are backwards compatible but using `class` here is deprecated with
Swift 5.4 so this fixes those warnings.