### PR TITLE
Support animating custom time ranges

### DIFF
--- a/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
+++ b/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
@@ -78,7 +78,7 @@ class AnimationPreviewViewController: UIViewController {
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-    animationView.play(fromProgress: 0, toProgress: 1)
+    updateAnimation()
   }
 
   // MARK: Private
@@ -89,38 +89,105 @@ class AnimationPreviewViewController: UIViewController {
 
   private var displayLink: CADisplayLink?
 
+  private var loopMode = LottieLoopMode.autoReverse
+  private var fromProgress: AnimationProgressTime = 0.75
+  private var toProgress: AnimationProgressTime = 0.25
+
   private func configureSettingsMenu() {
     navigationItem.rightBarButtonItem = UIBarButtonItem(
       title: "Settings",
       image: .init(systemName: "repeat.circle"),
       primaryAction: nil,
-      menu: UIMenu(
-        title: "Loop Mode",
-        children: [
-          UIAction(
-            title: "Autoreverse",
-            state: animationView.loopMode == .autoReverse ? .on : .off,
-            handler: { [weak self] _ in
-              self?.updateLoopMode(to: .autoReverse)
-            }),
-          UIAction(
-            title: "Loop",
-            state: animationView.loopMode == .loop ? .on : .off,
-            handler: { [weak self] _ in
-              self?.updateLoopMode(to: .loop)
-            }),
-          UIAction(
-            title: "Play Once",
-            state: animationView.loopMode == .playOnce ? .on : .off,
-            handler: { [weak self] _ in
-              self?.updateLoopMode(to: .playOnce)
-            }),
-        ]))
+      menu: UIMenu(children: [
+        UIMenu(
+          title: "Loop Mode...",
+          children: [
+            UIAction(
+              title: "Autoreverse",
+              state: loopMode == .autoReverse ? .on : .off,
+              handler: { [unowned self] _ in
+                loopMode = .autoReverse
+                updateAnimation()
+              }),
+            UIAction(
+              title: "Loop",
+              state: loopMode == .loop ? .on : .off,
+              handler: { [unowned self] _ in
+                loopMode = .loop
+                updateAnimation()
+              }),
+            UIAction(
+              title: "Play Once",
+              state: loopMode == .playOnce ? .on : .off,
+              handler: { [unowned self] _ in
+                loopMode = .playOnce
+                updateAnimation()
+              }),
+          ]),
+
+        UIMenu(
+          title: "From Progress...",
+          children: [
+            UIAction(
+              title: "0%",
+              state: fromProgress == 0 ? .on : .off,
+              handler: { [unowned self] _ in
+                fromProgress = 0
+                updateAnimation()
+              }),
+            UIAction(
+              title: "25%",
+              state: fromProgress == 0.25 ? .on : .off,
+              handler: { [unowned self] _ in
+                fromProgress = 0.25
+                updateAnimation()
+              }),
+            UIAction(
+              title: "50%",
+              state: fromProgress == 0.5 ? .on : .off,
+              handler: { [unowned self] _ in
+                fromProgress = 0.5
+                updateAnimation()
+              }),
+          ]),
+
+        UIMenu(
+          title: "To Progress...",
+          children: [
+            UIAction(
+              title: "0%",
+              state: toProgress == 0 ? .on : .off,
+              handler: { [unowned self] _ in
+                toProgress = 0
+                updateAnimation()
+              }),
+            UIAction(
+              title: "50%",
+              state: toProgress == 0.5 ? .on : .off,
+              handler: { [unowned self] _ in
+                toProgress = 0.5
+                updateAnimation()
+              }),
+            UIAction(
+              title: "75%",
+              state: toProgress == 0.75 ? .on : .off,
+              handler: { [unowned self] _ in
+                toProgress = 0.75
+                updateAnimation()
+              }),
+            UIAction(
+              title: "100%",
+              state: toProgress == 1 ? .on : .off,
+              handler: { [unowned self] _ in
+                toProgress = 1
+                updateAnimation()
+              }),
+          ])
+      ]))
   }
 
