### PR TITLE
Add support for Animation init with a dictionary (2-10x faster decoding)

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -7,6 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0CF66489267A96B900B75456 /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF66488267A96B900B75456 /* DictionaryInitializable.swift */; };
+		0CF6648A267A96B900B75456 /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF66488267A96B900B75456 /* DictionaryInitializable.swift */; };
+		0CF6648B267A96B900B75456 /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF66488267A96B900B75456 /* DictionaryInitializable.swift */; };
+		0CF6648C267A96B900B75456 /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF66488267A96B900B75456 /* DictionaryInitializable.swift */; };
+		0CF6648D267A96B900B75456 /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF66488267A96B900B75456 /* DictionaryInitializable.swift */; };
+		0CF6648F267BB50400B75456 /* CGPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF6648E267BB50400B75456 /* CGPointExtensions.swift */; };
+		0CF66490267BB50400B75456 /* CGPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF6648E267BB50400B75456 /* CGPointExtensions.swift */; };
+		0CF66491267BB50400B75456 /* CGPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF6648E267BB50400B75456 /* CGPointExtensions.swift */; };
+		0CF66492267BB50400B75456 /* CGPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF6648E267BB50400B75456 /* CGPointExtensions.swift */; };
+		0CF66493267BB50400B75456 /* CGPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF6648E267BB50400B75456 /* CGPointExtensions.swift */; };
 		25D5436F22306E2D00ED90FA /* CompatibleAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D5436E22306E2D00ED90FA /* CompatibleAnimationView.swift */; };
 		25D543712230787900ED90FA /* CompatibleAnimationKeypath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D543702230787900ED90FA /* CompatibleAnimationKeypath.swift */; };
 		25D5437222307C8700ED90FA /* CompatibleAnimationKeypath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D543702230787900ED90FA /* CompatibleAnimationKeypath.swift */; };
@@ -665,6 +675,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0CF66488267A96B900B75456 /* DictionaryInitializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryInitializable.swift; sourceTree = "<group>"; };
+		0CF6648E267BB50400B75456 /* CGPointExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGPointExtensions.swift; sourceTree = "<group>"; };
 		25D5436E22306E2D00ED90FA /* CompatibleAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibleAnimationView.swift; sourceTree = "<group>"; };
 		25D543702230787900ED90FA /* CompatibleAnimationKeypath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibleAnimationKeypath.swift; sourceTree = "<group>"; };
 		4866744022249C4E00258C00 /* TextAnimatorNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextAnimatorNode.swift; sourceTree = "<group>"; };
@@ -1325,9 +1337,11 @@
 			isa = PBXGroup;
 			children = (
 				486E8790220B78BF007CD915 /* CGFloatExtensions.swift */,
+				0CF6648E267BB50400B75456 /* CGPointExtensions.swift */,
 				486E8791220B78BF007CD915 /* AnimationKeypathExtension.swift */,
 				486E8792220B78BF007CD915 /* MathKit.swift */,
 				486E8793220B78BF007CD915 /* StringExtensions.swift */,
+				0CF66488267A96B900B75456 /* DictionaryInitializable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1590,6 +1604,7 @@
 				486E87A8220B78D1007CD915 /* UIColorExtension.swift in Sources */,
 				486E87A9220B78D1007CD915 /* AnimatedButton.swift in Sources */,
 				486E87AA220B78D1007CD915 /* LottieView.swift in Sources */,
+				0CF6648F267BB50400B75456 /* CGPointExtensions.swift in Sources */,
 				486E87AB220B78D1007CD915 /* AnimationSubview.swift in Sources */,
 				486E87AC220B78D1007CD915 /* AnimatedControl.swift in Sources */,
 				486E87AD220B78D1007CD915 /* AnimationTime.swift in Sources */,
@@ -1668,6 +1683,7 @@
 				486E87F2220B78D1007CD915 /* Rectangle.swift in Sources */,
 				4899B00824DB2A3D00194C96 /* TextLayer.swift in Sources */,
 				486E87F3220B78D1007CD915 /* Star.swift in Sources */,
+				0CF66489267A96B900B75456 /* DictionaryInitializable.swift in Sources */,
 				486E87F4220B78D1007CD915 /* SolidLayerModel.swift in Sources */,
 				486E87F5220B78D1007CD915 /* LayerModel.swift in Sources */,
 				486E87F6220B78D1007CD915 /* ImageLayerModel.swift in Sources */,
@@ -1728,6 +1744,7 @@
 				486E8821220B78E4007CD915 /* UIColorExtension.swift in Sources */,
 				486E8822220B78E4007CD915 /* AnimatedButton.swift in Sources */,
 				486E8823220B78E4007CD915 /* LottieView.swift in Sources */,
+				0CF66490267BB50400B75456 /* CGPointExtensions.swift in Sources */,
 				486E8824220B78E4007CD915 /* AnimationSubview.swift in Sources */,
 				486E8825220B78E4007CD915 /* AnimatedControl.swift in Sources */,
 				486E8826220B78E4007CD915 /* AnimationTime.swift in Sources */,
@@ -1806,6 +1823,7 @@
 				486E886B220B78E4007CD915 /* Rectangle.swift in Sources */,
 				4899B00924DB2A3D00194C96 /* TextLayer.swift in Sources */,
 				486E886C220B78E4007CD915 /* Star.swift in Sources */,
+				0CF6648A267A96B900B75456 /* DictionaryInitializable.swift in Sources */,
 				486E886D220B78E4007CD915 /* SolidLayerModel.swift in Sources */,
 				486E886E220B78E4007CD915 /* LayerModel.swift in Sources */,
 				486E886F220B78E4007CD915 /* ImageLayerModel.swift in Sources */,
@@ -1908,6 +1926,7 @@
 				486E88CA220B78F4007CD915 /* AnyValueContainer.swift in Sources */,
 				486E88CB220B78F4007CD915 /* KeyframeInterpolator.swift in Sources */,
 				486E88CC220B78F4007CD915 /* SingleValueProvider.swift in Sources */,
+				0CF66491267BB50400B75456 /* CGPointExtensions.swift in Sources */,
 				486E88CD220B78F4007CD915 /* GroupInterpolator.swift in Sources */,
 				486E88CE220B78F4007CD915 /* ItemsExtension.swift in Sources */,
 				486E88CF220B78F4007CD915 /* ShapeRenderLayer.swift in Sources */,
@@ -1934,6 +1953,7 @@
 				486E88E3220B78F4007CD915 /* LayerModel.swift in Sources */,
 				486E88E4220B78F4007CD915 /* ImageLayerModel.swift in Sources */,
 				486E88E5220B78F4007CD915 /* TextLayerModel.swift in Sources */,
+				0CF6648B267A96B900B75456 /* DictionaryInitializable.swift in Sources */,
 				486E88E6220B78F4007CD915 /* PreCompLayerModel.swift in Sources */,
 				486E88E7220B78F4007CD915 /* ShapeLayerModel.swift in Sources */,
 				486E88E8220B78F4007CD915 /* Animation.swift in Sources */,
@@ -1998,6 +2018,7 @@
 				486E890E220B78FF007CD915 /* BundleImageProvider.swift in Sources */,
 				486E890F220B78FF007CD915 /* UIColorExtension.swift in Sources */,
 				486E8910220B78FF007CD915 /* AnimatedButton.swift in Sources */,
+				0CF66492267BB50400B75456 /* CGPointExtensions.swift in Sources */,
 				486E8911220B78FF007CD915 /* LottieView.swift in Sources */,
 				486E8912220B78FF007CD915 /* AnimationSubview.swift in Sources */,
 				486E8913220B78FF007CD915 /* AnimatedControl.swift in Sources */,
