### PR TITLE
Bootstrap experimental rendering engine configuration / entry point

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2E3EEB382763C68C00287EEA /* Samples in Resources */ = {isa = PBXBuildFile; fileRef = 2E3EEB372763C68C00287EEA /* Samples */; };
 		2E3EEB392763C68C00287EEA /* Samples in Resources */ = {isa = PBXBuildFile; fileRef = 2E3EEB372763C68C00287EEA /* Samples */; };
 		2E3EEB3A2763C68C00287EEA /* Samples in Resources */ = {isa = PBXBuildFile; fileRef = 2E3EEB372763C68C00287EEA /* Samples */; };
+		2E97E3052767E7C600FE22C3 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E97E3042767E7C600FE22C3 /* Configuration.swift */; };
 		2E9E77AF27602BD400C84BA3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9E77AE27602BD400C84BA3 /* AppDelegate.swift */; };
 		2EA159F12761289C00CE8F1F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA159F02761289C00CE8F1F /* AppDelegate.swift */; };
 		2EA159F32761289C00CE8F1F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA159F22761289C00CE8F1F /* ViewController.swift */; };
@@ -37,6 +38,7 @@
 		2E0F2FBD27602CB300B65DE3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		2E362A1D2762BA06006AE7D2 /* SampleListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleListViewController.swift; sourceTree = "<group>"; };
 		2E3EEB372763C68C00287EEA /* Samples */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Samples; path = ../Tests/Samples; sourceTree = "<group>"; };
+		2E97E3042767E7C600FE22C3 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		2E9E77AC27602BD400C84BA3 /* Example (iOS).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example (iOS).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E9E77AE27602BD400C84BA3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2E9E77BC27602BD400C84BA3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -98,6 +100,7 @@
 				2E362A1D2762BA06006AE7D2 /* SampleListViewController.swift */,
 				2EC6E5072763D981002E091C /* LinkView.swift */,
 				2EC6E50F2763E79F002E091C /* AnimationPreviewViewController.swift */,
+				2E97E3042767E7C600FE22C3 /* Configuration.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -308,6 +311,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2EC6E5102763E79F002E091C /* AnimationPreviewViewController.swift in Sources */,
+				2E97E3052767E7C600FE22C3 /* Configuration.swift in Sources */,
 				2E362A1E2762BA06006AE7D2 /* SampleListViewController.swift in Sources */,
 				2E9E77AF27602BD400C84BA3 /* AppDelegate.swift in Sources */,
 				2EC6E5082763D981002E091C /* LinkView.swift in Sources */,

