### PR TITLE
Improve integration between AnimationView and ExperimentalAnimationLayer

### DIFF
--- a/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
+++ b/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
@@ -55,17 +55,7 @@ final class ExperimentalAnimationLayer: CALayer {
 
   /// The `AnimationImageProvider` that `ImageLayer`s use to retrieve images,
   /// referenced by name in the animation json.
-  var imageProvider: AnimationImageProvider {
-    didSet {
-      // When the image provider changes, we have to update all `ImageLayer`s
-      // so they can query the most up-to-date image from the new image provider.
-      for sublayer in allSublayers {
-        if let imageLayer = sublayer as? ImageLayer {
-          imageLayer.setupImage(context: layerContext)
-        }
-      }
-    }
-  }
+  var imageProvider: AnimationImageProvider
 
   /// Sets up `CAAnimation`s for each `AnimationLayer` in the layer hierarchy,
   /// playing from `currentFrame`.
@@ -281,7 +271,13 @@ extension ExperimentalAnimationLayer: RootAnimationLayer {
   }
 
   func reloadImages() {
-    LottieLogger.shared.assertionFailure("`reloadImages` is currently not implemented")
+    // When the image provider changes, we have to update all `ImageLayer`s
+    // so they can query the most up-to-date image from the new image provider.
+    for sublayer in allSublayers {
+      if let imageLayer = sublayer as? ImageLayer {
+        imageLayer.setupImage(context: layerContext)
+      }
+    }
   }
 
   func forceDisplayUpdate() {

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -900,27 +900,27 @@ final public class AnimationView: LottieView {
       return
     }
 
+    let animationLayer: RootAnimationLayer
     if experimentalFeatureConfiguration.useNewRenderingEngine {
-      let animationLayer = ExperimentalAnimationLayer(
+      animationLayer = ExperimentalAnimationLayer(
         animation: animation,
         imageProvider: imageProvider)
-
-      viewLayer?.addSublayer(animationLayer)
-      self.animationLayer = animationLayer
     } else {
-      let animationLayer = AnimationContainer(
+      animationLayer = AnimationContainer(
         animation: animation,
         imageProvider: imageProvider,
         textProvider: textProvider,
         fontProvider: fontProvider)
+
       animationLayer.renderScale = screenScale
-      viewLayer?.addSublayer(animationLayer)
-      self.animationLayer = animationLayer
-      reloadImages()
-      animationLayer.setNeedsDisplay()
-      setNeedsLayout()
-      currentFrame = CGFloat(animation.startFrame)
     }
+
+    viewLayer?.addSublayer(animationLayer)
+    self.animationLayer = animationLayer
+    reloadImages()
+    animationLayer.setNeedsDisplay()
+    setNeedsLayout()
+    currentFrame = CGFloat(animation.startFrame)
   }
 
   fileprivate func updateAnimationForBackgroundState() {

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -29,12 +29,6 @@ class SnapshotTests: XCTestCase {
   /// Validates that all of the snapshots in __Snapshots__ correspond to
   /// a sample JSON file that is visible to this test target.
   func testAllSnapshotsHaveCorrespondingSampleFile() {
-    // We don't want assertions to crash the tests, so we stub out the shared logger singleton
-    LottieLogger.shared = LottieLogger(
-      assert: { _, _, _, _ in },
-      assertionFailure: { _, _, _ in },
-      warn: { _, _, _ in })
-
     for snapshotURL in snapshotURLs {
       // The snapshot files follow the format `testCaseName.animationName-percentage.png`
       //  - We remove the known prefix and known suffixes to recover the input file name
@@ -74,6 +68,19 @@ class SnapshotTests: XCTestCase {
   func testCanAccessSamplesAndSnapshots() {
     XCTAssert(sampleAnimationURLs.count > 50)
     XCTAssert(snapshotURLs.count > 300)
+  }
+
+  override func setUp() {
+    // We don't want assertions to crash the snapshot tests,
+    // so we stub out the shared logger singleton
+    LottieLogger.shared = LottieLogger(
+      assert: { _, _, _, _ in },
+      assertionFailure: { _, _, _ in },
+      warn: { _, _, _ in })
+  }
+
+  override func tearDown() {
+    LottieLogger.shared = LottieLogger()
   }
 
   // MARK: Private
@@ -155,10 +162,9 @@ class SnapshotTests: XCTestCase {
           _experimentalFeatureConfiguration: ExperimentalFeatureConfiguration(
             useNewRenderingEngine: usingExperimentalRenderingEngine))
 
-        // Set up the animation view with a valid frame and layout
+        // Set up the animation view with a valid frame
         // so the geometry is correct when setting up the `CAAnimation`s
         animationView.frame.size = animation.snapshotSize
-        animationView.layoutIfNeeded()
 
         animationView.currentProgress = CGFloat(percent)
 


### PR DESCRIPTION
This PR improves the integration between `AnimationView` and `ExperimentalAnimationLayer`.

I'm working on adopting the new rendering engine in the Airbnb app. There are some cases where it hits a `Size must be non-zero before an animation can be played` assertion, even though the `AnimationView` has a valid frame / layout. This was because there was a different setup codepath for `ExperimentalAnimationLayer`, with slightly different behavior. This PR consolidates the two setup paths so they have more similar behavior.