### PR TITLE
Fix keyframe timing regression when playing animations in real time

### DIFF
--- a/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
+++ b/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
@@ -22,6 +22,11 @@ class AnimationPreviewViewController: UIViewController {
 
   // MARK: Internal
 
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    displayLink?.invalidate()
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .systemBackground

--- a/Sources/Private/Experimental/Animations/CAAnimation+TimingConfiguration.swift
+++ b/Sources/Private/Experimental/Animations/CAAnimation+TimingConfiguration.swift
@@ -74,8 +74,12 @@ extension CAAnimation {
     //    of this animation to a time slightly before the current time.
     //  - It's not really clear why this is necessary, but `timeOffset`
     //    is not applied correctly without this configuration.
-    let currentTime = layer.convertTime(CACurrentMediaTime(), from: nil)
-    clippingParent.beginTime = currentTime - .leastNonzeroMagnitude
+    //  - We can't do this when playing the animation in real time,
+    //    because it can cause keyframe timings to be incorrect.
+    if context.timingConfiguration.speed == 0 {
+      let currentTime = layer.convertTime(CACurrentMediaTime(), from: nil)
+      clippingParent.beginTime = currentTime - .leastNonzeroMagnitude
+    }
 
     return clippingParent
   }

--- a/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
+++ b/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
@@ -7,6 +7,10 @@
 /// to change or be removed at any time.
 public struct ExperimentalFeatureConfiguration {
 
+  public init(useNewRenderingEngine: Bool = false) {
+    self.useNewRenderingEngine = useNewRenderingEngine
+  }
+
   /// The singleton configuration for experimental features,
   /// which applies to all `AnimationView`s by default.
   public static var shared = ExperimentalFeatureConfiguration()
@@ -15,9 +19,5 @@ public struct ExperimentalFeatureConfiguration {
   /// which leverages the Core Animation render server to
   /// animate without executing on the main thread every frame.
   public var useNewRenderingEngine: Bool
-
-  public init(useNewRenderingEngine: Bool = false) {
-    self.useNewRenderingEngine = useNewRenderingEngine
-  }
 
 }

--- a/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
+++ b/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
@@ -14,7 +14,7 @@ public struct ExperimentalFeatureConfiguration {
   /// Whether or not to use the new, experimental, rendering engine,
   /// which leverages the Core Animation render server to
   /// animate without executing on the main thread every frame.
-  public var useNewRenderingEngine = false
+  public var useNewRenderingEngine: Bool
 
   public init(useNewRenderingEngine: Bool = false) {
     self.useNewRenderingEngine = useNewRenderingEngine

--- a/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
+++ b/Sources/Private/Experimental/ExperimentalFeatureConfiguration.swift
@@ -16,4 +16,8 @@ public struct ExperimentalFeatureConfiguration {
   /// animate without executing on the main thread every frame.
   public var useNewRenderingEngine = false
 
+  public init(useNewRenderingEngine: Bool = false) {
+    self.useNewRenderingEngine = useNewRenderingEngine
+  }
+
 }

--- a/Sources/Public/iOS/AnimatedButton.swift
+++ b/Sources/Public/iOS/AnimatedButton.swift
@@ -15,8 +15,11 @@ open class AnimatedButton: AnimatedControl {
 
   // MARK: Lifecycle
 
-  public override init(animation: Animation) {
-    super.init(animation: animation)
+  public override init(
+    animation: Animation,
+    _experimentalFeatureConfiguration: ExperimentalFeatureConfiguration = .shared)
+  {
+    super.init(animation: animation, _experimentalFeatureConfiguration: _experimentalFeatureConfiguration)
     accessibilityTraits = UIAccessibilityTraits.button
   }
 

--- a/Sources/Public/iOS/AnimatedControl.swift
+++ b/Sources/Public/iOS/AnimatedControl.swift
@@ -32,8 +32,14 @@ open class AnimatedControl: UIControl {
 
   // MARK: Initializers
 
-  public init(animation: Animation) {
-    animationView = AnimationView(animation: animation)
+  public init(
+    animation: Animation,
+    _experimentalFeatureConfiguration: ExperimentalFeatureConfiguration = .shared)
+  {
+    animationView = AnimationView(
+      animation: animation,
+      _experimentalFeatureConfiguration: _experimentalFeatureConfiguration)
+
     super.init(frame: animation.bounds)
     commonInit()
   }


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/airbnb/lottie-ios/pull/1478, where keyframe timing could be incorrect when playing animations in real time (e.g. when not just setting `currentFrame`).

We don't have automated tests for real time animations, which is why this wasn't caught by CI (I've tried to get these to work several times and haven't been able to figure out how).

| Before | After |
| ----- | ---- |
| ![Simulator Screen Shot - iPhone 12 Pro Max - 2022-01-12 at 12 44 40](https://user-images.githubusercontent.com/1811727/149381049-ebfde20f-51c6-4282-ae86-1acaba67ad9c.png) | ![Simulator Screen Shot - iPhone 12 Pro Max - 2022-01-12 at 12 44 50](https://user-images.githubusercontent.com/1811727/149381066-76765a25-d386-4bd4-9bac-04aaf386a66c.png) |