### PR TITLE
Masks animation container to bounds

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/AnimationContainer.swift
+++ b/lottie-swift/src/Private/LayerContainers/AnimationContainer.swift
@@ -115,6 +115,7 @@ final class AnimationContainer: CALayer {
     self.animationLayers = []
     super.init()
     bounds = animation.bounds
+    masksToBounds = true
     let layers = animation.layers.initializeCompositionLayers(assetLibrary: animation.assetLibrary, layerImageProvider: layerImageProvider, textProvider: textProvider, fontProvider: fontProvider, frameRate: CGFloat(animation.framerate))
     
     var imageLayers = [ImageCompositionLayer]()


### PR DESCRIPTION
Adding `masksToBounds` in `AnimationContainer` so the animation will only be rendered inside designated bounds which stated on animation file.

this also fixes #1338 