### PR TITLE
Issue 1412 cannot parse json in cae of no indecies

### DIFF
--- a/lottie-swift/src/Private/LayerContainers/Utility/CompositionLayersInitializer.swift
+++ b/lottie-swift/src/Private/LayerContainers/Utility/CompositionLayersInitializer.swift
@@ -22,7 +22,7 @@ extension Array where Element == LayerModel {
     var childLayers = [LayerModel]()
     
     for layer in self {
-      let layerIndex = layer.index ?? Int(layer.inFrame)
+      let layerIndex = layer.index ?? Int(layer.inFrame) // In case of using image sequencies not vector data json
       if layer.hidden == true {
         let genericLayer = NullCompositionLayer(layer: layer)
         compositionLayers.append(genericLayer)
@@ -68,7 +68,7 @@ extension Array where Element == LayerModel {
     }
     /// Now link children with their parents
     for layerModel in childLayers {
-      let layerIndex = layerModel.index ?? Int(layerModel.inFrame)
+      let layerIndex = layerModel.index ?? Int(layerModel.inFrame) // In case of using image sequencies not vector data json
       if let parentID = layerModel.parent {
         let childLayer = layerMap[layerIndex]
         let parentLayer = layerMap[parentID]

--- a/lottie-swift/src/Private/LayerContainers/Utility/CompositionLayersInitializer.swift
+++ b/lottie-swift/src/Private/LayerContainers/Utility/CompositionLayersInitializer.swift
@@ -22,18 +22,19 @@ extension Array where Element == LayerModel {
     var childLayers = [LayerModel]()
     
     for layer in self {
+      let layerIndex = layer.index ?? Int(layer.inFrame)
       if layer.hidden == true {
         let genericLayer = NullCompositionLayer(layer: layer)
         compositionLayers.append(genericLayer)
-        layerMap[layer.index] = genericLayer
+        layerMap[layerIndex] = genericLayer
       } else if let shapeLayer = layer as? ShapeLayerModel {
         let shapeContainer = ShapeCompositionLayer(shapeLayer: shapeLayer)
         compositionLayers.append(shapeContainer)
-        layerMap[layer.index] = shapeContainer
+        layerMap[layerIndex] = shapeContainer
       } else if let solidLayer = layer as? SolidLayerModel {
         let solidContainer = SolidCompositionLayer(solid: solidLayer)
         compositionLayers.append(solidContainer)
-        layerMap[layer.index] = solidContainer
+        layerMap[layerIndex] = solidContainer
       } else if let precompLayer = layer as? PreCompLayerModel,
         let assetLibrary = assetLibrary,
         let precompAsset = assetLibrary.precompAssets[precompLayer.referenceID] {
@@ -45,31 +46,31 @@ extension Array where Element == LayerModel {
                                                    assetLibrary: assetLibrary,
                                                    frameRate: frameRate)
         compositionLayers.append(precompContainer)
-        layerMap[layer.index] = precompContainer
+        layerMap[layerIndex] = precompContainer
       } else if let imageLayer = layer as? ImageLayerModel,
         let assetLibrary = assetLibrary,
         let imageAsset = assetLibrary.imageAssets[imageLayer.referenceID] {
         let imageContainer = ImageCompositionLayer(imageLayer: imageLayer, size: CGSize(width: imageAsset.width, height: imageAsset.height))
         compositionLayers.append(imageContainer)
-        layerMap[layer.index] = imageContainer
+        layerMap[layerIndex] = imageContainer
       } else if let textLayer = layer as? TextLayerModel {
         let textContainer = TextCompositionLayer(textLayer: textLayer, textProvider: textProvider, fontProvider: fontProvider)
         compositionLayers.append(textContainer)
-        layerMap[layer.index] = textContainer
+        layerMap[layerIndex] = textContainer
       } else {
         let genericLayer = NullCompositionLayer(layer: layer)
         compositionLayers.append(genericLayer)
-        layerMap[layer.index] = genericLayer
+        layerMap[layerIndex] = genericLayer
       }
       if layer.parent != nil {
         childLayers.append(layer)
       }
     }
-    
     /// Now link children with their parents
     for layerModel in childLayers {
+      let layerIndex = layerModel.index ?? Int(layerModel.inFrame)
       if let parentID = layerModel.parent {
-        let childLayer = layerMap[layerModel.index]
+        let childLayer = layerMap[layerIndex]
         let parentLayer = layerMap[parentID]
         childLayer?.transformNode.parentNode = parentLayer?.transformNode
       }

--- a/lottie-swift/src/Private/Model/Layers/LayerModel.swift
+++ b/lottie-swift/src/Private/Model/Layers/LayerModel.swift
@@ -77,7 +77,7 @@ class LayerModel: Codable {
   let name: String
   
   /// The index of the layer
-  let index: Int
+  let index: Int?
   
   /// The type of the layer.
   let type: LayerType
@@ -133,7 +133,6 @@ class LayerModel: Codable {
   required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: LayerModel.CodingKeys.self)
     self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? "Layer"
-    self.index = try container.decode(Int.self, forKey: .index)
     self.type = try container.decode(LayerType.self, forKey: .type)
     self.coordinateSpace = try container.decodeIfPresent(CoordinateSpace.self, forKey: .coordinateSpace) ?? .type2d
     self.inFrame = try container.decode(Double.self, forKey: .inFrame)
@@ -146,5 +145,6 @@ class LayerModel: Codable {
     self.timeStretch = try container.decodeIfPresent(Double.self, forKey: .timeStretch) ?? 1
     self.matte = try container.decodeIfPresent(MatteType.self, forKey: .matte)
     self.hidden = try container.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
+    self.index = try container.decodeIfPresent(Int.self, forKey: .index)
   }
 }


### PR DESCRIPTION
We use lotty not as vector graphics, but as a sequence of JPG images. And in this JSON we do not have their indices. Each picture is a separate object, it is also the initial frame, and this same frame is its own index. Due to the non-index option, we have no way to parse JSON.

In my fix we have to parse ind value, but if there no value we can use as default value start frame which can replace index because for img sequences each image == startFrame == index 