### PR TITLE
Fix for nil host warning when data url is base64 encoded.

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 		2EE8908127A3179D00354584 /* BaseAnimationLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE8908027A3179D00354584 /* BaseAnimationLayer.swift */; };
 		2EE8908227A3179D00354584 /* BaseAnimationLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE8908027A3179D00354584 /* BaseAnimationLayer.swift */; };
 		2EE8908327A3179E00354584 /* BaseAnimationLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE8908027A3179D00354584 /* BaseAnimationLayer.swift */; };
+		A1D5BAAC27C731A500777D06 /* DataURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5BAAB27C731A500777D06 /* DataURLTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -742,6 +743,7 @@
 		2EAF5A9827A0798700E00531 /* KeyframeExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyframeExtensions.swift; sourceTree = "<group>"; };
 		2EAF5A9A27A0798700E00531 /* AnimationContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationContext.swift; sourceTree = "<group>"; };
 		2EE8908027A3179D00354584 /* BaseAnimationLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAnimationLayer.swift; sourceTree = "<group>"; };
+		A1D5BAAB27C731A500777D06 /* DataURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataURLTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -807,6 +809,7 @@
 				2E80412527A07343006E74CB /* SnapshotConfiguration.swift */,
 				2E72128227BB329C0027BC56 /* AnimationKeypathTests.swift */,
 				2E72128427BB32DB0027BC56 /* PerformanceTests.swift */,
+				A1D5BAAB27C731A500777D06 /* DataURLTests.swift */,
 				2E8040BD27A07343006E74CB /* Utils */,
 			);
 			path = Tests;
@@ -1781,6 +1784,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1D5BAAC27C731A500777D06 /* DataURLTests.swift in Sources */,
 				2E8044AD27A07347006E74CB /* HardcodedImageProvider.swift in Sources */,
 				2E80450C27A07347006E74CB /* SnapshotTests.swift in Sources */,
 				2E09FA0627B6CEB600BA84E5 /* HardcodedFontProvider.swift in Sources */,

