### PR TITLE
Play new animations from current frame of existing animation

### DIFF
--- a/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
+++ b/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
@@ -55,8 +55,6 @@ class AnimationPreviewViewController: UIViewController {
     slider.bottomAnchor.constraint(equalTo: view.layoutMarginsGuide.bottomAnchor, constant: -12).isActive = true
     slider.addTarget(self, action: #selector(updateAnimation(sender:)), for: .valueChanged)
 
-    /// Play Animation
-
     /// Create a display link to make slider track with animation progress.
     displayLink = CADisplayLink(target: self, selector: #selector(animationCallback))
     displayLink?.add(

--- a/Sources/Private/Experimental/Animations/CAAnimation+TimingConfiguration.swift
+++ b/Sources/Private/Experimental/Animations/CAAnimation+TimingConfiguration.swift
@@ -1,0 +1,73 @@
+// Created by Cal Stephens on 1/6/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import QuartzCore
+
+// MARK: - LayerAnimationContext
+
+// Context describing the timing parameters of the current animation
+struct LayerAnimationContext {
+  /// The animation being played
+  let animation: Animation
+
+  /// The timing configuration that should be applied to `CAAnimation`s
+  let timingConfiguration: ExperimentalAnimationLayer.CAMediaTimingConfiguration
+
+  /// The absolute frame number that this animation begins at
+  let startFrame: AnimationFrameTime
+
+  /// The absolute frame number that this animation ends at
+  let endFrame: AnimationFrameTime
+}
+
+// MARK: - CAAnimation + LayerAnimationContext
+
+extension CAAnimation {
+  /// Creates a `CAAnimation` that wraps this animation,
+  /// applying timing-related configuration from the given `LayerAnimationContext`
+  func timed(with context: LayerAnimationContext) -> CAAnimation {
+
+    // The base animation always has the duration of the full animation,
+    // since that's the time space where keyframing and interpolating happens.
+    // So we start with a simple animation timeline from 0% to 100%:
+    //
+    //  ┌──────────────────────────────────┐
+    //  │           baseAnimation          │
+    //  └──────────────────────────────────┘
+    //  0%                                100%
+    //
+    let baseAnimation = self
+    baseAnimation.duration = context.animation.duration
+    baseAnimation.speed = (context.endFrame < context.startFrame) ? -1 : 1
+
+    // To select the subrange of the `baseAnimation` that should be played,
+    // we create a parent animation with the duration of that subrange
+    // to clip the `baseAnimation`. This parent animation can then loop
+    // and/or autoreverse over the clipped subrange.
+    //
+    //        ┌────────────────────┬───────►
+    //        │   clippingParent   │  ...
+    //        └────────────────────┴───────►
+    //       25%                  75%
+    //  ┌──────────────────────────────────┐
+    //  │           baseAnimation          │
+    //  └──────────────────────────────────┘
+    //  0%                                100%
+    //
+    let clippingParent = CAAnimationGroup()
+    clippingParent.animations = [baseAnimation]
+
+    clippingParent.duration = abs(context.animation.time(forFrame: context.endFrame - context.startFrame))
+    baseAnimation.timeOffset = context.animation.time(forFrame: context.startFrame)
+
+    clippingParent.autoreverses = context.timingConfiguration.autoreverses
+    clippingParent.repeatCount = context.timingConfiguration.repeatCount
+    clippingParent.timeOffset = context.timingConfiguration.timeOffset
+
+    // Once the animation ends, it should pause on the final frame
+    clippingParent.fillMode = .both
+    clippingParent.isRemovedOnCompletion = false
+
+    return clippingParent
+  }
+}

--- a/Sources/Private/Experimental/Layers/AnimationLayer.swift
+++ b/Sources/Private/Experimental/Layers/AnimationLayer.swift
@@ -3,81 +3,10 @@
 
 import QuartzCore
 
-// MARK: - AnimationLayer
-
 /// A type of `CALayer` that can be used in a Lottie animation
 ///  - Layers backed by a `LayerModel` subclass should subclass `BaseCompositionLayer`
 protocol AnimationLayer: CALayer {
   /// Instructs this layer to setup its `CAAnimation`s
   /// using the given `LayerAnimationContext`
   func setupAnimations(context: LayerAnimationContext)
-}
-
-// MARK: - LayerAnimationContext
-
-// Context describing the timing parameters of the current animation
-struct LayerAnimationContext {
-  /// The animation being played
-  let animation: Animation
-
-  /// The timing configuration that should be applied to `CAAnimation`s
-  let timingConfiguration: ExperimentalAnimationLayer.CAMediaTimingConfiguration
-
-  /// The absolute frame number that this animation begins at
-  let startFrame: AnimationFrameTime
-
-  /// The absolute frame number that this animation ends at
-  let endFrame: AnimationFrameTime
-}
-
-// MARK: - CAAnimation + LayerAnimationContext
-
-extension CAAnimation {
-  /// Creates a `CAAnimation` that wraps this animation,
-  /// applying timing-related configuration from the given `LayerAnimationContext`
-  func timed(with context: LayerAnimationContext) -> CAAnimation {
-
-    // The base animation always has the duration of the full animation,
-    // since that's the time space where keyframing and interpolating happens.
-    // So we start with a simple animation timeline from 0% to 100%:
-    //
-    //  ┌──────────────────────────────────┐
-    //  │           baseAnimation          │
-    //  └──────────────────────────────────┘
-    //  0%                                100%
-    //
-    let baseAnimation = self
-    baseAnimation.duration = context.animation.duration
-    baseAnimation.speed = (context.endFrame < context.startFrame) ? -1 : 1
-
-    // To select the subrange of the `baseAnimation` that should be played,
-    // we create a parent animation with the duration of that subrange
-    // to clip the `baseAnimation`. This parent animation can then loop
-    // and/or autoreverse over the clipped subrange.
-    //
-    //        ┌────────────────────┬───────►
-    //        │   clippingParent   │  ...
-    //        └────────────────────┴───────►
-    //       25%                  75%
-    //  ┌──────────────────────────────────┐
-    //  │           baseAnimation          │
-    //  └──────────────────────────────────┘
-    //  0%                                100%
-    //
-    let clippingParent = CAAnimationGroup()
-    clippingParent.animations = [baseAnimation]
-
-    clippingParent.duration = abs(context.animation.time(forFrame: context.endFrame - context.startFrame))
-    baseAnimation.timeOffset = context.animation.time(forFrame: context.startFrame)
-
-    clippingParent.autoreverses = context.timingConfiguration.autoreverses
-    clippingParent.repeatCount = context.timingConfiguration.repeatCount
-    clippingParent.timeOffset = context.timingConfiguration.timeOffset
-
-    // Once the animation ends, it should pause on the final frame
-    clippingParent.fillMode = .both
-    clippingParent.isRemovedOnCompletion = false
-
-    return clippingParent
-  }
 }


### PR DESCRIPTION
This PR updates `AnimationView`'s integration with `ExperimentalAnimationLayer` to play new animations from the `currentFrame` of the existing animation. This matches the behavior of the existing rendering engine, and fixes support for interruptible animations in `AnimatedSwitch`.

| Different `LottieLoopMode`s | Interruptible `AnimatedSwitch` animations | 
| ----- | ----- |
| ![2022-01-06 10 19 21](https://user-images.githubusercontent.com/1811727/148432861-873f10cf-a284-45b2-bd10-8e7066b3a615.gif) | ![2022-01-06 10 22 49](https://user-images.githubusercontent.com/1811727/148432866-9b2101c8-5216-40df-b068-f125da82c6c7.gif) |