### PR TITLE
Add support for tvOS in Package.swift file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ xcuserdata/
 
 # other
 build/
+.swiftpm/
 
 # macOS
 .DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Lottie",
-    platforms: [.iOS(.v9)],
+    platforms: [.iOS(.v9), .tvOS(.v9)],
     // platforms: [.iOS("9.0"), .macOS("10.10"), tvOS("9.0"), .watchOS("2.0")],
     products: [
         .library(name: "Lottie", targets: ["Lottie"])


### PR DESCRIPTION
This PR adds support for tvOS in the Package.swift file. tvOS is supported for CocoaPods and Carthage.