### PR TITLE
Improve performance by batching animation setup to next display() call

### DIFF
--- a/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
+++ b/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
@@ -56,6 +56,13 @@ final class ExperimentalAnimationLayer: BaseAnimationLayer {
     var timeOffset: TimeInterval = 0
   }
 
+  enum PlaybackState: Equatable {
+    /// The animation is playing in real-time
+    case playing
+    /// The animation is statically displaying a specific frame
+    case paused(frame: AnimationFrameTime)
+  }
+
   /// The `AnimationImageProvider` that `ImageLayer`s use to retrieve images,
   /// referenced by name in the animation json.
   var imageProvider: AnimationImageProvider {
@@ -68,43 +75,20 @@ final class ExperimentalAnimationLayer: BaseAnimationLayer {
     didSet { reloadFonts() }
   }
 
-  /// Sets up `CAAnimation`s for each `AnimationLayer` in the layer hierarchy,
-  /// playing from `currentFrame`.
-  func setupAnimation(
+  /// Queues the animation with the given timing configuration
+  /// to begin playing at the next `display()` call.
+  ///   - This batches together animations so that even if `playAnimation`
+  ///     is called multiple times in the same run loop cycle, the animation will only be
+  func playAnimation(
     context: AnimationContext,
-    timingConfiguration: CAMediaTimingConfiguration)
+    timingConfiguration: CAMediaTimingConfiguration,
+    playbackState: PlaybackState = .playing)
   {
-    // Remove any existing animations from the layer hierarchy
-    removeAnimations()
+    pendingAnimationConfiguration = (
+      animationConfiguration: .init(animationContext: context, timingConfiguration: timingConfiguration),
+      playbackState: playbackState)
 
-    playbackState = .playing
-
-    currentAnimationConfiguration = AnimationConfiguration(
-      animationContext: context,
-      timingConfiguration: timingConfiguration)
-
-    let layerContext = LayerAnimationContext(
-      animation: animation,
-      timingConfiguration: timingConfiguration,
-      startFrame: context.playFrom,
-      endFrame: context.playTo,
-      valueProviderStore: valueProviderStore,
-      currentKeypath: AnimationKeypath(keys: []))
-
-    // Perform a layout pass if necessary so all of the sublayers
-    // have the most up-to-date sizing information
-    layoutIfNeeded()
-
-    // Set the speed of this layer, which will be inherited
-    // by all sublayers and their animations.
-    //  - This is required to support scrubbing with a speed of 0
-    speed = timingConfiguration.speed
-
-    // Setup a placeholder animation to let us track the realtime animation progress
-    setupPlaceholderAnimation(context: layerContext)
-
-    // Set up the new animations with the current `TimingConfiguration`
-    setupAnimations(context: layerContext)
+    setNeedsDisplay()
   }
 
   override func layoutSublayers() {
@@ -113,10 +97,21 @@ final class ExperimentalAnimationLayer: BaseAnimationLayer {
     // If no animation has been set up yet, display the first frame
     // now that the layer hierarchy has been setup and laid out
     if
+      pendingAnimationConfiguration == nil,
       currentAnimationConfiguration == nil,
       bounds.size != .zero
     {
       currentFrame = animation.frameTime(forProgress: animationProgress)
+    }
+  }
+
+  override func display() {
+    super.display()
+
+    if let pendingAnimationConfiguration = pendingAnimationConfiguration {
+      self.pendingAnimationConfiguration = nil
+      setupAnimation(for: pendingAnimationConfiguration.animationConfiguration)
+      currentPlaybackState = pendingAnimationConfiguration.playbackState
     }
   }
 
@@ -127,14 +122,13 @@ final class ExperimentalAnimationLayer: BaseAnimationLayer {
     let timingConfiguration: CAMediaTimingConfiguration
   }
 
-  private enum PlaybackState: Equatable {
-    /// The animation is playing in real-time
-    case playing
-    /// The animation is statically displaying a specific frame
-    case paused(frame: AnimationFrameTime)
-  }
+  /// The configuration for the most recent animation which has been
+  /// queued by calling `playAnimation` but not yet actually set up
+  private var pendingAnimationConfiguration: (
+    animationConfiguration: AnimationConfiguration,
+    playbackState: PlaybackState)?
 
-  // Configuration for the animation that is currently setup in this layer
+  /// Configuration for the animation that is currently setup in this layer
   private var currentAnimationConfiguration: AnimationConfiguration?
 
   /// The current progress of the placeholder `CAAnimation`,
@@ -144,8 +138,8 @@ final class ExperimentalAnimationLayer: BaseAnimationLayer {
   private let animation: Animation
   private let valueProviderStore = ValueProviderStore()
 
-  // The current playback state of the animation that is displayed in this layer
-  private var playbackState: PlaybackState? {
+  /// The current playback state of the animation that is displayed in this layer
+  private var currentPlaybackState: PlaybackState? {
     didSet {
       guard playbackState != oldValue else { return }
 
@@ -156,6 +150,11 @@ final class ExperimentalAnimationLayer: BaseAnimationLayer {
         timeOffset = animation.time(forFrame: frame)
       }
     }
+  }
+
+  /// The current or pending playback state of the animation displayed in this layer
+  private var playbackState: PlaybackState? {
+    pendingAnimationConfiguration?.playbackState ?? currentPlaybackState
   }
 
   /// Context used when setting up and configuring sublayers
@@ -174,6 +173,39 @@ final class ExperimentalAnimationLayer: BaseAnimationLayer {
     setupLayerHierarchy(
       for: animation.layers,
       context: layerContext)
+  }
+
+  /// Immediately builds and begins playing `CAAnimation`s for each sublayer
+  private func setupAnimation(for configuration: AnimationConfiguration) {
+    // Remove any existing animations from the layer hierarchy
+    removeAnimations()
+
+    currentAnimationConfiguration = configuration
+
+    let layerContext = LayerAnimationContext(
+      animation: animation,
+      timingConfiguration: configuration.timingConfiguration,
+      startFrame: configuration.animationContext.playFrom,
+      endFrame: configuration.animationContext.playTo,
+      valueProviderStore: valueProviderStore,
+      currentKeypath: AnimationKeypath(keys: []))
+
+    // Perform a layout pass if necessary so all of the sublayers
+    // have the most up-to-date sizing information
+    layoutIfNeeded()
+
+    // Set the speed of this layer, which will be inherited
+    // by all sublayers and their animations.
+    //  - This is required to support scrubbing with a speed of 0
+    speed = configuration.timingConfiguration.speed
+
+    // Setup a placeholder animation to let us track the realtime animation progress
+    setupPlaceholderAnimation(context: layerContext)
+
+    // Set up the new animations with the current `TimingConfiguration`
+    for animationLayer in sublayers ?? [] {
+      (animationLayer as? AnimationLayer)?.setupAnimations(context: layerContext)
+    }
   }
 
   /// Sets up a placeholder `CABasicAnimation` that tracks the current
@@ -204,7 +236,7 @@ final class ExperimentalAnimationLayer: BaseAnimationLayer {
       currentFrame = frame
 
     case .playing:
-      setupAnimation(
+      playAnimation(
         context: currentConfiguration.animationContext,
         timingConfiguration: currentConfiguration.timingConfiguration)
     }
@@ -242,13 +274,22 @@ extension ExperimentalAnimationLayer: RootAnimationLayer {
           closure: nil),
         timingConfiguration: CAMediaTimingConfiguration(speed: 0))
 
-      if currentAnimationConfiguration != requiredAnimationConfiguration {
-        setupAnimation(
-          context: requiredAnimationConfiguration.animationContext,
-          timingConfiguration: requiredAnimationConfiguration.timingConfiguration)
+      if pendingAnimationConfiguration != nil {
+        pendingAnimationConfiguration = (
+          animationConfiguration: requiredAnimationConfiguration,
+          playbackState: .paused(frame: newValue))
       }
 
-      playbackState = .paused(frame: newValue)
+      else if currentAnimationConfiguration != requiredAnimationConfiguration {
+        playAnimation(
+          context: requiredAnimationConfiguration.animationContext,
+          timingConfiguration: requiredAnimationConfiguration.timingConfiguration,
+          playbackState: .paused(frame: newValue))
+      }
+
+      else {
+        currentPlaybackState = .paused(frame: newValue)
+      }
     }
   }
 
@@ -332,7 +373,7 @@ extension ExperimentalAnimationLayer: RootAnimationLayer {
 
   func removeAnimations() {
     currentAnimationConfiguration = nil
-    playbackState = nil
+    currentPlaybackState = nil
     removeAllAnimations()
 
     for sublayer in allSublayers {

--- a/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
+++ b/Sources/Private/Experimental/ExperimentalAnimationLayer.swift
@@ -78,7 +78,8 @@ final class ExperimentalAnimationLayer: BaseAnimationLayer {
   /// Queues the animation with the given timing configuration
   /// to begin playing at the next `display()` call.
   ///   - This batches together animations so that even if `playAnimation`
-  ///     is called multiple times in the same run loop cycle, the animation will only be
+  ///     is called multiple times in the same run loop cycle, the animation
+  ///     will only be set up a single time.
   func playAnimation(
     context: AnimationContext,
     timingConfiguration: CAMediaTimingConfiguration,
@@ -274,21 +275,18 @@ extension ExperimentalAnimationLayer: RootAnimationLayer {
           closure: nil),
         timingConfiguration: CAMediaTimingConfiguration(speed: 0))
 
-      if pendingAnimationConfiguration != nil {
-        pendingAnimationConfiguration = (
-          animationConfiguration: requiredAnimationConfiguration,
-          playbackState: .paused(frame: newValue))
+      if
+        pendingAnimationConfiguration == nil,
+        currentAnimationConfiguration == requiredAnimationConfiguration
+      {
+        currentPlaybackState = .paused(frame: newValue)
       }
 
-      else if currentAnimationConfiguration != requiredAnimationConfiguration {
+      else {
         playAnimation(
           context: requiredAnimationConfiguration.animationContext,
           timingConfiguration: requiredAnimationConfiguration.timingConfiguration,
           playbackState: .paused(frame: newValue))
-      }
-
-      else {
-        currentPlaybackState = .paused(frame: newValue)
       }
     }
   }

--- a/Sources/Private/LayerContainers/AnimationContainer.swift
+++ b/Sources/Private/LayerContainers/AnimationContainer.swift
@@ -134,9 +134,7 @@ final class AnimationContainer: CALayer, RootAnimationLayer {
     if respectAnimationFrameRate {
       newFrame = floor(newFrame)
     }
-    animationLayers.forEach {
-      $0.displayWithFrame(frame: newFrame, forceUpdates: false)
-    }
+    animationLayers.forEach { $0.displayWithFrame(frame: newFrame, forceUpdates: false) }
   }
 
   // MARK: Internal

--- a/Sources/Private/LayerContainers/AnimationContainer.swift
+++ b/Sources/Private/LayerContainers/AnimationContainer.swift
@@ -134,7 +134,9 @@ final class AnimationContainer: CALayer, RootAnimationLayer {
     if respectAnimationFrameRate {
       newFrame = floor(newFrame)
     }
-    animationLayers.forEach( { $0.displayWithFrame(frame: newFrame, forceUpdates: false) })
+    animationLayers.forEach {
+      $0.displayWithFrame(frame: newFrame, forceUpdates: false)
+    }
   }
 
   // MARK: Internal

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -1076,7 +1076,19 @@ final public class AnimationView: AnimationViewBase {
 
     self.animationContext = animationContext
 
-    guard window != nil else { waitingToPlayAnimation = true; return }
+    switch configuration.renderingEngine {
+    case .mainThread:
+      guard window != nil else {
+        waitingToPlayAnimation = true
+        return
+      }
+
+    case .coreAnimation:
+      // The Core Animation engine automatically batches animation setup to happen
+      // in `CALayer.display()`, which won't be called until the layer is on-screen,
+      // so we don't need to defer animation setup at this layer.
+      break
+    }
 
     animationID = animationID + 1
     _activeAnimationName = AnimationView.animationName + String(animationID)

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -1000,7 +1000,7 @@ final public class AnimationView: AnimationViewBase {
       case .forceFinish:
         removeCurrentAnimation()
         updateAnimationFrame(currentContext.playTo)
-      case .doNothing:
+      case .continuePlaying:
         break
       }
     }

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -19,15 +19,15 @@ final class PerformanceTests: XCTestCase {
     // This is basically a snapshot test for the performance of the Core Animation engine
     // compared to the Main Thread engine. Currently, the Core Animation engine is
     // about the same speed as the Main Thread engine in this example.
-    XCTAssertEqual(ratio, 0.95, accuracy: 0.15)
+    XCTAssertEqual(ratio, 1.0, accuracy: 0.35)
   }
 
   func testAnimationViewSetup_complexAnimation() {
     let ratio = compareEngineSetupPerformance(for: complexAnimation, iterations: 20)
 
-    // The Core Animation engine is currently about 1.6x slower than the
+    // The Core Animation engine is currently about 1.4x slower than the
     // Main Thread engine in this example.
-    XCTAssertEqual(ratio, 1.4, accuracy: 0.3)
+    XCTAssertEqual(ratio, 1.4, accuracy: 0.35)
   }
 
   func testAnimationViewScrubbing_simpleAnimation() {

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -23,11 +23,11 @@ final class PerformanceTests: XCTestCase {
   }
 
   func testAnimationViewSetup_complexAnimation() {
-    let ratio = compareEngineSetupPerformance(for: complexAnimation, iterations: 20)
+    let ratio = compareEngineSetupPerformance(for: complexAnimation, iterations: 500)
 
-    // The Core Animation engine is currently about 1.4x slower than the
+    // The Core Animation engine is currently about 1.5x slower than the
     // Main Thread engine in this example.
-    XCTAssertEqual(ratio, 1.4, accuracy: 0.35)
+    XCTAssertEqual(ratio, 1.5, accuracy: 0.45)
   }
 
   func testAnimationViewScrubbing_simpleAnimation() {


### PR DESCRIPTION
This PR improves the performance of the Core Animation engine by batching animation setup calls to be deferred until the next `display()` call. This prevents us from setting up multiple animations in the same run loop cycle (e.g. during view setup), which causes wasted work.