### PR TITLE
Fix layout jump

### DIFF
--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -784,14 +784,14 @@ final public class AnimationView: LottieView {
       let positionAnimation = animation.copy() as? CABasicAnimation ?? CABasicAnimation(keyPath: "position")
       positionAnimation.keyPath = "position"
       positionAnimation.isAdditive = false
-      positionAnimation.fromValue = animationLayer.presentation()?.position
+      positionAnimation.fromValue = (animationLayer.presentation() ?? animationLayer).position
       positionAnimation.toValue = position
       positionAnimation.isRemovedOnCompletion = true
 
       let xformAnimation = animation.copy() as? CABasicAnimation ?? CABasicAnimation(keyPath: "transform")
       xformAnimation.keyPath = "transform"
       xformAnimation.isAdditive = false
-      xformAnimation.fromValue = animationLayer.presentation()?.transform
+      xformAnimation.fromValue = (animationLayer.presentation() ?? animationLayer).transform
       xformAnimation.toValue = xform
       xformAnimation.isRemovedOnCompletion = true
 

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -784,14 +784,14 @@ final public class AnimationView: LottieView {
       let positionAnimation = animation.copy() as? CABasicAnimation ?? CABasicAnimation(keyPath: "position")
       positionAnimation.keyPath = "position"
       positionAnimation.isAdditive = false
-      positionAnimation.fromValue = animationLayer.position
+      positionAnimation.fromValue = animationLayer.presentation()?.position
       positionAnimation.toValue = position
       positionAnimation.isRemovedOnCompletion = true
 
       let xformAnimation = animation.copy() as? CABasicAnimation ?? CABasicAnimation(keyPath: "transform")
       xformAnimation.keyPath = "transform"
       xformAnimation.isAdditive = false
-      xformAnimation.fromValue = animationLayer.transform
+      xformAnimation.fromValue = animationLayer.presentation()?.transform
       xformAnimation.toValue = xform
       xformAnimation.isRemovedOnCompletion = true
 


### PR DESCRIPTION
When rotating the device I was noticing that the Lottie AnimationView was not always smoothly animating into the new position. After some digging it appears this is because of how `layoutAnimations` was handling setting up the animation.

Currently, if `layoutAnimations` is called multiple times, we will get the ending position as the 'from' value instead of the actual value on screen. This results in a potential visual 'jump' in the view.

This PR uses the layer's presentation layer rather than the model layer to setup the animation. By using the presentation layer's values, we get the values for where the layer is currently on screen, regardless of how many times `layoutAnimations` ends up getting called. This ensures the animation always appears to run smoothly.

I believe this should fix #1393.