@@ -2076,6 +2097,7 @@
 				486E8959220B78FF007CD915 /* Rectangle.swift in Sources */,
 				4899B00B24DB2A3D00194C96 /* TextLayer.swift in Sources */,
 				486E895A220B78FF007CD915 /* Star.swift in Sources */,
+				0CF6648C267A96B900B75456 /* DictionaryInitializable.swift in Sources */,
 				486E895B220B78FF007CD915 /* SolidLayerModel.swift in Sources */,
 				486E895C220B78FF007CD915 /* LayerModel.swift in Sources */,
 				486E895D220B78FF007CD915 /* ImageLayerModel.swift in Sources */,
@@ -2178,6 +2200,7 @@
 				486E89B7220B790E007CD915 /* KeypathSearchable.swift in Sources */,
 				486E89B8220B790E007CD915 /* AnyValueContainer.swift in Sources */,
 				486E89B9220B790E007CD915 /* KeyframeInterpolator.swift in Sources */,
+				0CF66493267BB50400B75456 /* CGPointExtensions.swift in Sources */,
 				486E89BA220B790E007CD915 /* SingleValueProvider.swift in Sources */,
 				486E89BB220B790E007CD915 /* GroupInterpolator.swift in Sources */,
 				486E89BC220B790E007CD915 /* ItemsExtension.swift in Sources */,
@@ -2204,6 +2227,7 @@
 				486E89D0220B790E007CD915 /* SolidLayerModel.swift in Sources */,
 				486E89D1220B790E007CD915 /* LayerModel.swift in Sources */,
 				486E89D2220B790E007CD915 /* ImageLayerModel.swift in Sources */,
+				0CF6648D267A96B900B75456 /* DictionaryInitializable.swift in Sources */,
 				486E89D3220B790E007CD915 /* TextLayerModel.swift in Sources */,
 				486E89D4220B790E007CD915 /* PreCompLayerModel.swift in Sources */,
 				486E89D5220B790E007CD915 /* ShapeLayerModel.swift in Sources */,

--- a/lottie-swift/src/Private/Model/Assets/Asset.swift
+++ b/lottie-swift/src/Private/Model/Assets/Asset.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class Asset: Codable {
+public class Asset: Codable, DictionaryInitializable {
   
   /// The ID of the asset
   public let id: String
@@ -22,6 +22,16 @@ public class Asset: Codable {
       self.id = id
     } else {
       self.id = String(try container.decode(Int.self, forKey: .id))
+    }
+  }
+  
+  required init(dictionary: [String : Any]) throws {
+    if let id = dictionary[CodingKeys.id.rawValue] as? String {
+      self.id = id
+    } else if let id = dictionary[CodingKeys.id.rawValue] as? Int {
+      self.id = String(id)
+    } else {
+      throw InitializableError.invalidInput
     }
   }
 }

--- a/lottie-swift/src/Private/Model/Assets/AssetLibrary.swift
+++ b/lottie-swift/src/Private/Model/Assets/AssetLibrary.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class AssetLibrary: Codable {
+final class AssetLibrary: Codable, AnyInitializable {
   
   /// The Assets
   let assets: [String : Asset]
@@ -44,5 +44,28 @@ final class AssetLibrary: Codable {
   func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
     try container.encode(contentsOf: Array(assets.values))
+  }
+  
+  init(value: Any) throws {
+    guard let dictionaries = value as? [[String: Any]] else {
+      throw InitializableError.invalidInput
+    }
+    var decodedAssets = [String : Asset]()
+    var imageAssets = [String : ImageAsset]()
+    var precompAssets = [String : PrecompAsset]()
+    try dictionaries.forEach { dictionary in
+      if dictionary[PrecompAsset.CodingKeys.layers.rawValue] != nil {
+        let asset = try PrecompAsset(dictionary: dictionary)
+        decodedAssets[asset.id] = asset
+        precompAssets[asset.id] = asset
+      } else {
+        let asset = try ImageAsset(dictionary: dictionary)
+        decodedAssets[asset.id] = asset
+        imageAssets[asset.id] = asset
+      }
+    }
+    self.assets = decodedAssets
+    self.precompAssets = precompAssets
+    self.imageAssets = imageAssets
   }
 }

--- a/lottie-swift/src/Private/Model/Assets/ImageAsset.swift
+++ b/lottie-swift/src/Private/Model/Assets/ImageAsset.swift
@@ -44,5 +44,13 @@ public final class ImageAsset: Asset {
     try container.encode(width, forKey: .width)
     try container.encode(height, forKey: .height)
   }
-
+  
+  required init(dictionary: [String : Any]) throws {
+    self.name = try dictionary.valueFor(key: CodingKeys.name.rawValue)
+    self.directory = try dictionary.valueFor(key: CodingKeys.directory.rawValue)
+    self.width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    self.height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/Assets/PrecompAsset.swift
+++ b/lottie-swift/src/Private/Model/Assets/PrecompAsset.swift
@@ -27,4 +27,10 @@ final class PrecompAsset: Asset {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(layers, forKey: .layers)
   }
+
+  required init(dictionary: [String : Any]) throws {
+    let layerDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.layers.rawValue)
+    self.layers = try [LayerModel].fromDictionaries(layerDictionaries)
+    try super.init(dictionary: dictionary)
+  }
 }