-  private func updateLoopMode(to loopMode: LottieLoopMode) {
-    animationView.loopMode = loopMode
-    animationView.play()
+  private func updateAnimation() {
+    animationView.play(fromProgress: fromProgress, toProgress: toProgress, loopMode: loopMode)
     configureSettingsMenu()
   }
 

--- a/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
+++ b/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
@@ -90,8 +90,8 @@ class AnimationPreviewViewController: UIViewController {
   private var displayLink: CADisplayLink?
 
   private var loopMode = LottieLoopMode.autoReverse
-  private var fromProgress: AnimationProgressTime = 0.75
-  private var toProgress: AnimationProgressTime = 0.25
+  private var fromProgress: AnimationProgressTime = 0
+  private var toProgress: AnimationProgressTime = 1
 
   private func configureSettingsMenu() {
     navigationItem.rightBarButtonItem = UIBarButtonItem(
@@ -182,7 +182,7 @@ class AnimationPreviewViewController: UIViewController {
                 toProgress = 1
                 updateAnimation()
               }),
-          ])
+          ]),
       ]))
   }
 

--- a/Sources/Private/Experimental/Animations/CALayer+addAnimation.swift
+++ b/Sources/Private/Experimental/Animations/CALayer+addAnimation.swift
@@ -53,7 +53,6 @@ extension CALayer {
     precondition(!keyframes.isEmpty, "Keyframes for \"\(keyPath.name)\" must be non-empty")
 
     let animation = CAKeyframeAnimation(keyPath: keyPath.name)
-    animation.configureTiming(with: context)
 
     // Convert the list of `Keyframe<T>` into
     // the representation used by `CAKeyframeAnimation`
@@ -61,8 +60,9 @@ extension CALayer {
       keyframeValueMapping(keyframeModel.value)
     }
 
-    var keyTimes = keyframes.map { keyframeModel in
-      NSNumber(value: Float(context.relativeTime(of: keyframeModel.time)))
+    var keyTimes = keyframes.map { keyframeModel -> NSNumber in
+      let progressTime = context.animation.progressTime(forFrame: keyframeModel.time, clamped: false)
+      return NSNumber(value: Float(progressTime))
     }
 
     // Compute the timing function between each keyframe and the subsequent keyframe
@@ -116,16 +116,7 @@ extension CALayer {
     animation.keyTimes = keyTimes
     animation.timingFunctions = timingFunctions
 
-    add(animation, forKey: keyPath.name)
+    add(animation.timed(with: context), forKey: keyPath.name)
   }
 
-}
-
-// MARK: - LayerAnimationContext helpers
-
-extension LayerAnimationContext {
-  /// The relative time (between 0 and 1) of the given absolute time value.
-  func relativeTime(of absoluteTime: AnimationFrameTime) -> AnimationProgressTime {
-    (absoluteTime / endFrame) + startFrame
-  }
 }

--- a/Sources/Private/Experimental/Animations/VisibilityAnimation.swift
+++ b/Sources/Private/Experimental/Animations/VisibilityAnimation.swift
@@ -26,12 +26,11 @@ extension CALayer {
     //    there should be three key times.
     animation.keyTimes = [
       NSNumber(value: 0.0),
-      NSNumber(value: Double(context.relativeTime(of: inFrame))),
-      NSNumber(value: Double(context.relativeTime(of: outFrame))),
+      NSNumber(value: Double(context.animation.progressTime(forFrame: inFrame))),
+      NSNumber(value: Double(context.animation.progressTime(forFrame: outFrame))),
       NSNumber(value: 1.0),
     ]
 
-    animation.configureTiming(with: context)
-    add(animation, forKey: #keyPath(isHidden))
+    add(animation.timed(with: context), forKey: #keyPath(isHidden))
   }
 }

--- a/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
+++ b/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
@@ -40,7 +40,7 @@ final class ExperimentalAnimationLayer: CALayer {
 
   /// Timing-related configuration to apply to this layer's child `CAAnimation`s
   ///  - This is effectively a configurable subset of `CAMediaTiming`
-  struct TimingConfiguration {
+  struct CAMediaTimingConfiguration {
     var autoreverses = false
     var repeatCount: Float = 0
     var speed: Float = 1
@@ -48,21 +48,21 @@ final class ExperimentalAnimationLayer: CALayer {
   }
 
   /// Sets up `CAAnimation`s for each `AnimationLayer` in the layer hierarchy
-  func setupAnimation(timingConfiguration: TimingConfiguration) {
+  func setupAnimation(
+    context: AnimationContext,
+    timingConfiguration: CAMediaTimingConfiguration)
+  {
     self.timingConfiguration = timingConfiguration
+    completionHandlerDelegate = context.closure
 
-    let context = LayerAnimationContext(
+    let layerContext = LayerAnimationContext(
+      animation: animation,
       timingConfiguration: timingConfiguration,
-      startFrame: animation.startFrame,
-      endFrame: animation.endFrame,
-      framerate: CGFloat(animation.framerate))
+      startFrame: context.playFrom,
+      endFrame: context.playTo)
 
     // Remove any existing animations from the layer hierarchy
-    removeAllAnimations()
-
-    for sublayer in allSublayers {
-      sublayer.removeAllAnimations()
-    }
+    removeAnimations()
 
     // Perform a layout pass if necessary so all of the sublayers
     // have the most up-to-date sizing information
@@ -74,11 +74,11 @@ final class ExperimentalAnimationLayer: CALayer {
     speed = timingConfiguration.speed
 
     // Setup a placeholder animation to let us track the realtime animation progress
-    setupPlaceholderAnimation(context: context)
+    setupPlaceholderAnimation(context: layerContext)
 
     // Set up the new animations with the current `TimingConfiguration`
     for animationLayer in childAnimationLayers {
-      animationLayer.setupAnimations(context: context)
+      animationLayer.setupAnimations(context: layerContext)
     }
   }
 
@@ -102,7 +102,12 @@ final class ExperimentalAnimationLayer: CALayer {
   // MARK: Private
 
   /// The timing configuration that is being used for the currently-active animation
-  private var timingConfiguration: TimingConfiguration?
+  private var timingConfiguration: CAMediaTimingConfiguration?
+
+  /// A strong reference to the `AnimationCompletionDelegate`
+  /// that serves as the `CAAnimationDelegate` of our animation
+  /// (so `AnimationView` can attach a completion handler).
+  private var completionHandlerDelegate: AnimationCompletionDelegate?
 
   /// The current progress of the placeholder `CAAnimation`,
   /// which is also the realtime animation progress of this layer's animation
@@ -125,10 +130,12 @@ final class ExperimentalAnimationLayer: CALayer {
   /// realtime animation progress via `self.currentFrame`.
   private func setupPlaceholderAnimation(context: LayerAnimationContext) {
     let animationProgressTracker = CABasicAnimation(keyPath: #keyPath(animationProgress))
-    animationProgressTracker.configureTiming(with: context)
     animationProgressTracker.fromValue = 0
     animationProgressTracker.toValue = 1
-    add(animationProgressTracker, forKey: #keyPath(animationProgress))
+
+    let timedProgressAnimation = animationProgressTracker.timed(with: context)
+    timedProgressAnimation.delegate = completionHandlerDelegate
+    add(timedProgressAnimation, forKey: #keyPath(animationProgress))
   }
 
 }
@@ -197,14 +204,23 @@ extension CALayer {
 
 extension ExperimentalAnimationLayer: RootAnimationLayer {
 
+  var primaryAnimationKey: AnimationKey {
+    .specific(#keyPath(animationProgress))
+  }
+
   var currentFrame: AnimationFrameTime {
     get {
       animation.frameTime(forProgress: (presentation() ?? self).animationProgress)
     }
     set {
-      setupAnimation(timingConfiguration: .init(
-        speed: 0,
-        timeOffset: animation.time(forFrame: newValue)))
+      setupAnimation(
+        context: .init(
+          playFrom: animation.startFrame,
+          playTo: animation.endFrame,
+          closure: nil),
+        timingConfiguration: .init(
+          speed: 0,
+          timeOffset: animation.time(forFrame: newValue)))
     }
   }
 
@@ -263,6 +279,13 @@ extension ExperimentalAnimationLayer: RootAnimationLayer {
 
   func animatorNodes(for _: AnimationKeypath) -> [AnimatorNode]? {
     fatalError("Currently unsupported")
+  }
+
+  func removeAnimations() {
+    self.removeAllAnimations()
+    for sublayer in allSublayers {
+      sublayer.removeAllAnimations()
+    }
   }
 
 }

--- a/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
+++ b/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
@@ -282,7 +282,7 @@ extension ExperimentalAnimationLayer: RootAnimationLayer {
   }
 
   func removeAnimations() {
-    self.removeAllAnimations()
+    removeAllAnimations()
     for sublayer in allSublayers {
       sublayer.removeAllAnimations()
     }

--- a/Sources/Private/Experimental/Layers/AnimationLayer.swift
+++ b/Sources/Private/Experimental/Layers/AnimationLayer.swift
@@ -48,6 +48,7 @@ extension CAAnimation {
     //
     let baseAnimation = self
     baseAnimation.duration = context.animation.duration
+    baseAnimation.speed = (context.endFrame < context.startFrame) ? -1 : 1
 
     // To select the subrange of the `baseAnimation` that should be played,
     // we create a parent animation with the duration of that subrange
@@ -66,7 +67,7 @@ extension CAAnimation {
     let clippingParent = CAAnimationGroup()
     clippingParent.animations = [baseAnimation]
 
-    clippingParent.duration = context.animation.time(forFrame: context.endFrame - context.startFrame)
+    clippingParent.duration = abs(context.animation.time(forFrame: context.endFrame - context.startFrame))
     baseAnimation.timeOffset = context.animation.time(forFrame: context.startFrame)
 
     clippingParent.autoreverses = context.timingConfiguration.autoreverses

--- a/Sources/Private/Experimental/Layers/AnimationLayer.swift
+++ b/Sources/Private/Experimental/Layers/AnimationLayer.swift
@@ -17,36 +17,66 @@ protocol AnimationLayer: CALayer {
 
 // Context describing the timing parameters of the current animation
 struct LayerAnimationContext {
+  /// The animation being played
+  let animation: Animation
+
   /// The timing configuration that should be applied to `CAAnimation`s
-  let timingConfiguration: ExperimentalAnimationLayer.TimingConfiguration
+  let timingConfiguration: ExperimentalAnimationLayer.CAMediaTimingConfiguration
 
   /// The absolute frame number that this animation begins at
   let startFrame: AnimationFrameTime
 
   /// The absolute frame number that this animation ends at
   let endFrame: AnimationFrameTime
-
-  /// The frame rate that this animation is played at
-  let framerate: CGFloat
-
-  /// The duration of this animation, in seconds
-  var duration: TimeInterval {
-    let frameDuration = endFrame - startFrame
-    return TimeInterval(frameDuration / framerate)
-  }
 }
 
 // MARK: - CAAnimation + LayerAnimationContext
 
 extension CAAnimation {
-  /// Configures the timing properties of this `CAAnimation`
-  /// using the current `LayerAnimationContext`
-  func configureTiming(with context: LayerAnimationContext) {
-    duration = context.duration
-    repeatCount = context.timingConfiguration.repeatCount
-    autoreverses = context.timingConfiguration.autoreverses
-    timeOffset = context.timingConfiguration.timeOffset
-    isRemovedOnCompletion = false
-    fillMode = .both
+  /// Creates a `CAAnimation` that wraps this animation,
+  /// applying timing-related configuration from the given `LayerAnimationContext`
+  func timed(with context: LayerAnimationContext) -> CAAnimation {
+
+    // The base animation always has the duration of the full animation,
+    // since that's the time space where keyframing and interpolating happens.
+    // So we start with a simple animation timeline from 0% to 100%:
+    //
+    //  ┌──────────────────────────────────┐
+    //  │           baseAnimation          │
+    //  └──────────────────────────────────┘
+    //  0%                                100%
+    //
+    let baseAnimation = self
+    baseAnimation.duration = context.animation.duration
+
+    // To select the subrange of the `baseAnimation` that should be played,
+    // we create a parent animation with the duration of that subrange
+    // to clip the `baseAnimation`. This parent animation can then loop
+    // and/or autoreverse over the clipped subrange.
+    //
+    //        ┌────────────────────┬───────►
+    //        │   clippingParent   │  ...
+    //        └────────────────────┴───────►
+    //       25%                  75%
+    //  ┌──────────────────────────────────┐
+    //  │           baseAnimation          │
+    //  └──────────────────────────────────┘
+    //  0%                                100%
+    //
+    let clippingParent = CAAnimationGroup()
+    clippingParent.animations = [baseAnimation]
+
+    clippingParent.duration = context.animation.time(forFrame: context.endFrame - context.startFrame)
+    baseAnimation.timeOffset = context.animation.time(forFrame: context.startFrame)
+
+    clippingParent.autoreverses = context.timingConfiguration.autoreverses
+    clippingParent.repeatCount = context.timingConfiguration.repeatCount
+    clippingParent.timeOffset = context.timingConfiguration.timeOffset
+
+    // Once the animation ends, it should pause on the final frame
+    clippingParent.fillMode = .both
+    clippingParent.isRemovedOnCompletion = false
+
+    return clippingParent
   }
 }

--- a/Sources/Private/LayerContainers/AnimationContainer.swift
+++ b/Sources/Private/LayerContainers/AnimationContainer.swift
@@ -144,6 +144,10 @@ final class AnimationContainer: CALayer, RootAnimationLayer {
 
   var animationLayers: ContiguousArray<CompositionLayer>
 
+  var primaryAnimationKey: AnimationKey {
+    .managed
+  }
+
   var _animationLayers: [CALayer] {
     Array(animationLayers)
   }
@@ -175,6 +179,10 @@ final class AnimationContainer: CALayer, RootAnimationLayer {
 
   func reloadImages() {
     layerImageProvider.reloadImages()
+  }
+
+  func removeAnimations() {
+    // no-op, since the primary animation is managed by the `AnimationView`.
   }
 
   /// Forces the view to update its drawing.

--- a/Sources/Private/LayerContainers/RootAnimationLayer.swift
+++ b/Sources/Private/LayerContainers/RootAnimationLayer.swift
@@ -14,6 +14,14 @@ protocol RootAnimationLayer: CALayer {
   var textProvider: AnimationTextProvider { get set }
   var fontProvider: AnimationFontProvider { get set }
 
+  /// The `CAAnimation` key corresponding to the primary animation.
+  ///  - `AnimationView` uses this key to check if the animation is still active
+  var primaryAnimationKey: AnimationKey { get }
+
+  /// Instructs this layer to remove all `CAAnimation`s,
+  /// other than the `CAAnimation` managed by `AnimationView` (if applicable)
+  func removeAnimations()
+
   func reloadImages()
   func forceDisplayUpdate()
   func logHierarchyKeypaths()
@@ -23,4 +31,11 @@ protocol RootAnimationLayer: CALayer {
 
   func layer(for keypath: AnimationKeypath) -> CALayer?
   func animatorNodes(for keypath: AnimationKeypath) -> [AnimatorNode]?
+}
+
+enum AnimationKey {
+  /// The primary animation and its key should be managed by `AnimationView`
+  case managed
+  /// The primary animation always uses the given key
+  case specific(String)
 }

--- a/Sources/Private/LayerContainers/RootAnimationLayer.swift
+++ b/Sources/Private/LayerContainers/RootAnimationLayer.swift
@@ -3,6 +3,8 @@
 
 import QuartzCore
 
+// MARK: - RootAnimationLayer
+
 /// A root `CALayer` responsible for playing a Lottie animation
 protocol RootAnimationLayer: CALayer {
   var currentFrame: AnimationFrameTime { get set }
@@ -32,6 +34,8 @@ protocol RootAnimationLayer: CALayer {
   func layer(for keypath: AnimationKeypath) -> CALayer?
   func animatorNodes(for keypath: AnimationKeypath) -> [AnimatorNode]?
 }
+
+// MARK: - AnimationKey
 
 enum AnimationKey {
   /// The primary animation and its key should be managed by `AnimationView`

--- a/Sources/Private/Utility/Helpers/AnimationContext.swift
+++ b/Sources/Private/Utility/Helpers/AnimationContext.swift
@@ -17,8 +17,8 @@ public typealias LottieCompletionBlock = (Bool) -> Void
 struct AnimationContext {
 
   init(
-    playFrom: CGFloat,
-    playTo: CGFloat,
+    playFrom: AnimationFrameTime,
+    playTo: AnimationFrameTime,
     closure: LottieCompletionBlock?)
   {
     self.playTo = playTo
@@ -26,8 +26,8 @@ struct AnimationContext {
     self.closure = AnimationCompletionDelegate(completionBlock: closure)
   }
 
-  var playFrom: CGFloat
-  var playTo: CGFloat
+  var playFrom: AnimationFrameTime
+  var playTo: AnimationFrameTime
   var closure: AnimationCompletionDelegate
 
 }

--- a/Sources/Public/Animation/AnimationPublic.swift
+++ b/Sources/Public/Animation/AnimationPublic.swift
@@ -184,9 +184,20 @@ extension Animation {
     return marker.frameTime
   }
 
-  /// Converts Frame Time (Seconds * Framerate) into Progress Time (0 to 1).
-  public func progressTime(forFrame frameTime: AnimationFrameTime) -> AnimationProgressTime {
-    ((frameTime - startFrame) / (endFrame - startFrame)).clamp(0, 1)
+  /// Converts Frame Time (Seconds * Framerate) into Progress Time
+  /// (optionally clamped to between 0 and 1).
+  public func progressTime(
+    forFrame frameTime: AnimationFrameTime,
+    clamped: Bool = true)
+    -> AnimationProgressTime
+  {
+    let progressTime = ((frameTime - startFrame) / (endFrame - startFrame))
+
+    if clamped {
+      return progressTime.clamp(0, 1)
+    } else {
+      return progressTime
+    }
   }
 
   /// Converts Progress Time (0 to 1) into Frame Time (Seconds * Framerate)

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -173,7 +173,7 @@ final public class AnimationView: LottieView {
 
   /// Returns `true` if the animation is currently playing.
   public var isAnimationPlaying: Bool {
-    return animationLayer?.animation(forKey: activeAnimationName) != nil
+    animationLayer?.animation(forKey: activeAnimationName) != nil
   }
 
   /// Returns `true` if the animation will start playing when this view is added to a window.

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -173,14 +173,7 @@ final public class AnimationView: LottieView {
 
   /// Returns `true` if the animation is currently playing.
   public var isAnimationPlaying: Bool {
-    let caAnimationName: String
-    if animationLayer is ExperimentalAnimationLayer {
-      caAnimationName = "animationProgress"
-    } else {
-      caAnimationName = activeAnimationName
-    }
-
-    return animationLayer?.animation(forKey: caAnimationName) != nil
+    return animationLayer?.animation(forKey: activeAnimationName) != nil
   }
 
   /// Returns `true` if the animation will start playing when this view is added to a window.
@@ -876,10 +869,19 @@ final public class AnimationView: LottieView {
   // MARK: Fileprivate
 
   fileprivate var animationContext: AnimationContext?
-  fileprivate var activeAnimationName: String = AnimationView.animationName
+  fileprivate var _activeAnimationName: String = AnimationView.animationName
   fileprivate var animationID: Int = 0
 
   fileprivate var waitingToPlayAnimation: Bool = false
+
+  fileprivate var activeAnimationName: String {
+    switch animationLayer?.primaryAnimationKey {
+    case .specific(let animationKey):
+      return animationKey
+    case .managed, nil:
+      return _activeAnimationName
+    }
+  }
 
   // MARK: - Private (Building Animation View)
 
@@ -997,13 +999,14 @@ final public class AnimationView: LottieView {
     guard window != nil else { waitingToPlayAnimation = true; return }
 
     animationID = animationID + 1
-    activeAnimationName = AnimationView.animationName + String(animationID)
+    _activeAnimationName = AnimationView.animationName + String(animationID)
 
     // TODO: Improve this integration point with the experimental rendering engine
     // (e.g. when changing the `loopMode`, the new animation should begin at
     // `currentFrame` instead of starting from the beginning.)
     if let experimentalAnimationLayer = animationlayer as? ExperimentalAnimationLayer {
       experimentalAnimationLayer.setupAnimation(
+        context: animationContext,
         timingConfiguration: .init(
           autoreverses: loopMode.caAnimationConfiguration.autoreverses,
           repeatCount: loopMode.caAnimationConfiguration.repeatCount,


### PR DESCRIPTION
This PR adds support for animating custom time ranges in `ExperimentalAnimationLayer` (it was previously hardcoded to always play from 0% to 100%).

Now `AnimatedControl` and `AnimatedButton` almost completely work:

| Custom time ranges | Controls demo |
| ----- | ----- |
| ![2022-01-05 12 15 17](https://user-images.githubusercontent.com/1811727/148304622-25c8246d-5cfa-4abe-aa40-8e48f9dc1f7a.gif) | ![2022-01-05 15 24 23](https://user-images.githubusercontent.com/1811727/148304642-8c2aa6be-255e-4330-8782-5210efb42fe7.gif) |

The only lingering issue is with interrupting in-flight animations -- the standard engine resumes the new animation from where the previous animation left off, but the experimental engine always starts from the beginning. Will work on this in a follow-up.