### PR TITLE
Use scanHexInt64 instead of the deprecated scanHexInt32 in iOS 13

### DIFF
--- a/lottie-swift/src/Private/Utility/Extensions/StringExtensions.swift
+++ b/lottie-swift/src/Private/Utility/Extensions/StringExtensions.swift
@@ -22,8 +22,8 @@ extension String {
       return (red: 0, green: 0, blue: 0)
     }
     
-    var rgbValue:UInt32 = 0
-    Scanner(string: cString).scanHexInt32(&rgbValue)
+    var rgbValue:UInt64 = 0
+    Scanner(string: cString).scanHexInt64(&rgbValue)
     
     return (red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
             green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,


### PR DESCRIPTION
If you build Lottie-Swift with a deployment target of iOS 13 and treat warnings as errors, the error `'scanHexInt32' was deprecated in iOS 13.0` comes up. 

This PR should fix it without side effects.