--- a/Example/iOS/AppDelegate.swift
+++ b/Example/iOS/AppDelegate.swift
@@ -13,6 +13,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?)
     -> Bool
   {
+    Configuration.applyCurrentConfiguration()
+
     let window = UIWindow(frame: UIScreen.main.bounds)
 
     let navigationController = UINavigationController(

--- a/Example/iOS/Configuration.swift
+++ b/Example/iOS/Configuration.swift
@@ -1,0 +1,24 @@
+// Created by Cal Stephens on 12/13/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import Foundation
+import Lottie
+
+final class Configuration {
+
+  /// Whether or not to use the new, experimental rendering engine
+  static var useNewRenderingEngine: Bool {
+    get { UserDefaults.standard.bool(forKey: #function) }
+    set {
+      UserDefaults.standard.set(newValue, forKey: #function)
+      applyCurrentConfiguration()
+    }
+  }
+
+  /// Applies the current configuration (stored in UserDefaults)
+  /// to the singleton `Lottie.ExperimentalFeatureConfiguration.shared`
+  static func applyCurrentConfiguration() {
+    Lottie.ExperimentalFeatureConfiguration.shared.useNewRenderingEngine = useNewRenderingEngine
+  }
+
+}

--- a/Example/iOS/SampleListViewController.swift
+++ b/Example/iOS/SampleListViewController.swift
@@ -99,14 +99,14 @@ final class SampleListViewController: CollectionViewController {
         title: "Rendering Engine",
         children: [
           UIAction(
-            title: "Standard (CPU)",
+            title: "Standard",
             state: Configuration.useNewRenderingEngine ? .off : .on,
             handler: { [weak self] _ in
               Configuration.useNewRenderingEngine = false
               self?.configureSettingsMenu()
             }),
           UIAction(
-            title: "Experimental (GPU)",
+            title: "Experimental",
             state: Configuration.useNewRenderingEngine ? .on : .off,
             handler: { [weak self] _ in
               Configuration.useNewRenderingEngine = true

--- a/Example/iOS/SampleListViewController.swift
+++ b/Example/iOS/SampleListViewController.swift
@@ -22,6 +22,7 @@ final class SampleListViewController: CollectionViewController {
     setItems(items, animated: false)
 
     title = directory
+    configureSettingsMenu()
   }
 
   // MARK: Internal
@@ -88,5 +89,30 @@ final class SampleListViewController: CollectionViewController {
   // MARK: Private
 
   private let directory: String
+
+  private func configureSettingsMenu() {
+    navigationItem.rightBarButtonItem = UIBarButtonItem(
+      title: "Settings",
+      image: .init(systemName: "gear"),
+      primaryAction: nil,
+      menu: UIMenu(
+        title: "Rendering Engine",
+        children: [
+          UIAction(
+            title: "Standard (CPU)",
+            state: Configuration.useNewRenderingEngine ? .off : .on,
+            handler: { [weak self] _ in
+              Configuration.useNewRenderingEngine = false
+              self?.configureSettingsMenu()
+            }),
+          UIAction(
+            title: "Experimental (GPU)",
+            state: Configuration.useNewRenderingEngine ? .on : .off,
+            handler: { [weak self] _ in
+              Configuration.useNewRenderingEngine = true
+              self?.configureSettingsMenu()
+            }),
+        ]))
+  }
 
 }

--- a/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
+++ b/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
@@ -1,0 +1,95 @@
+// Created by Cal Stephens on 12/13/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import Foundation
+import QuartzCore
+
+// MARK: - ExperimentalAnimationLayer
+
+/// The root `CALayer` responsible for playing a Lottie animation
+final class ExperimentalAnimationLayer: CALayer {
+
+  // MARK: Lifecycle
+
+  init(animation: Animation) {
+    self.animation = animation
+    super.init()
+  }
+
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Private
+
+  private let animation: Animation
+
+}
+
+// MARK: RootAnimationLayer
+
+extension ExperimentalAnimationLayer: RootAnimationLayer {
+
+  var currentFrame: CGFloat {
+    get { 0 }
+    set { /* Currently unsupported */ }
+  }
+
+  var renderScale: CGFloat {
+    get { 0 }
+    set { fatalError("Currently unsupported") }
+  }
+
+  var respectAnimationFrameRate: Bool {
+    get { false }
+    set { fatalError("Currently unsupported") }
+  }
+
+  var animationLayers: ContiguousArray<CompositionLayer> {
+    []
+  }
+
+  var imageProvider: AnimationImageProvider {
+    get { fatalError("Currently unsupported") }
+    set { fatalError("Currently unsupported") }
+  }
+
+  var textProvider: AnimationTextProvider {
+    get { fatalError("Currently unsupported") }
+    set { fatalError("Currently unsupported") }
+  }
+
+  var fontProvider: AnimationFontProvider {
+    get { fatalError("Currently unsupported") }
+    set { fatalError("Currently unsupported") }
+  }
+
+  func reloadImages() {
+    fatalError("Currently unsupported")
+  }
+
+  func forceDisplayUpdate() {
+    // Unimplemented
+  }
+
+  func logHierarchyKeypaths() {
+    fatalError("Currently unsupported")
+  }
+
+  func setValueProvider(_: AnyValueProvider, keypath _: AnimationKeypath) {
+    fatalError("Currently unsupported")
+  }
+
+  func getValue(for _: AnimationKeypath, atFrame _: AnimationFrameTime?) -> Any? {
+    fatalError("Currently unsupported")
+  }
+
+  func layer(for _: AnimationKeypath) -> CALayer? {
+    fatalError("Currently unsupported")
+  }
+
+  func animatorNodes(for _: AnimationKeypath) -> [AnimatorNode]? {
+    fatalError("Currently unsupported")
+  }
+
+}

--- a/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
+++ b/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
@@ -6,7 +6,9 @@ import QuartzCore
 
 // MARK: - ExperimentalAnimationLayer
 
-/// The root `CALayer` responsible for playing a Lottie animation
+/// The root `CALayer` of the experimental rendering engine,
+/// which leverages the Core Animation render server to
+/// animate without executing on the main thread every frame.
 final class ExperimentalAnimationLayer: CALayer {
 
   // MARK: Lifecycle

--- a/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
+++ b/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
@@ -1,0 +1,13 @@
+// Created by Cal Stephens on 12/13/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+public struct ExperimentalFeatureConfiguration {
+
+  /// The singleton configuration for experimental features,
+  /// which applies to all `AnimationView`s.
+  public static var shared = ExperimentalFeatureConfiguration()
+
+  /// Whether or not to use the new, experimental, rendering engine
+  public var useNewRenderingEngine = false
+
+}

--- a/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
+++ b/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
@@ -1,10 +1,14 @@
 // Created by Cal Stephens on 12/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+/// Configuration for experimental features that are in development
+///
+/// Experimental features are not considered stable and are subject
+/// to change or be removed at any time.
 public struct ExperimentalFeatureConfiguration {
 
   /// The singleton configuration for experimental features,
-  /// which applies to all `AnimationView`s.
+  /// which applies to all `AnimationView`s by default.
   public static var shared = ExperimentalFeatureConfiguration()
 
   /// Whether or not to use the new, experimental, rendering engine

--- a/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
+++ b/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
@@ -11,7 +11,9 @@ public struct ExperimentalFeatureConfiguration {
   /// which applies to all `AnimationView`s by default.
   public static var shared = ExperimentalFeatureConfiguration()
 
-  /// Whether or not to use the new, experimental, rendering engine
+  /// Whether or not to use the new, experimental, rendering engine,
+  /// which leverages the Core Animation render server to
+  /// animate without executing on the main thread every frame.
   public var useNewRenderingEngine = false
 
 }

--- a/Sources/Private/LayerContainers/AnimationContainer.swift
+++ b/Sources/Private/LayerContainers/AnimationContainer.swift
@@ -16,7 +16,7 @@ import QuartzCore
  This layer holds a single composition container and allows for animation of
  the currentFrame property.
  */
-final class AnimationContainer: CALayer {
+final class AnimationContainer: CALayer, RootAnimationLayer {
 
   // MARK: Lifecycle
 

--- a/Sources/Private/LayerContainers/RootAnimationLayer.swift
+++ b/Sources/Private/LayerContainers/RootAnimationLayer.swift
@@ -1,0 +1,26 @@
+// Created by Cal Stephens on 12/13/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import QuartzCore
+
+/// A root `CALayer` responsible for playing a Lottie animation
+protocol RootAnimationLayer: CALayer {
+  var currentFrame: CGFloat { get set }
+  var renderScale: CGFloat { get set }
+  var respectAnimationFrameRate: Bool { get set }
+
+  var animationLayers: ContiguousArray<CompositionLayer> { get }
+  var imageProvider: AnimationImageProvider { get set }
+  var textProvider: AnimationTextProvider { get set }
+  var fontProvider: AnimationFontProvider { get set }
+
+  func reloadImages()
+  func forceDisplayUpdate()
+  func logHierarchyKeypaths()
+
+  func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath)
+  func getValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any?
+
+  func layer(for keypath: AnimationKeypath) -> CALayer?
+  func animatorNodes(for keypath: AnimationKeypath) -> [AnimatorNode]?
+}

--- a/Sources/Private/Utility/Helpers/AnimationContext.swift
+++ b/Sources/Private/Utility/Helpers/AnimationContext.swift
@@ -69,7 +69,7 @@ class AnimationCompletionDelegate: NSObject, CAAnimationDelegate {
 
   // MARK: Internal
 
-  var animationLayer: AnimationContainer?
+  var animationLayer: RootAnimationLayer?
   var animationKey: String?
   var ignoreDelegate: Bool = false
   var animationState: AnimationContextState = .playing

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -77,7 +77,7 @@ final public class AnimationView: LottieView {
     self.imageProvider = imageProvider ?? BundleImageProvider(bundle: Bundle.main, searchPath: nil)
     self.textProvider = textProvider
     self.fontProvider = fontProvider
-    self.experimentalFeatureConfiguration = _experimentalFeatureConfiguration
+    experimentalFeatureConfiguration = _experimentalFeatureConfiguration
     super.init(frame: .zero)
     commonInit()
     makeAnimationLayer()

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -70,12 +70,14 @@ final public class AnimationView: LottieView {
     animation: Animation?,
     imageProvider: AnimationImageProvider? = nil,
     textProvider: AnimationTextProvider = DefaultTextProvider(),
-    fontProvider: AnimationFontProvider = DefaultFontProvider())
+    fontProvider: AnimationFontProvider = DefaultFontProvider(),
+    _experimentalFeatureConfiguration: ExperimentalFeatureConfiguration = .shared)
   {
     self.animation = animation
     self.imageProvider = imageProvider ?? BundleImageProvider(bundle: Bundle.main, searchPath: nil)
     self.textProvider = textProvider
     self.fontProvider = fontProvider
+    self.experimentalFeatureConfiguration = _experimentalFeatureConfiguration
     super.init(frame: .zero)
     commonInit()
     makeAnimationLayer()
@@ -89,6 +91,7 @@ final public class AnimationView: LottieView {
     imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
     textProvider = DefaultTextProvider()
     fontProvider = DefaultFontProvider()
+    experimentalFeatureConfiguration = .shared
     super.init(frame: .zero)
     commonInit()
   }
@@ -98,6 +101,7 @@ final public class AnimationView: LottieView {
     imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
     textProvider = DefaultTextProvider()
     fontProvider = DefaultFontProvider()
+    experimentalFeatureConfiguration = .shared
     super.init(frame: .zero)
     commonInit()
   }
@@ -106,6 +110,7 @@ final public class AnimationView: LottieView {
     imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
     textProvider = DefaultTextProvider()
     fontProvider = DefaultFontProvider()
+    experimentalFeatureConfiguration = .shared
     super.init(coder: aDecoder)
     commonInit()
   }
@@ -886,7 +891,7 @@ final public class AnimationView: LottieView {
       return
     }
 
-    if ExperimentalFeatureConfiguration.shared.useNewRenderingEngine {
+    if experimentalFeatureConfiguration.useNewRenderingEngine {
       animationLayer = ExperimentalAnimationLayer(animation: animation)
     } else {
       let animationLayer = AnimationContainer(
@@ -1046,4 +1051,8 @@ final public class AnimationView: LottieView {
   // MARK: Private
 
   static private let animationName: String = "Lottie"
+
+  /// The configuration of experimental features that this `AnimationView` uses
+  private let experimentalFeatureConfiguration: ExperimentalFeatureConfiguration
+
 }

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -670,7 +670,7 @@ final public class AnimationView: LottieView {
 
   // MARK: - Private (Properties)
 
-  var animationLayer: AnimationContainer? = nil
+  var animationLayer: RootAnimationLayer? = nil
 
   /// Set animation name from Interface Builder
   @IBInspectable var animationName: String? {
@@ -876,7 +876,7 @@ final public class AnimationView: LottieView {
     /// Remove current animation if any
     removeCurrentAnimation()
 
-    if let oldAnimation = self.animationLayer {
+    if let oldAnimation = animationLayer {
       oldAnimation.removeFromSuperlayer()
     }
 
@@ -886,18 +886,22 @@ final public class AnimationView: LottieView {
       return
     }
 
-    let animationLayer = AnimationContainer(
-      animation: animation,
-      imageProvider: imageProvider,
-      textProvider: textProvider,
-      fontProvider: fontProvider)
-    animationLayer.renderScale = screenScale
-    viewLayer?.addSublayer(animationLayer)
-    self.animationLayer = animationLayer
-    reloadImages()
-    animationLayer.setNeedsDisplay()
-    setNeedsLayout()
-    currentFrame = CGFloat(animation.startFrame)
+    if ExperimentalFeatureConfiguration.shared.useNewRenderingEngine {
+      animationLayer = ExperimentalAnimationLayer(animation: animation)
+    } else {
+      let animationLayer = AnimationContainer(
+        animation: animation,
+        imageProvider: imageProvider,
+        textProvider: textProvider,
+        fontProvider: fontProvider)
+      animationLayer.renderScale = screenScale
+      viewLayer?.addSublayer(animationLayer)
+      self.animationLayer = animationLayer
+      reloadImages()
+      animationLayer.setNeedsDisplay()
+      setNeedsLayout()
+      currentFrame = CGFloat(animation.startFrame)
+    }
   }
 
   fileprivate func updateAnimationForBackgroundState() {


### PR DESCRIPTION
This PR bootstraps the configuration / entry point for a new, prototype, experimental rendering engine. 

The current rendering engine must run on the main thread once per frame, which introduces performance overhead and can cause animations to stutter under high CPU load. The goal for this experimental prototype is to see if we can leverage Core Animation more effectively to reduce (or eliminate!) work that has to happen on the main thread.

This PR specifically:
 - creates a new `ExperimentalFeatureConfiguration` that allows consumers to choose which rendering implementation should be used
 - adds a menu to the Example app that lets you switch between the two rendering engines
 - creates a new `ExperimentalAnimationLayer` (the `RootAnimationLayer` of the experimental engine) that slots in to `AnimationView` without any changes
 
 Follow-up PRs will begin implementing some actual rendering behaviors. For example, in this gif you can see some early support for rendering static shapes and fill colors:
 
<img src="https://user-images.githubusercontent.com/1811727/146054385-d3ca31c6-631f-4cf8-bd7a-d18317d83d04.gif" width=350>
 