### PR TITLE
Rebuild current animation after registering new value provider

### DIFF
--- a/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
+++ b/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
@@ -123,6 +123,13 @@ final class ExperimentalAnimationLayer: CALayer {
   // Configuration for the animation that is currently setup in this layer
   private var currentAnimationConfiguration: AnimationConfiguration?
 
+  /// The current progress of the placeholder `CAAnimation`,
+  /// which is also the realtime animation progress of this layer's animation
+  @objc private var animationProgress: CGFloat = 0
+
+  private let animation: Animation
+  private let valueProviderStore = ValueProviderStore()
+
   // The current state of the animation that is playing in this layer
   private var playbackState: PlaybackState? {
     didSet {
@@ -134,13 +141,6 @@ final class ExperimentalAnimationLayer: CALayer {
       }
     }
   }
-
-  /// The current progress of the placeholder `CAAnimation`,
-  /// which is also the realtime animation progress of this layer's animation
-  @objc private var animationProgress: CGFloat = 0
-
-  private let animation: Animation
-  private let valueProviderStore = ValueProviderStore()
 
   private func setup() {
     bounds = animation.bounds

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -149,21 +149,16 @@ class SnapshotTests: XCTestCase {
           _experimentalFeatureConfiguration: ExperimentalFeatureConfiguration(
             useNewRenderingEngine: usingExperimentalRenderingEngine))
 
-        // TODO: If we move this below where we set `animationView.currentProgress`,
-        // the tests for the legacy engine succeed but the tests for the experimental
-        // engine fail. This is because the experimental engine currently doesn't
-        // automatically re-build the animation after registering new value providers,
-        // which needs to be fixed.
-        for (keypath, customValueProvider) in configuration.customValueProviders {
-          animationView.setValueProvider(customValueProvider, keypath: keypath)
-        }
-
         // Set up the animation view with a valid frame and layout
         // so the geometry is correct when setting up the `CAAnimation`s
         animationView.frame.size = animation.snapshotSize
         animationView.layoutIfNeeded()
 
         animationView.currentProgress = CGFloat(percent)
+
+        for (keypath, customValueProvider) in configuration.customValueProviders {
+          animationView.setValueProvider(customValueProvider, keypath: keypath)
+        }
 
         assertSnapshot(
           matching: animationView,


### PR DESCRIPTION
This PR fixes an issue where new `ValueProvider`s wouldn't take effect until the next time an animation is set up.

| Before | After |
| ----- | ----- |
| ![2022-01-19 15 28 55](https://user-images.githubusercontent.com/1811727/150235384-234ebdd8-e374-469c-807a-1902583a81d5.gif) | ![2022-01-19 15 27 57](https://user-images.githubusercontent.com/1811727/150235393-f76dca5e-58fb-4409-8b37-c51bdc962ebc.gif) |