### PR TITLE
Rename LottieView to AnimationViewBase

### DIFF
--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -1,5 +1,5 @@
 //
-//  LottieView.swift
+//  AnimationView.swift
 //  lottie-swift
 //
 //  Created by Brandon Withrow on 1/23/19.
@@ -59,13 +59,13 @@ extension LottieLoopMode: Equatable {
 // MARK: - AnimationView
 
 @IBDesignable
-final public class AnimationView: LottieView {
+final public class AnimationView: AnimationViewBase {
 
   // MARK: Lifecycle
 
   // MARK: - Public (Initializers)
 
-  /// Initializes a LottieView with an animation.
+  /// Initializes an AnimationView with an animation.
   public init(
     animation: Animation?,
     imageProvider: AnimationImageProvider? = nil,

--- a/Sources/Public/iOS/AnimationViewBase.swift
+++ b/Sources/Public/iOS/AnimationViewBase.swift
@@ -1,32 +1,32 @@
 //
-//  LottieView.swift
+//  AnimationViewBase.swift
 //  lottie-swift-iOS
 //
 //  Created by Brandon Withrow on 2/6/19.
 //
 
-import Foundation
 #if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
 import UIKit
 
-//public typealias LottieView = UIView
+/// The base view for `AnimationView` on iOS, tvOS, watchOS, and macCatalyst.
+///
+/// Enables the `AnimationView` implementation to be shared across platforms.
+public class AnimationViewBase: UIView {
 
-open class LottieView: UIView {
+  // MARK: Public
 
-  // MARK: Open
-
-  open override var contentMode: UIView.ContentMode {
+  public override var contentMode: UIView.ContentMode {
     didSet {
       setNeedsLayout()
     }
   }
 
-  open override func didMoveToWindow() {
+  public override func didMoveToWindow() {
     super.didMoveToWindow()
     animationMovedToWindow()
   }
 
-  open override func layoutSubviews() {
+  public override func layoutSubviews() {
     super.layoutSubviews()
     layoutAnimation()
   }
@@ -42,11 +42,11 @@ open class LottieView: UIView {
   }
 
   func layoutAnimation() {
-
+    // Implemented by subclasses.
   }
 
   func animationMovedToWindow() {
-
+    // Implemented by subclasses.
   }
 
   func commonInit() {
@@ -66,10 +66,12 @@ open class LottieView: UIView {
 
   @objc
   func animationWillMoveToBackground() {
+    // Implemented by subclasses.
   }
 
   @objc
   func animationWillEnterForeground() {
+    // Implemented by subclasses.
   }
 
 }

--- a/Sources/Public/macOS/AnimationViewBase.macOS.swift
+++ b/Sources/Public/macOS/AnimationViewBase.macOS.swift
@@ -1,5 +1,5 @@
 //
-//  LottieView.swift
+//  AnimationViewBase.swift
 //  lottie-swift-iOS
 //
 //  Created by Brandon Withrow on 2/6/19.
@@ -24,9 +24,10 @@ public enum LottieContentMode: Int {
   case bottomRight
 }
 
-/// A wrapper around NSView for cross platform compatibility.
-
-public class LottieView: NSView {
+/// The base view for `AnimationView` on macOs.
+///
+/// Enables the `AnimationView` implementation to be shared across platforms.
+public class AnimationViewBase: NSView {
 
   // MARK: Public
 
@@ -68,11 +69,11 @@ public class LottieView: NSView {
   }
 
   func layoutAnimation() {
-
+    // Implemented by subclasses.
   }
 
   func animationMovedToWindow() {
-
+    // Implemented by subclasses.
   }
 
   func commonInit() {
@@ -84,15 +85,17 @@ public class LottieView: NSView {
   }
 
   func layoutIfNeeded() {
-
+    // Implemented by subclasses.
   }
 
   @objc
   func animationWillMoveToBackground() {
+    // Implemented by subclasses.
   }
 
   @objc
   func animationWillEnterForeground() {
+    // Implemented by subclasses.
   }
 
 }


### PR DESCRIPTION
This makes it more clear how this API is meant to be used (as an implementation detail to enable cross platform compatibility), and differentiates it from `AnimationView` to make it easier for consumers to understand that the public Lottie API is available on `AnimationView`, not `LottieView`.

While we're here we also remove the `open` from `AnimationViewBase` to make it more clear that it shouldn't be subclassed by consumers of Lottie.