### PR TITLE
Use initializer argument to set the frame of an AnimationView

### DIFF
--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -124,13 +124,13 @@ final public class AnimationView: AnimationViewBase {
     commonInit()
   }
 
-  public override init(frame _: CGRect) {
+  public override init(frame: CGRect) {
     animation = nil
     imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
     textProvider = DefaultTextProvider()
     fontProvider = DefaultFontProvider()
     configuration = .shared
-    super.init(frame: .zero)
+    super.init(frame: frame)
     commonInit()
   }
 


### PR DESCRIPTION
Addresses https://github.com/airbnb/lottie-ios/issues/1207

Edit: The issue is that initializing an AnimationView with a frame is expected to produce a view with that frame size. In actuality, the frame of the AnimationView is set to .zero, with either results in a non-visible view or a required set of the frame sometime after initialization.