--- a/lottie-swift/src/Private/Model/Keyframes/Keyframe.swift
+++ b/lottie-swift/src/Private/Model/Keyframes/Keyframe.swift
@@ -69,7 +69,7 @@ final class Keyframe<T: Interpolatable> {
  type of keyframea and also the version of the JSON. By parsing the raw data
  we can reconfigure it into a constant format.
  */
-final class KeyframeData<T: Codable>: Codable {
+final class KeyframeData<T>: Codable, DictionaryInitializable where T: Codable, T: AnyInitializable {
   
   /// The start value of the keyframe
   let startValue: T?
@@ -106,6 +106,41 @@ final class KeyframeData<T: Codable>: Codable {
     self.outTangent = outTangent
     self.spatialInTangent = spatialInTangent
     self.spatialOutTangent = spatialOutTangent
+  }
+  
+  init(dictionary: [String : Any]) throws {
+    if let rawValue = dictionary[CodingKeys.startValue.rawValue] {
+      self.startValue = try? T(value: rawValue)
+    } else {
+      self.startValue = nil
+    }
+    if let rawValue = dictionary[CodingKeys.endValue.rawValue] {
+      self.endValue = try? T(value: rawValue)
+    } else {
+      self.endValue = nil
+    }
+    self.time = try? dictionary.valueFor(key: CodingKeys.time.rawValue)
+    self.hold = try? dictionary.valueFor(key: CodingKeys.hold.rawValue)
+    if let rawValue = dictionary[CodingKeys.inTangent.rawValue] {
+      self.inTangent = try? Vector2D(value: rawValue)
+    } else {
+      self.inTangent = nil
+    }
+    if let rawValue = dictionary[CodingKeys.outTangent.rawValue] {
+      self.outTangent = try? Vector2D(value: rawValue)
+    } else {
+      self.outTangent = nil
+    }
+    if let rawValue = dictionary[CodingKeys.spatialInTangent.rawValue] {
+      self.spatialInTangent = try? Vector3D(value: rawValue)
+    } else {
+      self.spatialInTangent = nil
+    }
+    if let rawValue = dictionary[CodingKeys.spatialOutTangent.rawValue] {
+      self.spatialOutTangent = try? Vector3D(value: rawValue)
+    } else {
+      self.spatialOutTangent = nil
+    }
   }
   
   enum CodingKeys : String, CodingKey {

--- a/lottie-swift/src/Private/Model/Layers/ImageLayerModel.swift
+++ b/lottie-swift/src/Private/Model/Layers/ImageLayerModel.swift
@@ -29,4 +29,9 @@ final class ImageLayerModel: LayerModel {
     try container.encode(referenceID, forKey: .referenceID)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    self.referenceID = try dictionary.valueFor(key: CodingKeys.referenceID.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/Layers/PreCompLayerModel.swift
+++ b/lottie-swift/src/Private/Model/Layers/PreCompLayerModel.swift
@@ -47,4 +47,16 @@ final class PreCompLayerModel: LayerModel {
     try container.encode(height, forKey: .height)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    self.referenceID = try dictionary.valueFor(key: CodingKeys.referenceID.rawValue)
+    if let timeRemappingDictionary = dictionary[CodingKeys.timeRemapping.rawValue] as? [String: Any] {
+      self.timeRemapping = try KeyframeGroup<Vector1D>(dictionary: timeRemappingDictionary)
+    } else {
+      self.timeRemapping = nil
+    }
+    self.width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    self.height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/Layers/ShapeLayerModel.swift
+++ b/lottie-swift/src/Private/Model/Layers/ShapeLayerModel.swift
@@ -29,4 +29,10 @@ final class ShapeLayerModel: LayerModel {
     try container.encode(self.items, forKey: .items)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    let itemDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.items.rawValue)
+    self.items = try [ShapeItem].fromDictionaries(itemDictionaries)
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/Layers/SolidLayerModel.swift
+++ b/lottie-swift/src/Private/Model/Layers/SolidLayerModel.swift
@@ -41,4 +41,11 @@ final class SolidLayerModel: LayerModel {
     try container.encode(height, forKey: .height)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    self.colorHex = try dictionary.valueFor(key: CodingKeys.colorHex.rawValue)
+    self.width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    self.height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/Layers/TextLayerModel.swift
+++ b/lottie-swift/src/Private/Model/Layers/TextLayerModel.swift
@@ -41,4 +41,13 @@ final class TextLayerModel: LayerModel {
     try textContainer.encode(animators, forKey: .animators)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    let containerDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.textGroup.rawValue)
+    let textDictionary: [String: Any] = try containerDictionary.valueFor(key: TextCodingKeys.text.rawValue)
+    self.text = try KeyframeGroup<TextDocument>(dictionary: textDictionary)
+    let animatorDictionaries: [[String: Any]] = try containerDictionary.valueFor(key: TextCodingKeys.animators.rawValue)
+    self.animators = try animatorDictionaries.map({ try TextAnimator(dictionary: $0) })
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/Objects/DashPattern.swift
+++ b/lottie-swift/src/Private/Model/Objects/DashPattern.swift
@@ -13,12 +13,22 @@ enum DashElementType: String, Codable {
   case gap = "g"
 }
 
-final class DashElement: Codable {
+final class DashElement: Codable, DictionaryInitializable {
   let type: DashElementType
   let value: KeyframeGroup<Vector1D>
   
   enum CodingKeys : String, CodingKey {
     case type = "n"
     case value = "v"
+  }
+  
+  init(dictionary: [String : Any]) throws {
+    let typeRawValue: String = try dictionary.valueFor(key: CodingKeys.type.rawValue)
+    guard let type = DashElementType(rawValue: typeRawValue) else {
+      throw InitializableError.invalidInput
+    }
+    self.type = type
+    let valueDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.value.rawValue)
+    self.value = try KeyframeGroup<Vector1D>(dictionary: valueDictionary)
   }
 }

--- a/lottie-swift/src/Private/Model/Objects/Marker.swift
+++ b/lottie-swift/src/Private/Model/Objects/Marker.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A time marker
-final class Marker: Codable {
+final class Marker: Codable, DictionaryInitializable {
   
   /// The Marker Name
   let name: String
@@ -19,5 +19,10 @@ final class Marker: Codable {
   enum CodingKeys : String, CodingKey {
     case name = "cm"
     case frameTime = "tm"
+  }
+
+  init(dictionary: [String : Any]) throws {
+    self.name = try dictionary.valueFor(key: CodingKeys.name.rawValue)
+    self.frameTime = try dictionary.valueFor(key: CodingKeys.frameTime.rawValue)
   }
 }

--- a/lottie-swift/src/Private/Model/Objects/Mask.swift
+++ b/lottie-swift/src/Private/Model/Objects/Mask.swift
@@ -17,7 +17,7 @@ enum MaskMode: String, Codable {
   case none = "n"
 }
 
-final class Mask: Codable {
+final class Mask: Codable, DictionaryInitializable {
   
   let mode: MaskMode
   
@@ -44,5 +44,27 @@ final class Mask: Codable {
     self.shape = try container.decode(KeyframeGroup<BezierPath>.self, forKey: .shape)
     self.inverted = try container.decodeIfPresent(Bool.self, forKey: .inverted) ?? false
     self.expansion = try container.decodeIfPresent(KeyframeGroup<Vector1D>.self, forKey: .expansion) ?? KeyframeGroup(Vector1D(0))
+  }
+  
+  init(dictionary: [String : Any]) throws {
+    if let modeRawType = dictionary[CodingKeys.mode.rawValue] as? String,
+       let mode = MaskMode(rawValue: modeRawType) {
+      self.mode = mode
+    } else {
+      self.mode = .add
+    }
+    if let opacityDictionary = dictionary[CodingKeys.opacity.rawValue] as? [String: Any] {
+      self.opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    } else {
+      self.opacity = KeyframeGroup(Vector1D(100))
+    }
+    let shapeDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.shape.rawValue)
+    self.shape = try KeyframeGroup<BezierPath>(dictionary: shapeDictionary)
+    self.inverted = (try? dictionary.valueFor(key: CodingKeys.inverted.rawValue)) ?? false
+    if let expansionDictionary = dictionary[CodingKeys.expansion.rawValue] as? [String: Any] {
+      self.expansion = try KeyframeGroup<Vector1D>(dictionary: expansionDictionary)
+    } else {
+      self.expansion = KeyframeGroup(Vector1D(0))
+    }
   }
 }

--- a/lottie-swift/src/Private/Model/Objects/Transform.swift
+++ b/lottie-swift/src/Private/Model/Objects/Transform.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The animatable transform for a layer. Controls position, rotation, scale, and opacity.
-final class Transform: Codable {
+final class Transform: Codable, DictionaryInitializable {
   
   /// The anchor point of the transform.
   let anchorPoint: KeyframeGroup<Vector3D>
@@ -101,5 +101,59 @@ final class Transform: Codable {
     
     // Opacity
     self.opacity = try container.decodeIfPresent(KeyframeGroup<Vector1D>.self, forKey: .opacity) ?? KeyframeGroup(Vector1D(100))
+  }
+  
+  init(dictionary: [String : Any]) throws {
+    if let anchorPointDictionary = dictionary[CodingKeys.anchorPoint.rawValue] as? [String: Any],
+       let anchorPoint = try? KeyframeGroup<Vector3D>(dictionary: anchorPointDictionary) {
+      self.anchorPoint = anchorPoint
+    } else {
+      self.anchorPoint = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+    
+    if let xDictionary = dictionary[CodingKeys.positionX.rawValue] as? [String: Any],
+       let yDictionary = dictionary[CodingKeys.positionY.rawValue] as? [String: Any] {
+      self.positionX = try KeyframeGroup<Vector1D>(dictionary: xDictionary)
+      self.positionY = try KeyframeGroup<Vector1D>(dictionary: yDictionary)
+      self.position = nil
+    } else if let positionDictionary = dictionary[CodingKeys.position.rawValue] as? [String: Any],
+              positionDictionary[KeyframeGroup<Vector3D>.KeyframeWrapperKey.keyframeData.rawValue] != nil {
+      self.position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+      self.positionX = nil
+      self.positionY = nil
+    } else if let positionDictionary = dictionary[CodingKeys.position.rawValue] as? [String: Any],
+              let xDictionary = positionDictionary[PositionCodingKeys.positionX.rawValue] as? [String: Any],
+              let yDictionary = positionDictionary[PositionCodingKeys.positionY.rawValue] as? [String: Any] {
+      self.positionX = try KeyframeGroup<Vector1D>(dictionary: xDictionary)
+      self.positionY = try KeyframeGroup<Vector1D>(dictionary: yDictionary)
+      self.position = nil
+    } else {
+      self.position = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+      self.positionX = nil
+      self.positionY = nil
+    }
+    
+    if let scaleDictionary = dictionary[CodingKeys.scale.rawValue] as? [String: Any],
+       let scale = try? KeyframeGroup<Vector3D>(dictionary: scaleDictionary) {
+      self.scale = scale
+    } else {
+      self.scale = KeyframeGroup(Vector3D(x: Double(100), y: 100, z: 100))
+    }
+    if let rotationDictionary = dictionary[CodingKeys.rotationZ.rawValue] as? [String: Any],
+       let rotation = try? KeyframeGroup<Vector1D>(dictionary: rotationDictionary) {
+      self.rotation = rotation
+    } else if let rotationDictionary = dictionary[CodingKeys.rotation.rawValue] as? [String: Any],
+              let rotation = try? KeyframeGroup<Vector1D>(dictionary: rotationDictionary) {
+      self.rotation = rotation
+    } else {
+      self.rotation = KeyframeGroup(Vector1D(0))
+    }
+    self.rotationZ = nil
+    if let opacityDictionary = dictionary[CodingKeys.opacity.rawValue] as? [String: Any],
+       let opacity = try? KeyframeGroup<Vector1D>(dictionary: opacityDictionary) {
+      self.opacity = opacity
+    } else {
+      self.opacity = KeyframeGroup(Vector1D(100))
+    }
   }
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/Ellipse.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/Ellipse.swift
@@ -47,4 +47,18 @@ final class Ellipse: ShapeItem {
     try container.encode(size, forKey: .size)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    if let directionRawType = dictionary[CodingKeys.direction.rawValue] as? Int,
+       let direction = PathDirection(rawValue: directionRawType) {
+      self.direction = direction
+    } else {
+      self.direction = .clockwise
+    }
+    let positionDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.position.rawValue)
+    self.position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    let sizeDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.size.rawValue)
+    self.size = try KeyframeGroup<Vector3D>(dictionary: sizeDictionary)
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/FillI.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/FillI.swift
@@ -46,4 +46,18 @@ final class Fill: ShapeItem {
     try container.encode(fillRule, forKey: .fillRule)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    self.opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    let colorDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.color.rawValue)
+    self.color = try KeyframeGroup<Color>(dictionary: colorDictionary)
+    if let fillRuleRawValue = dictionary[CodingKeys.fillRule.rawValue] as? Int,
+       let fillRule = FillRule(rawValue: fillRuleRawValue) {
+      self.fillRule = fillRule
+    } else {
+      self.fillRule = .nonZeroWinding
+    }
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/GradientFill.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/GradientFill.swift
@@ -83,4 +83,33 @@ final class GradientFill: ShapeItem {
     try colorsContainer.encode(colors, forKey: .colors)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    self.opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    let startPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.startPoint.rawValue)
+    self.startPoint = try KeyframeGroup<Vector3D>(dictionary: startPointDictionary)
+    let endPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.endPoint.rawValue)
+    self.endPoint = try KeyframeGroup<Vector3D>(dictionary: endPointDictionary)
+    let gradientRawType: Int = try dictionary.valueFor(key: CodingKeys.gradientType.rawValue)
+    guard let gradient = GradientType(rawValue: gradientRawType) else {
+      throw InitializableError.invalidInput
+    }
+    self.gradientType = gradient
+    if let highlightLengthDictionary = dictionary[CodingKeys.highlightLength.rawValue] as? [String: Any] {
+      self.highlightLength = try? KeyframeGroup<Vector1D>(dictionary: highlightLengthDictionary)
+    } else {
+      self.highlightLength = nil
+    }
+    if let highlightAngleDictionary = dictionary[CodingKeys.highlightAngle.rawValue] as? [String: Any] {
+      self.highlightAngle = try? KeyframeGroup<Vector1D>(dictionary: highlightAngleDictionary)
+    } else {
+      self.highlightAngle = nil
+    }
+    let colorsDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.colors.rawValue)
+    let nestedColorsDictionary: [String: Any] = try colorsDictionary.valueFor(key: GradientDataKeys.colors.rawValue)
+    self.colors = try KeyframeGroup<[Double]>(dictionary: nestedColorsDictionary)
+    self.numberOfColors = try colorsDictionary.valueFor(key: GradientDataKeys.numberOfColors.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/GradientStroke.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/GradientStroke.swift
@@ -122,4 +122,50 @@ final class GradientStroke: ShapeItem {
     try container.encodeIfPresent(dashPattern, forKey: .dashPattern)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    self.opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    let startPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.startPoint.rawValue)
+    self.startPoint = try KeyframeGroup<Vector3D>(dictionary: startPointDictionary)
+    let endPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.endPoint.rawValue)
+    self.endPoint = try KeyframeGroup<Vector3D>(dictionary: endPointDictionary)
+    let gradientRawType: Int = try dictionary.valueFor(key: CodingKeys.gradientType.rawValue)
+    guard let gradient = GradientType(rawValue: gradientRawType) else {
+      throw InitializableError.invalidInput
+    }
+    self.gradientType = gradient
+    if let highlightLengthDictionary = dictionary[CodingKeys.highlightLength.rawValue] as? [String: Any] {
+      self.highlightLength = try? KeyframeGroup<Vector1D>(dictionary: highlightLengthDictionary)
+    } else {
+      self.highlightLength = nil
+    }
+    if let highlightAngleDictionary = dictionary[CodingKeys.highlightAngle.rawValue] as? [String: Any] {
+      self.highlightAngle = try? KeyframeGroup<Vector1D>(dictionary: highlightAngleDictionary)
+    } else {
+      self.highlightAngle = nil
+    }
+    let widthDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    self.width = try KeyframeGroup<Vector1D>(dictionary: widthDictionary)
+    if let lineCapRawValue = dictionary[CodingKeys.lineCap.rawValue] as? Int,
+       let lineCap = LineCap(rawValue: lineCapRawValue) {
+      self.lineCap = lineCap
+    } else {
+      self.lineCap = .round
+    }
+    if let lineJoinRawValue = dictionary[CodingKeys.lineJoin.rawValue] as? Int,
+       let lineJoin = LineJoin(rawValue: lineJoinRawValue) {
+      self.lineJoin = lineJoin
+    } else {
+      self.lineJoin = .round
+    }
+    self.miterLimit = (try? dictionary.valueFor(key: CodingKeys.miterLimit.rawValue)) ?? 4
+    let colorsDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.colors.rawValue)
+    let nestedColorsDictionary: [String: Any] = try colorsDictionary.valueFor(key: GradientDataKeys.colors.rawValue)
+    self.colors = try KeyframeGroup<[Double]>(dictionary: nestedColorsDictionary)
+    self.numberOfColors = try colorsDictionary.valueFor(key: GradientDataKeys.numberOfColors.rawValue)
+    let dashPatternDictionaries = dictionary[CodingKeys.dashPattern.rawValue] as? [[String: Any]]
+    self.dashPattern = try? dashPatternDictionaries?.map({ try DashElement(dictionary: $0) })
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/Group.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/Group.swift
@@ -28,5 +28,11 @@ final class Group: ShapeItem {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(items, forKey: .items)
   }
-
+  
+  required init(dictionary: [String : Any]) throws {
+    let itemDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.items.rawValue)
+    self.items = try [ShapeItem].fromDictionaries(itemDictionaries)
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/Merge.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/Merge.swift
@@ -38,4 +38,13 @@ final class Merge: ShapeItem {
     try container.encode(mode, forKey: .mode)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    let modeRawType: Int = try dictionary.valueFor(key: CodingKeys.mode.rawValue)
+    guard let mode = MergeMode(rawValue: modeRawType) else {
+      throw InitializableError.invalidInput
+    }
+    self.mode = mode
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/Rectangle.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/Rectangle.swift
@@ -46,5 +46,21 @@ final class Rectangle: ShapeItem {
     try container.encode(size, forKey: .size)
     try container.encode(cornerRadius, forKey: .cornerRadius)
   }
+
+  required init(dictionary: [String : Any]) throws {
+    if let directionRawType = dictionary[CodingKeys.direction.rawValue] as? Int,
+       let direction = PathDirection(rawValue: directionRawType) {
+      self.direction = direction
+    } else {
+      self.direction = .clockwise
+    }
+    let positionDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.position.rawValue)
+    self.position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    let sizeDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.size.rawValue)
+    self.size = try KeyframeGroup<Vector3D>(dictionary: sizeDictionary)
+    let cornerRadiusDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.cornerRadius.rawValue)
+    self.cornerRadius = try KeyframeGroup<Vector1D>(dictionary: cornerRadiusDictionary)
+    try super.init(dictionary: dictionary)
+  }
   
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/Repeater.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/Repeater.swift
@@ -77,4 +77,49 @@ final class Repeater: ShapeItem {
     try transformContainer.encode(scale, forKey: .scale)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    if let copiesDictionary = dictionary[CodingKeys.copies.rawValue] as? [String: Any] {
+      self.copies = try KeyframeGroup<Vector1D>(dictionary: copiesDictionary)
+    } else {
+      self.copies = KeyframeGroup(Vector1D(0))
+    }
+    if let offsetDictionary = dictionary[CodingKeys.offset.rawValue] as? [String: Any] {
+      self.offset = try KeyframeGroup<Vector1D>(dictionary: offsetDictionary)
+    } else {
+      self.offset = KeyframeGroup(Vector1D(0))
+    }
+    let transformDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.transform.rawValue)
+    if let startOpacityDictionary = transformDictionary[TransformKeys.startOpacity.rawValue] as? [String: Any] {
+      self.startOpacity = try KeyframeGroup<Vector1D>(dictionary: startOpacityDictionary)
+    } else {
+      self.startOpacity = KeyframeGroup(Vector1D(100))
+    }
+    if let endOpacityDictionary = transformDictionary[TransformKeys.endOpacity.rawValue] as? [String: Any] {
+      self.endOpacity = try KeyframeGroup<Vector1D>(dictionary: endOpacityDictionary)
+    } else {
+      self.endOpacity = KeyframeGroup(Vector1D(100))
+    }
+    if let rotationDictionary = transformDictionary[TransformKeys.rotation.rawValue] as? [String: Any] {
+      self.rotation = try KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
+    } else {
+      self.rotation = KeyframeGroup(Vector1D(0))
+    }
+    if let positionDictionary = transformDictionary[TransformKeys.position.rawValue] as? [String: Any] {
+      self.position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    } else {
+      self.position = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+    if let anchorPointDictionary = transformDictionary[TransformKeys.anchorPoint.rawValue] as? [String: Any] {
+      self.anchorPoint = try KeyframeGroup<Vector3D>(dictionary: anchorPointDictionary)
+    } else {
+      self.anchorPoint = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+    if let scaleDictionary = transformDictionary[TransformKeys.scale.rawValue] as? [String: Any] {
+      self.scale = try KeyframeGroup<Vector3D>(dictionary: scaleDictionary)
+    } else {
+      self.scale = KeyframeGroup(Vector3D(x: Double(100), y: 100, z: 100))
+    }
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/Shape.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/Shape.swift
@@ -34,4 +34,16 @@ final class Shape: ShapeItem {
     try container.encodeIfPresent(direction, forKey: .direction)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    let pathDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.path.rawValue)
+    self.path = try KeyframeGroup<BezierPath>(dictionary: pathDictionary)
+    if let directionRawValue = dictionary[CodingKeys.direction.rawValue] as? Int,
+       let direction = PathDirection(rawValue: directionRawValue) {
+      self.direction = direction
+    } else {
+      self.direction = nil
+    }
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/ShapeItem.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/ShapeItem.swift
@@ -69,7 +69,7 @@ enum ShapeType: String, Codable {
 }
 
 /// An item belonging to a Shape Layer
-class ShapeItem: Codable {
+class ShapeItem: Codable, DictionaryInitializable {
   
   /// The name of the shape
   let name: String
@@ -79,7 +79,7 @@ class ShapeItem: Codable {
   
   let hidden: Bool
   
-  private enum CodingKeys : String, CodingKey {
+  fileprivate enum CodingKeys : String, CodingKey {
     case name = "nm"
     case type = "ty"
     case hidden = "hd"
@@ -91,5 +91,53 @@ class ShapeItem: Codable {
     self.type = try container.decode(ShapeType.self, forKey: .type)
     self.hidden = try container.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
   }
+  
+  required init(dictionary: [String : Any]) throws {
+    self.name = (try? dictionary.valueFor(key: CodingKeys.name.rawValue)) ?? "Layer"
+    self.type = ShapeType(rawValue: try dictionary.valueFor(key: CodingKeys.type.rawValue)) ?? .unknown
+    self.hidden = (try? dictionary.valueFor(key: CodingKeys.hidden.rawValue)) ?? false
+  }
+  
+}
 
+extension Array where Element == ShapeItem {
+  
+  static func fromDictionaries(_ dictionaries: [[String: Any]]) throws -> [ShapeItem] {
+    return try dictionaries.compactMap { dictionary in
+      let shapeType = dictionary[ShapeItem.CodingKeys.type.rawValue] as? String
+      switch ShapeType(rawValue: shapeType ?? ShapeType.unknown.rawValue) {
+      case .ellipse:
+        return try Ellipse(dictionary: dictionary)
+      case .fill:
+        return try Fill(dictionary: dictionary)
+      case .gradientFill:
+        return try GradientFill(dictionary: dictionary)
+      case .group:
+        return try Group(dictionary: dictionary)
+      case .gradientStroke:
+        return try GradientStroke(dictionary: dictionary)
+      case .merge:
+        return try Merge(dictionary: dictionary)
+      case .rectangle:
+        return try Rectangle(dictionary: dictionary)
+      case .repeater:
+        return try Repeater(dictionary: dictionary)
+      case .shape:
+        return try Shape(dictionary: dictionary)
+      case .star:
+        return try Star(dictionary: dictionary)
+      case .stroke:
+        return try Stroke(dictionary: dictionary)
+      case .trim:
+        return try Trim(dictionary: dictionary)
+      case .transform:
+        return try ShapeTransform(dictionary: dictionary)
+      case .none:
+        return nil
+      default:
+        return try ShapeItem(dictionary: dictionary)
+      }
+    }
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/ShapeTransform.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/ShapeTransform.swift
@@ -65,4 +65,50 @@ final class ShapeTransform: ShapeItem {
     try container.encode(skewAxis, forKey: .skewAxis)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    if let anchorDictionary = dictionary[CodingKeys.anchor.rawValue] as? [String: Any],
+       let anchor = try? KeyframeGroup<Vector3D>(dictionary: anchorDictionary) {
+      self.anchor = anchor
+    } else {
+      self.anchor = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+    if let positionDictionary = dictionary[CodingKeys.position.rawValue] as? [String: Any],
+       let position = try? KeyframeGroup<Vector3D>(dictionary: positionDictionary) {
+      self.position = position
+    } else {
+      self.position = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+    if let scaleDictionary = dictionary[CodingKeys.scale.rawValue] as? [String: Any],
+       let scale = try? KeyframeGroup<Vector3D>(dictionary: scaleDictionary) {
+      self.scale = scale
+    } else {
+      self.scale = KeyframeGroup(Vector3D(x: Double(100), y: 100, z: 100))
+    }
+    if let rotationDictionary = dictionary[CodingKeys.rotation.rawValue] as? [String: Any],
+       let rotation = try? KeyframeGroup<Vector1D>(dictionary: rotationDictionary) {
+      self.rotation = rotation
+    } else {
+      self.rotation = KeyframeGroup(Vector1D(0))
+    }
+    if let opacityDictionary = dictionary[CodingKeys.opacity.rawValue] as? [String: Any],
+       let opacity = try? KeyframeGroup<Vector1D>(dictionary: opacityDictionary) {
+      self.opacity = opacity
+    } else {
+      self.opacity = KeyframeGroup(Vector1D(100))
+    }
+    if let skewDictionary = dictionary[CodingKeys.skew.rawValue] as? [String: Any],
+       let skew = try? KeyframeGroup<Vector1D>(dictionary: skewDictionary) {
+      self.skew = skew
+    } else {
+      self.skew = KeyframeGroup(Vector1D(0))
+    }
+    if let skewAxisDictionary = dictionary[CodingKeys.skewAxis.rawValue] as? [String: Any],
+       let skewAxis = try? KeyframeGroup<Vector1D>(dictionary: skewAxisDictionary) {
+      self.skewAxis = skewAxis
+    } else {
+      self.skewAxis = KeyframeGroup(Vector1D(0))
+    }
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/Star.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/Star.swift
@@ -83,4 +83,39 @@ final class Star: ShapeItem {
     try container.encode(starType, forKey: .starType)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    if let directionRawValue = dictionary[CodingKeys.direction.rawValue] as? Int,
+       let direction = PathDirection(rawValue: directionRawValue) {
+      self.direction = direction
+    } else {
+      self.direction = .clockwise
+    }
+    let positionDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.position.rawValue)
+    self.position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    let outerRadiusDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.outerRadius.rawValue)
+    self.outerRadius = try KeyframeGroup<Vector1D>(dictionary: outerRadiusDictionary)
+    let outerRoundnessDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.outerRoundness.rawValue)
+    self.outerRoundness = try KeyframeGroup<Vector1D>(dictionary: outerRoundnessDictionary)
+    if let innerRadiusDictionary = dictionary[CodingKeys.innerRadius.rawValue] as? [String: Any] {
+      self.innerRadius = try KeyframeGroup<Vector1D>(dictionary: innerRadiusDictionary)
+    } else {
+      self.innerRadius = nil
+    }
+    if let innerRoundnessDictionary = dictionary[CodingKeys.innerRoundness.rawValue] as? [String: Any] {
+      self.innerRoundness = try KeyframeGroup<Vector1D>(dictionary: innerRoundnessDictionary)
+    } else {
+      self.innerRoundness = nil
+    }
+    let rotationDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.rotation.rawValue)
+    self.rotation = try KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
+    let pointsDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.points.rawValue)
+    self.points = try KeyframeGroup<Vector1D>(dictionary: pointsDictionary)
+    let starTypeRawValue: Int = try dictionary.valueFor(key: CodingKeys.starType.rawValue)
+    guard let starType = StarType(rawValue: starTypeRawValue) else {
+      throw InitializableError.invalidInput
+    }
+    self.starType = starType
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/Stroke.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/Stroke.swift
@@ -64,4 +64,29 @@ final class Stroke: ShapeItem {
     try container.encode(miterLimit, forKey: .miterLimit)
     try container.encodeIfPresent(dashPattern, forKey: .dashPattern)
   }
+  
+  required init(dictionary: [String : Any]) throws {
+    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    self.opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    let colorDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.color.rawValue)
+    self.color = try KeyframeGroup<Color>(dictionary: colorDictionary)
+    let widthDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    self.width = try KeyframeGroup<Vector1D>(dictionary: widthDictionary)
+    if let lineCapRawValue = dictionary[CodingKeys.lineCap.rawValue] as? Int,
+       let lineCap = LineCap(rawValue: lineCapRawValue) {
+      self.lineCap = lineCap
+    } else {
+      self.lineCap = .round
+    }
+    if let lineJoinRawValue = dictionary[CodingKeys.lineJoin.rawValue] as? Int,
+       let lineJoin = LineJoin(rawValue: lineJoinRawValue) {
+      self.lineJoin = lineJoin
+    } else {
+      self.lineJoin = .round
+    }
+    self.miterLimit = (try? dictionary.valueFor(key: CodingKeys.miterLimit.rawValue)) ?? 4
+    let dashPatternDictionaries = dictionary[CodingKeys.dashPattern.rawValue] as? [[String: Any]]
+    self.dashPattern = try? dashPatternDictionaries?.map({ try DashElement(dictionary: $0) })
+    try super.init(dictionary: dictionary)
+  }
 }

--- a/lottie-swift/src/Private/Model/ShapeItems/Trim.swift
+++ b/lottie-swift/src/Private/Model/ShapeItems/Trim.swift
@@ -50,4 +50,19 @@ final class Trim: ShapeItem {
     try container.encode(trimType, forKey: .trimType)
   }
   
+  required init(dictionary: [String : Any]) throws {
+    let startDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.start.rawValue)
+    self.start = try KeyframeGroup<Vector1D>(dictionary: startDictionary)
+    let endDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.end.rawValue)
+    self.end = try KeyframeGroup<Vector1D>(dictionary: endDictionary)
+    let offsetDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.offset.rawValue)
+    self.offset = try KeyframeGroup<Vector1D>(dictionary: offsetDictionary)
+    let trimTypeRawValue: Int = try dictionary.valueFor(key: CodingKeys.trimType.rawValue)
+    guard let trimType = TrimType(rawValue: trimTypeRawValue) else {
+      throw InitializableError.invalidInput
+    }
+    self.trimType = trimType
+    try super.init(dictionary: dictionary)
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/Text/Font.swift
+++ b/lottie-swift/src/Private/Model/Text/Font.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class Font: Codable {
+final class Font: Codable, DictionaryInitializable {
   
   let name: String
   let familyName: String
@@ -21,15 +21,27 @@ final class Font: Codable {
     case ascent = "ascent"
   }
   
+  init(dictionary: [String : Any]) throws {
+    self.name = try dictionary.valueFor(key: CodingKeys.name.rawValue)
+    self.familyName = try dictionary.valueFor(key: CodingKeys.familyName.rawValue)
+    self.style = try dictionary.valueFor(key: CodingKeys.style.rawValue)
+    self.ascent = try dictionary.valueFor(key: CodingKeys.ascent.rawValue)
+  }
+  
 }
 
 /// A list of fonts
-final class FontList: Codable {
+final class FontList: Codable, DictionaryInitializable {
   
   let fonts: [Font]
   
   enum CodingKeys : String, CodingKey {
     case fonts = "list"
+  }
+
+  init(dictionary: [String : Any]) throws {
+    let fontDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.fonts.rawValue)
+    self.fonts = try fontDictionaries.map({ try Font(dictionary:$0) })
   }
   
 }

--- a/lottie-swift/src/Private/Model/Text/Glyph.swift
+++ b/lottie-swift/src/Private/Model/Text/Glyph.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A model that holds a vector character
-final class Glyph: Codable {
+final class Glyph: Codable, DictionaryInitializable {
   
   /// The character
   let character: String
@@ -68,5 +68,19 @@ final class Glyph: Codable {
     
     var shapeContainer = container.nestedContainer(keyedBy: ShapeKey.self, forKey: .shapeWrapper)
     try shapeContainer.encode(shapes, forKey: .shapes)
+  }
+  
+  init(dictionary: [String : Any]) throws {
+    self.character = try dictionary.valueFor(key: CodingKeys.character.rawValue)
+    self.fontSize = try dictionary.valueFor(key: CodingKeys.fontSize.rawValue)
+    self.fontFamily = try dictionary.valueFor(key: CodingKeys.fontFamily.rawValue)
+    self.fontStyle = try dictionary.valueFor(key: CodingKeys.fontStyle.rawValue)
+    self.width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    if let shapes = dictionary[CodingKeys.shapeWrapper.rawValue] as? [String: Any],
+       let shapeDictionaries = shapes[ShapeKey.shapes.rawValue] as? [[String: Any]] {
+      self.shapes = try [ShapeItem].fromDictionaries(shapeDictionaries)
+    } else {
+      self.shapes = [ShapeItem]()
+    }
   }
 }

--- a/lottie-swift/src/Private/Model/Text/TextAnimator.swift
+++ b/lottie-swift/src/Private/Model/Text/TextAnimator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class TextAnimator: Codable {
+final class TextAnimator: Codable, DictionaryInitializable {
   
   let name: String
   
@@ -96,4 +96,65 @@ final class TextAnimator: Codable {
     try animatorContainer.encodeIfPresent(strokeWidth, forKey: .strokeWidth)
     try animatorContainer.encodeIfPresent(tracking, forKey: .tracking)
   }
+  
+  init(dictionary: [String : Any]) throws {
+    self.name = (try? dictionary.valueFor(key: CodingKeys.name.rawValue)) ?? ""
+    let animatorDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.textAnimator.rawValue)
+    if let fillColorDictionary = animatorDictionary[TextAnimatorKeys.fillColor.rawValue] as? [String: Any] {
+      self.fillColor = try? KeyframeGroup<Color>(dictionary: fillColorDictionary)
+    } else {
+      self.fillColor = nil
+    }
+    if let strokeColorDictionary = animatorDictionary[TextAnimatorKeys.strokeColor.rawValue] as? [String: Any] {
+      self.strokeColor = try? KeyframeGroup<Color>(dictionary: strokeColorDictionary)
+    } else {
+      self.strokeColor = nil
+    }
+    if let strokeWidthDictionary = animatorDictionary[TextAnimatorKeys.strokeWidth.rawValue] as? [String: Any] {
+      self.strokeWidth = try? KeyframeGroup<Vector1D>(dictionary: strokeWidthDictionary)
+    } else {
+      self.strokeWidth = nil
+    }
+    if let trackingDictionary = animatorDictionary[TextAnimatorKeys.tracking.rawValue] as? [String: Any] {
+      self.tracking = try? KeyframeGroup<Vector1D>(dictionary: trackingDictionary)
+    } else {
+      self.tracking = nil
+    }
+    if let anchorDictionary = animatorDictionary[TextAnimatorKeys.anchor.rawValue] as? [String: Any] {
+      self.anchor = try? KeyframeGroup<Vector3D>(dictionary: anchorDictionary)
+    } else {
+      self.anchor = nil
+    }
+    if let positionDictionary = animatorDictionary[TextAnimatorKeys.position.rawValue] as? [String: Any] {
+      self.position = try? KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    } else {
+      self.position = nil
+    }
+    if let scaleDictionary = animatorDictionary[TextAnimatorKeys.scale.rawValue] as? [String: Any] {
+      self.scale = try? KeyframeGroup<Vector3D>(dictionary: scaleDictionary)
+    } else {
+      self.scale = nil
+    }
+    if let skewDictionary = animatorDictionary[TextAnimatorKeys.skew.rawValue] as? [String: Any] {
+      self.skew = try? KeyframeGroup<Vector1D>(dictionary: skewDictionary)
+    } else {
+      self.skew = nil
+    }
+    if let skewAxisDictionary = animatorDictionary[TextAnimatorKeys.skewAxis.rawValue] as? [String: Any] {
+      self.skewAxis = try? KeyframeGroup<Vector1D>(dictionary: skewAxisDictionary)
+    } else {
+      self.skewAxis = nil
+    }
+    if let rotationDictionary = animatorDictionary[TextAnimatorKeys.rotation.rawValue] as? [String: Any] {
+      self.rotation = try? KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
+    } else {
+      self.rotation = nil
+    }
+    if let opacityDictionary = animatorDictionary[TextAnimatorKeys.opacity.rawValue] as? [String: Any] {
+      self.opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    } else {
+      self.opacity = nil
+    }
+  }
+  
 }

--- a/lottie-swift/src/Private/Model/Text/TextDocument.swift
+++ b/lottie-swift/src/Private/Model/Text/TextDocument.swift
@@ -13,7 +13,7 @@ enum TextJustification: Int, Codable {
   case center
 }
 
-final class TextDocument: Codable {
+final class TextDocument: Codable, DictionaryInitializable, AnyInitializable {
   
   /// The Text
   let text: String
@@ -66,5 +66,48 @@ final class TextDocument: Codable {
     case strokeOverFill = "of"
     case textFramePosition = "ps"
     case textFrameSize = "sz"
+  }
+  
+  init(dictionary: [String : Any]) throws {
+    self.text = try dictionary.valueFor(key: CodingKeys.text.rawValue)
+    self.fontSize = try dictionary.valueFor(key: CodingKeys.fontSize.rawValue)
+    self.fontFamily = try dictionary.valueFor(key: CodingKeys.fontFamily.rawValue)
+    let justificationValue: Int = try dictionary.valueFor(key: CodingKeys.justification.rawValue)
+    guard let justification = TextJustification(rawValue: justificationValue) else {
+      throw InitializableError.invalidInput
+    }
+    self.justification = justification
+    self.tracking = try dictionary.valueFor(key: CodingKeys.tracking.rawValue)
+    self.lineHeight = try dictionary.valueFor(key: CodingKeys.lineHeight.rawValue)
+    self.baseline = try dictionary.valueFor(key: CodingKeys.baseline.rawValue)
+    if let fillColorRawValue = dictionary[CodingKeys.fillColorData.rawValue] {
+      self.fillColorData = try? Color(value: fillColorRawValue)
+    } else {
+      self.fillColorData = nil
+    }
+    if let strokeColorRawValue = dictionary[CodingKeys.strokeColorData.rawValue] {
+      self.strokeColorData = try? Color(value: strokeColorRawValue)
+    } else {
+      self.strokeColorData = nil
+    }
+    self.strokeWidth = try? dictionary.valueFor(key: CodingKeys.strokeWidth.rawValue)
+    self.strokeOverFill = try? dictionary.valueFor(key: CodingKeys.strokeOverFill.rawValue)
+    if let textFramePositionRawValue = dictionary[CodingKeys.textFramePosition.rawValue] {
+      self.textFramePosition = try? Vector3D(value: textFramePositionRawValue)
+    } else {
+      self.textFramePosition = nil
+    }
+    if let textFrameSizeRawValue = dictionary[CodingKeys.textFrameSize.rawValue] {
+      self.textFrameSize = try? Vector3D(value: textFrameSizeRawValue)
+    } else {
+      self.textFrameSize = nil
+    }
+  }
+  
+  convenience init(value: Any) throws {
+    guard let dictionary = value as? [String: Any] else {
+      throw InitializableError.invalidInput
+    }
+    try self.init(dictionary: dictionary)
   }
 }

--- a/lottie-swift/src/Private/Utility/Extensions/CGPointExtensions.swift
+++ b/lottie-swift/src/Private/Utility/Extensions/CGPointExtensions.swift
@@ -1,0 +1,26 @@
+//
+//  CGPointExtensions.swift
+//  Lottie
+//
+//  Created by Zak Forrest on 6/17/21.
+//  Copyright © 2021 YurtvilleProds. All rights reserved.
+//
+
+import CoreGraphics
+
+extension CGPoint: AnyInitializable {
+  
+  init(value: Any) throws {
+    if let dictionary = value as? [String: CGFloat] {
+      let x: CGFloat = try dictionary.valueFor(key: "x")
+      let y: CGFloat = try dictionary.valueFor(key: "y")
+      self.init(x: x, y: y)
+    } else if let array = value as? [CGFloat],
+              array.count > 1 {
+      self.init(x: array[0], y: array[1])
+    } else {
+      throw InitializableError.invalidInput
+    }
+  }
+  
+}

--- a/lottie-swift/src/Private/Utility/Extensions/DictionaryInitializable.swift
+++ b/lottie-swift/src/Private/Utility/Extensions/DictionaryInitializable.swift
@@ -1,0 +1,46 @@
+//
+//  DictionaryInitializable.swift
+//  lottie-swift
+//
+//  Created by Zak Forrest on 6/16/21.
+//
+
+import Foundation
+
+enum InitializableError: Error {
+  case invalidInput
+}
+
+protocol DictionaryInitializable {
+  
+  init(dictionary: [String: Any]) throws
+  
+}
+
+protocol AnyInitializable {
+  
+  init(value: Any) throws
+  
+}
+
+extension Dictionary {
+  
+  func valueFor<T>(key: Key) throws -> T {
+    guard let value = self[key] as? T else {
+      throw InitializableError.invalidInput
+    }
+    return value
+  }
+  
+}
+
+extension Array: AnyInitializable where Element == Double {
+  
+  init(value: Any) throws {
+    guard let array = value as? [Double] else {
+      throw InitializableError.invalidInput
+    }
+    self = array
+  }
+  
+}

--- a/lottie-swift/src/Private/Utility/Primitives/ColorExtension.swift
+++ b/lottie-swift/src/Private/Utility/Primitives/ColorExtension.swift
@@ -62,6 +62,30 @@ extension Color: Codable {
   
 }
 
+extension Color: AnyInitializable {
+  
+  init(value: Any) throws {
+    guard var array = value as? [Double] else {
+      throw InitializableError.invalidInput
+    }
+    var r: Double = array.count > 0 ? array.removeFirst() : 0
+    var g: Double = array.count > 0 ? array.removeFirst() : 0
+    var b: Double = array.count > 0 ? array.removeFirst() : 0
+    var a: Double = array.count > 0 ? array.removeFirst() : 1
+    if r > 1, g > 1, b > 1, a > 1 {
+      r /= 255
+      g /= 255
+      b /= 255
+      a /= 255
+    }
+    self.r = r
+    self.g = g
+    self.b = b
+    self.a = a
+  }
+  
+}
+
 extension Color {
   
   static var clearColor: CGColor {

--- a/lottie-swift/src/Private/Utility/Primitives/VectorsExtensions.swift
+++ b/lottie-swift/src/Private/Utility/Primitives/VectorsExtensions.swift
@@ -41,6 +41,21 @@ extension Double {
   }
 }
 
+extension Vector1D: AnyInitializable {
+  
+  init(value: Any) throws {
+    if let array = value as? [Double],
+       let double = array.first {
+      self.value = double
+    } else if let double = value as? Double {
+      self.value = double
+    } else {
+      throw InitializableError.invalidInput
+    }
+  }
+  
+}
+
 /**
  Needed for decoding json {x: y:} to a CGPoint
  */
@@ -88,7 +103,30 @@ struct Vector2D: Codable {
   }
 }
 
-extension Vector2D {
+extension Vector2D: AnyInitializable {
+  
+  init(value: Any) throws {
+    guard let dictionary = value as? [String: Any] else {
+      throw InitializableError.invalidInput
+    }
+    
+    if let array = dictionary[CodingKeys.x.rawValue] as? [Double],
+       let double = array.first {
+      self.x = double
+    } else if let double = dictionary[CodingKeys.x.rawValue] as? Double {
+      self.x = double
+    } else {
+      throw InitializableError.invalidInput
+    }
+    if let array = dictionary[CodingKeys.y.rawValue] as? [Double],
+       let double = array.first {
+      self.y = double
+    } else if let double = dictionary[CodingKeys.y.rawValue] as? Double {
+      self.y = double
+    } else {
+      throw InitializableError.invalidInput
+    }
+  }
   
 }
 
@@ -138,6 +176,19 @@ extension Vector3D: Codable {
     try container.encode(x)
     try container.encode(y)
     try container.encode(z)
+  }
+  
+}
+
+extension Vector3D: AnyInitializable {
+  
+  init(value: Any) throws {
+    guard var array = value as? [Double] else {
+      throw InitializableError.invalidInput
+    }
+    self.x = array.count > 0 ? array.removeFirst() : 0
+    self.y = array.count > 0 ? array.removeFirst() : 0
+    self.z = array.count > 0 ? array.removeFirst() : 0
   }
   
 }

--- a/lottie-swift/src/Public/Animation/AnimationPublic.swift
+++ b/lottie-swift/src/Public/Animation/AnimationPublic.swift
@@ -78,6 +78,20 @@ public extension Animation {
       return nil
     }
   }
+
+  /**
+   Loads an animation from data. Uses a dictionary to decode the data rather than `JSONDecoder`.
+   - Parameter data: The data containing the animation.
+
+   - Returns: Deserialized `Animation`. Optional.
+   */
+  static func data(_ data: Data) -> Animation? {
+    guard let dictionary = try? JSONSerialization.jsonObject(with: data, options: .init()) as? [String: Any],
+      let animation = try? Animation(dictionary: dictionary) else {
+      return nil
+    }
+    return animation
+  }
   
   /// A closure for an Animation download. The closure is passed `nil` if there was an error.
   typealias DownloadClosure = (Animation?) -> Void


### PR DESCRIPTION
Provides 2-10x faster decoding time and also uses 3-4x less memory while decoding, compared to using `JSONDecoder`. This is documented under the Performance Regression Refactor project card [here](https://github.com/airbnb/lottie-ios/projects/2#card-29711649) and was discussed in the past as a solution [here](https://github.com/airbnb/lottie-ios/issues/872#issuecomment-498733043)  (#872).

- Adds `DictionaryInitializable` and `AnyInitializable` protocols
- The `Animation` and child objects adhere to `DictionaryInitializable`
- Added a public `Animation` initializer using `Data`
- No core logic changed - only added protocols and applied them to existing models

Tested using all provided animations, as well as ~20 animations of my own, on an iPhone XS.