### PR TITLE
Fix issue where animation would fail to play when currentFrame is approximately animationContext.playTo

### DIFF
--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -1013,8 +1013,10 @@ final public class AnimationView: AnimationViewBase {
 
       // The animation should start playing from the `currentFrame`,
       // if `currentFrame` is included in the time range being played.
-      // We have to configure this differently depending on the loop mode:
-      if currentFrame.clamp(animationContext.playFrom, animationContext.playTo) == currentFrame {
+      let lowerBoundTime = min(animationContext.playFrom, animationContext.playTo)
+      let upperBoundTime = max(animationContext.playFrom, animationContext.playTo)
+      if (lowerBoundTime ..< upperBoundTime).contains(round(currentFrame)) {
+        // We have to configure this differently depending on the loop mode:
         switch loopMode {
         // When playing exactly once (and not looping), we can just set the
         // `playFrom` time to be the `currentFrame`. Since the animation duration


### PR DESCRIPTION
This PR fixes an issue where an animation would fail to play when `currentFrame` is approximately `animationContext.playTo`.

For example, in the `AnimationButton` animations below, `currentFrame` is ~`50` (the animation's `endFrame`) when the animation finishes. When the next animation starts, `animationContext.playFrom` is set to `currentFrame` (`50`, aka `endFrame`), so the animation unexpectedly has a duration of ~0. This causes the animation to fail to play.

| Before | After |
| ----- | ---- |
| ![2022-01-21 10 56 28](https://user-images.githubusercontent.com/1811727/150586061-721d7190-cb2c-44d9-86b1-90470fe97cb1.gif) | ![2022-01-21 11 00 34](https://user-images.githubusercontent.com/1811727/150586070-1de8ab66-738e-49d3-a6ba-7c22168e9e0d.gif) |