--- a/Sources/Private/Model/Assets/ImageAsset.swift
+++ b/Sources/Private/Model/Assets/ImageAsset.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// MARK: - ImageAsset
+
 public final class ImageAsset: Asset {
 
   // MARK: Lifecycle
@@ -53,12 +55,8 @@ public final class ImageAsset: Asset {
 }
 
 extension Data {
-  internal struct DataURLReadOptions: OptionSet {
-    let rawValue: Int
 
-    /// Will read Data URL using Data(contentsOf:)
-    static let legacy = DataURLReadOptions(rawValue: 1 << 0)
-  }
+  // MARK: Lifecycle
 
   /// Initializes `Data` from an `ImageAsset`.
   ///
@@ -74,20 +72,33 @@ extension Data {
   /// - parameter dataString: The data string to parse.
   /// - parameter options: Options for the string parsing. Default value is `[]`.
   internal init?(dataString: String, options: DataURLReadOptions = []) {
-    guard dataString.hasPrefix("data:"),
-          let url = URL(string: dataString)
+    guard
+      dataString.hasPrefix("data:"),
+      let url = URL(string: dataString)
     else {
       return nil
     }
     // The code below is needed because Data(contentsOf:) floods logs
     // with messages since url doesn't have a host. This only fixes flooding logs
     // when data inside Data URL is base64 encoded.
-    if let base64Range = dataString.range(of: ";base64,"),
-       !options.contains(DataURLReadOptions.legacy) {
+    if
+      let base64Range = dataString.range(of: ";base64,"),
+      !options.contains(DataURLReadOptions.legacy)
+    {
       let encodedString = String(dataString[base64Range.upperBound...])
       self.init(base64Encoded: encodedString)
     } else {
       try? self.init(contentsOf: url)
     }
   }
+
+  // MARK: Internal
+
+  internal struct DataURLReadOptions: OptionSet {
+    let rawValue: Int
+
+    /// Will read Data URL using Data(contentsOf:)
+    static let legacy = DataURLReadOptions(rawValue: 1 << 0)
+  }
+
 }

--- a/Sources/Private/Model/Assets/ImageAsset.swift
+++ b/Sources/Private/Model/Assets/ImageAsset.swift
@@ -51,3 +51,43 @@ public final class ImageAsset: Asset {
     case height = "h"
   }
 }
+
+extension Data {
+  internal struct DataURLReadOptions: OptionSet {
+    let rawValue: Int
+
+    /// Will read Data URL using Data(contentsOf:)
+    static let legacy = DataURLReadOptions(rawValue: 1 << 0)
+  }
+
+  /// Initializes `Data` from an `ImageAsset`.
+  ///
+  /// Returns nil when the input is not recognized as valid Data URL.
+  /// - parameter imageAsset: The image asset that contains Data URL.
+  internal init?(imageAsset: ImageAsset) {
+    self.init(dataString: imageAsset.name)
+  }
+
+  /// Initializes `Data` from a [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) String.
+  ///
+  /// Returns nil when the input is not recognized as valid Data URL.
+  /// - parameter dataString: The data string to parse.
+  /// - parameter options: Options for the string parsing. Default value is `[]`.
+  internal init?(dataString: String, options: DataURLReadOptions = []) {
+    guard dataString.hasPrefix("data:"),
+          let url = URL(string: dataString)
+    else {
+      return nil
+    }
+    // The code below is needed because Data(contentsOf:) floods logs
+    // with messages since url doesn't have a host. This only fixes flooding logs
+    // when data inside Data URL is base64 encoded.
+    if let base64Range = dataString.range(of: ";base64,"),
+       !options.contains(DataURLReadOptions.legacy) {
+      let encodedString = String(dataString[base64Range.upperBound...])
+      self.init(base64Encoded: encodedString)
+    } else {
+      try? self.init(contentsOf: url)
+    }
+  }
+}

--- a/Sources/Public/iOS/BundleImageProvider.swift
+++ b/Sources/Public/iOS/BundleImageProvider.swift
@@ -34,9 +34,7 @@ public class BundleImageProvider: AnimationImageProvider {
   public func imageForAsset(asset: ImageAsset) -> CGImage? {
 
     if
-      asset.name.hasPrefix("data:"),
-      let url = URL(string: asset.name),
-      let data = try? Data(contentsOf: url),
+      let data = Data(imageAsset: asset),
       let image = UIImage(data: data)
     {
       return image.cgImage

--- a/Sources/Public/macOS/BundleImageProvider.macOS.swift
+++ b/Sources/Public/macOS/BundleImageProvider.macOS.swift
@@ -31,9 +31,7 @@ public class BundleImageProvider: AnimationImageProvider {
   public func imageForAsset(asset: ImageAsset) -> CGImage? {
 
     if
-      asset.name.hasPrefix("data:"),
-      let url = URL(string: asset.name),
-      let data = try? Data(contentsOf: url),
+      let data = Data(imageAsset: asset),
       let image = NSImage(data: data)
     {
       return image.CGImage

--- a/Tests/DataURLTests.swift
+++ b/Tests/DataURLTests.swift
@@ -12,11 +12,11 @@ import XCTest
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
 final class DataURLTests: XCTestCase {
 
-  let red5x5 = "%89%50%4e%47%0d%0a%1a%0a%00%00%00%0d%49%48%44%52%00%00%00%05%00%00%00%05%08%06%00%00%00%8d%6f%26%e5%00%00%00%12%49%44%41%54%78%da%63%fc%cf%c0%00%44%a8%80%91%06%82%00%5c%65%09%fc%86%fe%00%b0%00%00%00%00%49%45%4e%44%ae%42%60%82"
+  let red5x5 =
+    "%89%50%4e%47%0d%0a%1a%0a%00%00%00%0d%49%48%44%52%00%00%00%05%00%00%00%05%08%06%00%00%00%8d%6f%26%e5%00%00%00%12%49%44%41%54%78%da%63%fc%cf%c0%00%44%a8%80%91%06%82%00%5c%65%09%fc%86%fe%00%b0%00%00%00%00%49%45%4e%44%ae%42%60%82"
 
   let red5x5Base64 = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAEklEQVR42mP8z8AARKiAkQaCAFxlCfyG/gCwAAAAAElFTkSuQmCC"
 
-  // MARK: Internal
   func testValidDataURL() {
     let dataString = "data:image/png;base64,\(red5x5Base64)"
 
@@ -51,8 +51,8 @@ final class DataURLTests: XCTestCase {
 
     let data = Data(dataString: dataString)
     let legacyData = Data(dataString: dataString, options: .legacy)
-    XCTAssertNil(data,"Data should be nil because 'INVALIDBASE64' is not valid base64 string.")
-    XCTAssertNil(legacyData,"Data should be nil because 'INVALIDBASE64' is not valid base64 string.")
+    XCTAssertNil(data, "Data should be nil because 'INVALIDBASE64' is not valid base64 string.")
+    XCTAssertNil(legacyData, "Data should be nil because 'INVALIDBASE64' is not valid base64 string.")
   }
 
   func testInvalidDataURL() {

--- a/Tests/DataURLTests.swift
+++ b/Tests/DataURLTests.swift
@@ -1,0 +1,64 @@
+// Created by Nicholas Mata on 2/23/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import Foundation
+import XCTest
+
+@testable import Lottie
+
+// MARK: - DataURLTests
+
+// Tests are based on implementation found here
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+final class DataURLTests: XCTestCase {
+
+  let red5x5 = "%89%50%4e%47%0d%0a%1a%0a%00%00%00%0d%49%48%44%52%00%00%00%05%00%00%00%05%08%06%00%00%00%8d%6f%26%e5%00%00%00%12%49%44%41%54%78%da%63%fc%cf%c0%00%44%a8%80%91%06%82%00%5c%65%09%fc%86%fe%00%b0%00%00%00%00%49%45%4e%44%ae%42%60%82"
+
+  let red5x5Base64 = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAEklEQVR42mP8z8AARKiAkQaCAFxlCfyG/gCwAAAAAElFTkSuQmCC"
+
+  // MARK: Internal
+  func testValidDataURL() {
+    let dataString = "data:image/png;base64,\(red5x5Base64)"
+
+    let data = Data(dataString: dataString)
+    XCTAssertNotNil(data, "Data should not be nil if valid base64 string")
+    let image = UIImage(data: data!)
+    XCTAssertNotNil(image, "Should be valid image")
+
+    // Since legacy options will print nil host logs
+    let legacyData = Data(dataString: dataString, options: .legacy)
+    XCTAssertNotNil(legacyData, "Data should not be nil if valid base64 string")
+    let legacyImage = UIImage(data: legacyData!)
+    XCTAssertNotNil(legacyImage, "Should be valid image")
+
+    XCTAssertEqual(data, legacyData)
+  }
+
+  func testValidDataURLWithoutBase64() {
+    let dataString = "data:image/png,\(red5x5)"
+    // Since ;base64 is missing still prints nil host warnings.
+    // If we can figure out how to turn red5x5 into Data properly
+    // like Data(contentsOf:) does then we can avoid the warning.
+    let data = Data(dataString: dataString)
+    XCTAssertNotNil(data, "Data should not be nil since format is valid data URL")
+
+    let image = UIImage(data: data!)
+    XCTAssertNotNil(image, "Should be valid image. Since missing ';base64' the data is valid just not base64 encoded")
+  }
+
+  func testInvalidDataURLWithBadBase64() {
+    let dataString = "data:image/png;base64,INVALIDBASE64"
+
+    let data = Data(dataString: dataString)
+    let legacyData = Data(dataString: dataString, options: .legacy)
+    XCTAssertNil(data,"Data should be nil because 'INVALIDBASE64' is not valid base64 string.")
+    XCTAssertNil(legacyData,"Data should be nil because 'INVALIDBASE64' is not valid base64 string.")
+  }
+
+  func testInvalidDataURL() {
+    let dataString = "ImageAssetName"
+
+    let data = Data(dataString: dataString)
+    XCTAssertNil(data, "Data should be nil as valid Data URL starts with 'data:'")
+  }
+}


### PR DESCRIPTION
This commit fixes the following warnings
```
nil host used in call to allowsSpecificHTTPSCertificateForHost
nil host used in call to allowsAnyHTTPSCertificateForHost:
```

__This only fixes the issue when data url uses Base64 encoded data which is the most common__ *(As without Base64 encoding the string is much larger.)*

This PR also moves converting from `ImageAsset` to `Data` to be non platform specific.

However, I did write a test case for a data url that doesn't use Base64 encoding (`testValidDataURLWithoutBase64`) this will still print the nil host warnings. This test can be used in the future to try and avoid nil host warnings for non base64 encoded data.

The fix and implementation is based on the following [Data URL Definition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) 

This fixes #1256 and applies comments specified in #1354 by @calda 