### PR TITLE
Allow subclassing AnimatedSwitch and Button

### DIFF
--- a/Sources/Public/iOS/AnimatedButton.swift
+++ b/Sources/Public/iOS/AnimatedButton.swift
@@ -11,7 +11,7 @@ import UIKit
 /**
  An interactive button that plays an animation when pressed.
  */
-final public class AnimatedButton: AnimatedControl {
+open class AnimatedButton: AnimatedControl {
 
   // MARK: Lifecycle
 

--- a/Sources/Public/iOS/AnimatedSwitch.swift
+++ b/Sources/Public/iOS/AnimatedSwitch.swift
@@ -15,7 +15,7 @@ import UIKit
 
  Both the 'On' and 'Off' have an animation play range associated with their state.
  */
-final public class AnimatedSwitch: AnimatedControl {
+open class AnimatedSwitch: AnimatedControl {
 
   // MARK: Lifecycle
 


### PR DESCRIPTION
In order to create a `AnimatedSwitch` which applies the
`traitCollection` either a subclass of `AnimatedControl` and
reimplementing all the switch logic or creating a wrapper view and
exposing the `AnimatedControl` has to be done.
Same is true for `AnimatedButton`.

```swift
final class ThemedAnimatedSwitch: UIView {
    let toggle: AnimatedSwitch
    let redValueProvider = ColorValueProvider(Color(r: 1, g: 0.2, b: 0.3, a: 1))

    init(frame: CGRect) {
        toggle = .init(animation: animation)
        super.init(frame: frame)

        toggle.setValueProvider(valueProvider, keypath: AnimationKeypath(keypath: "**.Fill 1.Color"))
    }

    required init?(coder: NSCoder) { ... }
}
```

Then use `animatedSwitch.toggle`.

---

```swift
final class TestSwitch: AnimatedSwitch {
    let redValueProvider = ColorValueProvider(Color(r: 1, g: 0.2, b: 0.3, a: 1))

    convenience override init() {
        self.init(animation: animation)

        setValueProvider(valueProvider, keypath: AnimationKeypath(keypath: "**.Fill 1.Color"))
    }
}
```

Then use `animatedSwitch` directly.

Since the public interface of `AnimatedSwitch` is `public` instead of
`open` functions like `func setIsOn(_ isOn: Bool, animated: Bool,
shouldFireHaptics: Bool = true)` cannot be overridden.

Supersedes https://github.com/airbnb/lottie-ios/pull/1359