### PR TITLE
Add support for P3 Wide Color Gamut

### DIFF
--- a/lottie-swift/src/Private/Utility/Primitives/ColorExtension.swift
+++ b/lottie-swift/src/Private/Utility/Primitives/ColorExtension.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreGraphics
+import UIKit
 
 extension Color: Codable {
 
@@ -69,8 +70,19 @@ extension Color {
   }
   
   var cgColorValue: CGColor {
-    // TODO: Fix color spaces
-    let colorspace = CGColorSpaceCreateDeviceRGB()
-    return CGColor(colorSpace: colorspace, components: [CGFloat(r), CGFloat(g), CGFloat(b), CGFloat(a)]) ?? Color.clearColor
+    if #available(iOS 10, *), #available(tvOS 10, *) {
+      let color: UIColor
+
+      if AnimationColorSpace.shared.useP3ColorSpace {
+        color = UIColor(displayP3Red: CGFloat(r), green: CGFloat(g), blue: CGFloat(b), alpha: CGFloat(a))
+      } else {
+        color = UIColor(red: CGFloat(r), green: CGFloat(g), blue: CGFloat(b), alpha: CGFloat(a))
+      }
+
+      return color.cgColor
+    } else {
+      let colorspace = CGColorSpaceCreateDeviceRGB()
+      return CGColor(colorSpace: colorspace, components: [CGFloat(r), CGFloat(g), CGFloat(b), CGFloat(a)]) ?? Color.clearColor
+    }
   }
 }

--- a/lottie-swift/src/Public/Animation/AnimationColorSpace.swift
+++ b/lottie-swift/src/Public/Animation/AnimationColorSpace.swift
@@ -1,0 +1,18 @@
+//
+//  AnimationColorSpace.swift
+//  lottie-swift
+//
+//  Created by Kyle Fox on 5/14/21.
+//
+
+@available(iOS 10, *)
+public final class AnimationColorSpace {
+
+    public init() { }
+
+    public static let shared = AnimationColorSpace()
+
+    /// Set this variable to choose whether to use p3 Color Space in all animations.
+    public var useP3ColorSpace: Bool = false
+
+}


### PR DESCRIPTION
Fixes #958

For this PR, I intentionally went with a very simple, global setting for controlling P3 color settings, so I could solicit feedback from the maintainers before digging further! I believe a global setting will be satisfactory for most use cases, but there isn't an existing location for this type of global configuration, as far as I can tell - this simple singleton is based on `LRUAnimationCache`. It would also be necessary to configure the setting in `AnimationColorSpace` as early in the app lifecycle as possible, as this code is simple enough that it won't handle re-rendering any views to update their color space - that probably warrants an addition to the documentation, which I can also provide after merging. I chose to use an intermediary `UIColor` object before converting to `CGColor`, because that API is available in iOS 10, whereas `CGColorSpace` doesn't seem to support P3 color until later versions of iOS.

Open to any direction from the maintainers! With the recent performance improvements to Lottie Swift, this change brings us one step closer to being able to upgrade from v2.5.2 😄 