### PR TITLE
Fix issue where animations with a startTime greater than 0 would animate with incorrect duration

### DIFF
--- a/Sources/Private/Experimental/Animations/CAAnimation+TimingConfiguration.swift
+++ b/Sources/Private/Experimental/Animations/CAAnimation+TimingConfiguration.swift
@@ -39,7 +39,7 @@ extension CAAnimation {
     let clippingParent = CAAnimationGroup()
     clippingParent.animations = [baseAnimation]
 
-    clippingParent.duration = abs(context.animation.time(forFrame: context.endFrame - context.startFrame))
+    clippingParent.duration = abs(context.endFrame - context.startFrame) / context.animation.framerate
     baseAnimation.timeOffset = context.animation.time(forFrame: context.startFrame)
 
     clippingParent.autoreverses = context.timingConfiguration.autoreverses

--- a/Sources/Private/Experimental/Animations/CAAnimation+TimingConfiguration.swift
+++ b/Sources/Private/Experimental/Animations/CAAnimation+TimingConfiguration.swift
@@ -39,7 +39,7 @@ extension CAAnimation {
     let clippingParent = CAAnimationGroup()
     clippingParent.animations = [baseAnimation]
 
-    clippingParent.duration = abs(context.endFrame - context.startFrame) / context.animation.framerate
+    clippingParent.duration = Double(abs(context.endFrame - context.startFrame)) / context.animation.framerate
     baseAnimation.timeOffset = context.animation.time(forFrame: context.startFrame)
 
     clippingParent.autoreverses = context.timingConfiguration.autoreverses


### PR DESCRIPTION
This PR fixes an issue where animations with a `startTime` greater than 0 would animate with an incorrect duration, causing it to appear broken in some circumstances:

This specific animation has a `startTime` of ~200:

| Before | After |
| ---- | ---- |
| ![2022-03-07 17 41 22](https://user-images.githubusercontent.com/1811727/157149051-7b7d9375-cd0f-4443-99ea-18672ae423c8.gif) | ![2022-03-07 17 38 23](https://user-images.githubusercontent.com/1811727/157149045-629597dc-4d0b-4f71-94c3-8ccb6a407a9b.gif) |