### PR TITLE
Add supporting infrastructure for `RenderingEngineOption.automatic`

### DIFF
--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example (iOS).xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example (iOS).xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Example.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2E80409927A0725D006E74CB"
+               BuildableName = "Lottie.framework"
+               BlueprintName = "Lottie-iOS"
+               ReferencedContainer = "container:../Lottie.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Example/iOS/Configuration.swift
+++ b/Example/iOS/Configuration.swift
@@ -4,6 +4,8 @@
 import Foundation
 import Lottie
 
+// MARK: - Configuration
+
 final class Configuration {
 
   /// Whether or not to use the new, experimental rendering engine
@@ -25,17 +27,11 @@ final class Configuration {
 
 }
 
+// MARK: - RenderingEngineOption + RawRepresentable
+
 extension RenderingEngineOption: RawRepresentable {
-  public var rawValue: String {
-    switch self {
-    case .automatic:
-      return "Automatic"
-    case .specific(.mainThread):
-      return "Main Thread"
-    case .specific(.coreAnimation):
-      return "Core Animation"
-    }
-  }
+
+  // MARK: Lifecycle
 
   public init?(rawValue: String) {
     switch rawValue {
@@ -49,4 +45,18 @@ extension RenderingEngineOption: RawRepresentable {
       return nil
     }
   }
+
+  // MARK: Public
+
+  public var rawValue: String {
+    switch self {
+    case .automatic:
+      return "Automatic"
+    case .specific(.mainThread):
+      return "Main Thread"
+    case .specific(.coreAnimation):
+      return "Core Animation"
+    }
+  }
+
 }

--- a/Example/iOS/Configuration.swift
+++ b/Example/iOS/Configuration.swift
@@ -7,10 +7,12 @@ import Lottie
 final class Configuration {
 
   /// Whether or not to use the new, experimental rendering engine
-  static var useNewRenderingEngine: Bool {
-    get { UserDefaults.standard.bool(forKey: #function) }
+  static var renderingEngineOption: RenderingEngineOption {
+    get {
+      RenderingEngineOption(rawValue: UserDefaults.standard.string(forKey: #function) ?? "Automatic") ?? .automatic
+    }
     set {
-      UserDefaults.standard.set(newValue, forKey: #function)
+      UserDefaults.standard.set(newValue.rawValue, forKey: #function)
       applyCurrentConfiguration()
     }
   }
@@ -18,7 +20,33 @@ final class Configuration {
   /// Applies the current configuration (stored in UserDefaults)
   /// to the singleton `LottieConfiguration.shared`
   static func applyCurrentConfiguration() {
-    LottieConfiguration.shared.renderingEngine = useNewRenderingEngine ? .coreAnimation : .mainThread
+    LottieConfiguration.shared.renderingEngine = renderingEngineOption
   }
 
+}
+
+extension RenderingEngineOption: RawRepresentable {
+  public var rawValue: String {
+    switch self {
+    case .automatic:
+      return "Automatic"
+    case .specific(.mainThread):
+      return "Main Thread"
+    case .specific(.coreAnimation):
+      return "Core Animation"
+    }
+  }
+
+  public init?(rawValue: String) {
+    switch rawValue {
+    case "Automatic":
+      self = .automatic
+    case "Main Thread":
+      self = .mainThread
+    case "Core Animation":
+      self = .coreAnimation
+    default:
+      return nil
+    }
+  }
 }

--- a/Example/iOS/ViewControllers/SampleListViewController.swift
+++ b/Example/iOS/ViewControllers/SampleListViewController.swift
@@ -78,7 +78,10 @@ final class SampleListViewController: CollectionViewController {
           dataID: animationName,
           content: .init(
             animationName: animationPath,
-            title: animationName))
+            title: animationName,
+            subtitle: Animation.named(animationPath)?.supportedByCoreAnimationEngine == true
+              ? "Supports Core Animation"
+              : nil))
           .didSelect { [weak self] context in
             self?.show(
               AnimationPreviewViewController(animationPath),
@@ -121,21 +124,20 @@ final class SampleListViewController: CollectionViewController {
       menu: UIMenu(
         title: "Rendering Engine",
         children: [
-          UIAction(
-            title: "Standard",
-            state: Configuration.useNewRenderingEngine ? .off : .on,
-            handler: { [weak self] _ in
-              Configuration.useNewRenderingEngine = false
-              self?.configureSettingsMenu()
-            }),
-          UIAction(
-            title: "Experimental",
-            state: Configuration.useNewRenderingEngine ? .on : .off,
-            handler: { [weak self] _ in
-              Configuration.useNewRenderingEngine = true
-              self?.configureSettingsMenu()
-            }),
+          action(for: .automatic),
+          action(for: .mainThread),
+          action(for: .coreAnimation),
         ]))
+  }
+
+  private func action(for renderingEngineOption: RenderingEngineOption) -> UIAction {
+    UIAction(
+      title: renderingEngineOption.rawValue,
+      state: Configuration.renderingEngineOption == renderingEngineOption ? .on : .off,
+      handler: { [weak self] _ in
+        Configuration.renderingEngineOption = renderingEngineOption
+        self?.configureSettingsMenu()
+      })
   }
 
 }

--- a/Example/iOS/Views/LinkView.swift
+++ b/Example/iOS/Views/LinkView.swift
@@ -29,6 +29,7 @@ final class LinkView: UIView, EpoxyableView {
   struct Content: Equatable {
     var animationName: String?
     var title: String
+    var subtitle: String?
   }
 
   func setContent(_ content: Content, animated _: Bool) {
@@ -55,17 +56,38 @@ final class LinkView: UIView, EpoxyableView {
           })
       }
 
-      GroupItem<UILabel>(
-        dataID: DataID.title,
-        content: content.title,
-        make: {
-          let label = UILabel()
-          label.translatesAutoresizingMaskIntoConstraints = false
-          return label
-        },
-        setContent: { context, content in
-          context.constrainable.text = content
-        })
+      VGroupItem(
+        dataID: DataID.titleSubtitleGroup,
+        style: .init(spacing: 4))
+      {
+        GroupItem<UILabel>(
+          dataID: DataID.title,
+          content: content.title,
+          make: {
+            let label = UILabel()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            return label
+          },
+          setContent: { context, content in
+            context.constrainable.text = content
+          })
+
+        if let subtitle = content.subtitle {
+          GroupItem<UILabel>(
+            dataID: DataID.subtitle,
+            content: subtitle,
+            make: {
+              let label = UILabel()
+              label.textColor = .secondaryLabel
+              label.font = .preferredFont(forTextStyle: .caption2)
+              label.translatesAutoresizingMaskIntoConstraints = false
+              return label
+            },
+            setContent: { context, content in
+              context.constrainable.text = content
+            })
+        }
+      }
     }
   }
 
@@ -73,10 +95,12 @@ final class LinkView: UIView, EpoxyableView {
 
   private enum DataID {
     case animationPreview
+    case titleSubtitleGroup
     case title
+    case subtitle
   }
 
-  private let group = HGroup(alignment: .fill, spacing: 24)
+  private let group = HGroup(alignment: .center, spacing: 24)
 }
 
 // MARK: HighlightableView

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2E044E1E28204C4000FA773B /* AutomaticRenderingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E044E1D28204C4000FA773B /* AutomaticRenderingEngine.swift */; };
 		2E044E1F28204C4000FA773B /* AutomaticRenderingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E044E1D28204C4000FA773B /* AutomaticRenderingEngine.swift */; };
 		2E044E2028204C4000FA773B /* AutomaticRenderingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E044E1D28204C4000FA773B /* AutomaticRenderingEngine.swift */; };
+		2E044E272820536800FA773B /* AutomaticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E044E262820536800FA773B /* AutomaticEngineTests.swift */; };
 		2E09FA0627B6CEB600BA84E5 /* HardcodedFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E09FA0527B6CEB600BA84E5 /* HardcodedFontProvider.swift */; };
 		2E29E51A27B5C072007E25CE /* StrokeAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E29E51927B5C072007E25CE /* StrokeAnimation.swift */; };
 		2E29E51B27B5C072007E25CE /* StrokeAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E29E51927B5C072007E25CE /* StrokeAnimation.swift */; };
@@ -560,6 +561,7 @@
 /* Begin PBXFileReference section */
 		1133E6AC27AA4920000633AC /* DataExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
 		2E044E1D28204C4000FA773B /* AutomaticRenderingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticRenderingEngine.swift; sourceTree = "<group>"; };
+		2E044E262820536800FA773B /* AutomaticEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticEngineTests.swift; sourceTree = "<group>"; };
 		2E09FA0527B6CEB600BA84E5 /* HardcodedFontProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardcodedFontProvider.swift; sourceTree = "<group>"; };
 		2E29E51927B5C072007E25CE /* StrokeAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrokeAnimation.swift; sourceTree = "<group>"; };
 		2E72128227BB329C0027BC56 /* AnimationKeypathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationKeypathTests.swift; sourceTree = "<group>"; };
@@ -815,6 +817,7 @@
 				2E72128427BB32DB0027BC56 /* PerformanceTests.swift */,
 				A1D5BAAB27C731A500777D06 /* DataURLTests.swift */,
 				2E8040BD27A07343006E74CB /* Utils */,
+				2E044E262820536800FA773B /* AutomaticEngineTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1799,6 +1802,7 @@
 				2E8044AE27A07347006E74CB /* Snapshotting+presentationLayer.swift in Sources */,
 				2E72128527BB32DB0027BC56 /* PerformanceTests.swift in Sources */,
 				2E72128327BB329C0027BC56 /* AnimationKeypathTests.swift in Sources */,
+				2E044E272820536800FA773B /* AutomaticEngineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		1133E6AD27AA4920000633AC /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1133E6AC27AA4920000633AC /* DataExtension.swift */; };
 		1133E6AE27AA4920000633AC /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1133E6AC27AA4920000633AC /* DataExtension.swift */; };
 		1133E6AF27AA4920000633AC /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1133E6AC27AA4920000633AC /* DataExtension.swift */; };
+		2E044E1E28204C4000FA773B /* AutomaticRenderingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E044E1D28204C4000FA773B /* AutomaticRenderingEngine.swift */; };
+		2E044E1F28204C4000FA773B /* AutomaticRenderingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E044E1D28204C4000FA773B /* AutomaticRenderingEngine.swift */; };
+		2E044E2028204C4000FA773B /* AutomaticRenderingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E044E1D28204C4000FA773B /* AutomaticRenderingEngine.swift */; };
 		2E09FA0627B6CEB600BA84E5 /* HardcodedFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E09FA0527B6CEB600BA84E5 /* HardcodedFontProvider.swift */; };
 		2E29E51A27B5C072007E25CE /* StrokeAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E29E51927B5C072007E25CE /* StrokeAnimation.swift */; };
 		2E29E51B27B5C072007E25CE /* StrokeAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E29E51927B5C072007E25CE /* StrokeAnimation.swift */; };
@@ -556,6 +559,7 @@
 
 /* Begin PBXFileReference section */
 		1133E6AC27AA4920000633AC /* DataExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
+		2E044E1D28204C4000FA773B /* AutomaticRenderingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticRenderingEngine.swift; sourceTree = "<group>"; };
 		2E09FA0527B6CEB600BA84E5 /* HardcodedFontProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardcodedFontProvider.swift; sourceTree = "<group>"; };
 		2E29E51927B5C072007E25CE /* StrokeAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrokeAnimation.swift; sourceTree = "<group>"; };
 		2E72128227BB329C0027BC56 /* AnimationKeypathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationKeypathTests.swift; sourceTree = "<group>"; };
@@ -871,6 +875,7 @@
 				2EAF59C927A0798700E00531 /* AnimationViewInitializers.swift */,
 				2EAF59CA27A0798700E00531 /* AnimationView.swift */,
 				2EAF59CB27A0798700E00531 /* AnimationPublic.swift */,
+				2E044E1D28204C4000FA773B /* AutomaticRenderingEngine.swift */,
 			);
 			path = Animation;
 			sourceTree = "<group>";
@@ -1659,6 +1664,7 @@
 				2EAF5AAA27A0798700E00531 /* AnimationViewInitializers.swift in Sources */,
 				2EAF5C3F27A0798800E00531 /* Bundle.swift in Sources */,
 				2EAF5B8527A0798700E00531 /* LayerTextProvider.swift in Sources */,
+				2E044E1E28204C4000FA773B /* AutomaticRenderingEngine.swift in Sources */,
 				2EAF5B4F27A0798700E00531 /* GradientAnimations.swift in Sources */,
 				2EAF5C1B27A0798800E00531 /* SolidLayerModel.swift in Sources */,
 				2EAF5BCA27A0798700E00531 /* AnyNodeProperty.swift in Sources */,
@@ -1856,6 +1862,7 @@
 				2EAF5AAB27A0798700E00531 /* AnimationViewInitializers.swift in Sources */,
 				2EAF5C4027A0798800E00531 /* Bundle.swift in Sources */,
 				2EAF5B8627A0798700E00531 /* LayerTextProvider.swift in Sources */,
+				2E044E1F28204C4000FA773B /* AutomaticRenderingEngine.swift in Sources */,
 				2EAF5B5027A0798700E00531 /* GradientAnimations.swift in Sources */,
 				2EAF5C1C27A0798800E00531 /* SolidLayerModel.swift in Sources */,
 				2EAF5BCB27A0798700E00531 /* AnyNodeProperty.swift in Sources */,
@@ -2037,6 +2044,7 @@
 				2EAF5AAC27A0798700E00531 /* AnimationViewInitializers.swift in Sources */,
 				2EAF5C4127A0798800E00531 /* Bundle.swift in Sources */,
 				2EAF5B8727A0798700E00531 /* LayerTextProvider.swift in Sources */,
+				2E044E2028204C4000FA773B /* AutomaticRenderingEngine.swift in Sources */,
 				2EAF5B5127A0798700E00531 /* GradientAnimations.swift in Sources */,
 				2EAF5C1D27A0798800E00531 /* SolidLayerModel.swift in Sources */,
 				2EAF5BCC27A0798700E00531 /* AnyNodeProperty.swift in Sources */,

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -161,7 +161,7 @@ final public class AnimationView: AnimationViewBase {
   ///
   /// The default for the Core Animation engine is `continuePlaying`,
   /// since the Core Animation engine does not have any CPU overhead.
-  public lazy var backgroundBehavior: LottieBackgroundBehavior = .default(for: configuration.renderingEngine) {
+  public lazy var backgroundBehavior: LottieBackgroundBehavior = .default(for: renderingEngine) {
     didSet {
       if
         configuration.renderingEngine == .mainThread,
@@ -904,7 +904,7 @@ final public class AnimationView: AnimationViewBase {
     }
 
     let animationLayer: RootAnimationLayer
-    switch configuration.renderingEngine {
+    switch configuration.renderingEngine.renderingEngine(for: animation) {
     case .coreAnimation:
       animationLayer = ExperimentalAnimationLayer(
         animation: animation,
@@ -969,7 +969,7 @@ final public class AnimationView: AnimationViewBase {
   ///    this step lets us avoid building the animations twice (once paused
   ///    and once again playing)
   fileprivate func removeCurrentAnimationIfNecessary() {
-    switch configuration.renderingEngine {
+    switch renderingEngine {
     case .mainThread:
       removeCurrentAnimation()
     case .coreAnimation:
@@ -1021,7 +1021,7 @@ final public class AnimationView: AnimationViewBase {
 
     self.animationContext = animationContext
 
-    switch configuration.renderingEngine {
+    switch renderingEngine {
     case .mainThread:
       guard window != nil else {
         waitingToPlayAnimation = true
@@ -1123,6 +1123,10 @@ final public class AnimationView: AnimationViewBase {
   // MARK: Private
 
   static private let animationName = "Lottie"
+
+  private var renderingEngine: RenderingEngine {
+    configuration.renderingEngine.renderingEngine(for: animation) ?? .mainThread
+  }
 
 }
 

--- a/Sources/Public/Animation/AutomaticRenderingEngine.swift
+++ b/Sources/Public/Animation/AutomaticRenderingEngine.swift
@@ -1,0 +1,32 @@
+// Created by Cal Stephens on 5/2/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import Foundation
+
+extension RenderingEngineOption {
+  public func renderingEngine(for animation: Animation) -> RenderingEngine {
+    switch self {
+    case .specific(let engine):
+      return engine
+    case .automatic:
+      return animation.supportedByCoreAnimationEngine ? .coreAnimation : .mainThread
+    }
+  }
+
+  public func renderingEngine(for animation: Animation?) -> RenderingEngine? {
+    switch self {
+    case .specific(let engine):
+      return engine
+    case .automatic:
+      guard let animation = animation else { return nil }
+      return animation.supportedByCoreAnimationEngine ? .coreAnimation : .mainThread
+    }
+  }
+}
+
+extension Animation {
+  /// Whether or not this animation can be rendered by the Core Animation engine
+  public var supportedByCoreAnimationEngine: Bool {
+    false // TODO: Implement
+  }
+}

--- a/Sources/Public/Animation/AutomaticRenderingEngine.swift
+++ b/Sources/Public/Animation/AutomaticRenderingEngine.swift
@@ -27,6 +27,6 @@ extension RenderingEngineOption {
 extension Animation {
   /// Whether or not this animation can be rendered by the Core Animation engine
   public var supportedByCoreAnimationEngine: Bool {
-    false // TODO: Implement
+    true // TODO: Implement checks
   }
 }

--- a/Sources/Public/LottieConfiguration.swift
+++ b/Sources/Public/LottieConfiguration.swift
@@ -6,7 +6,7 @@
 /// Global configuration options for Lottie animations
 public struct LottieConfiguration: Hashable {
 
-  public init(renderingEngine: RenderingEngine = .mainThread) {
+  public init(renderingEngine: RenderingEngineOption = .mainThread) {
     self.renderingEngine = renderingEngine
   }
 
@@ -15,8 +15,28 @@ public struct LottieConfiguration: Hashable {
   public static var shared = LottieConfiguration()
 
   /// The rendering engine implementation to use when displaying an animation
-  public var renderingEngine: RenderingEngine
+  public var renderingEngine: RenderingEngineOption
 
+}
+
+// MARK: - RenderingEngineOption
+
+public enum RenderingEngineOption: Hashable {
+  /// Uses the Core Animation engine for supported animations, and falls back to using
+  /// the Main Thread engine for animations that use features not supported by the
+  /// Core Animation engine.
+  case automatic
+
+  /// Uses the specified rendering engine
+  case specific(RenderingEngine)
+
+  /// The original / default rendering engine, which supports all Lottie features
+  /// but runs on the main thread, which comes with some CPU overhead.
+  public static var mainThread: RenderingEngineOption { .specific(.mainThread) }
+
+  /// The new rendering engine, that animates using Core Animation
+  /// and has no CPU overhead but doesn't support all Lottie features.
+  public static var coreAnimation: RenderingEngineOption { .specific(.coreAnimation) }
 }
 
 // MARK: - RenderingEngine

--- a/Tests/AutomaticEngineTests.swift
+++ b/Tests/AutomaticEngineTests.swift
@@ -1,0 +1,71 @@
+// Created by Cal Stephens on 5/2/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import XCTest
+import UIKit
+
+@testable import Lottie
+import SnapshotTesting
+
+final class AutomaticEngineTests: XCTestCase {
+
+  /// Checks that the result of `animation.supportedByCoreAnimationEngine`
+  /// matches whether or not an assertion is emitted when rendering the animation
+  /// using the Core Animation engine
+  func testAutomaticEngineDetection() {
+    // While this feature is still in development, we disable assertions
+    // for this test case to keep CI green. TODO: Enable assertions in CI.
+    let emitXCTAssertions = { false }()
+
+    for sampleAnimationName in Samples.sampleAnimationNames {
+      var logs = [String]()
+
+      LottieLogger.shared = .init(
+        assert: { condition, message, _, _ in
+          if !condition() {
+            logs.append(message())
+          }
+        },
+        assertionFailure: { message, _, _ in
+          logs.append(message())
+        },
+        warn: { message, _, _ in
+          logs.append(message())
+        })
+
+      guard
+        let (animation, animationView) = SnapshotConfiguration.makeAnimationView(
+          for: sampleAnimationName,
+          configuration: .init(renderingEngine: .coreAnimation))
+      else { continue }
+
+      animationView.frame = CGRect(origin: .zero, size: animation.size)
+      animationView.layoutIfNeeded()
+      animationView.currentProgress = 0.5
+
+      let supportsCoreAnimationEngine = animation.supportedByCoreAnimationEngine
+
+      if emitXCTAssertions {
+        if supportsCoreAnimationEngine {
+          XCTAssert(logs.isEmpty, """
+            Unexpected assertions / logs for animation "\(sampleAnimationName)":
+            \(logs)
+            """)
+        } else {
+          XCTAssert(!logs.isEmpty, """
+          Animation "\(sampleAnimationName)" is listed as not supporting the Core Animation engine,
+          but no assertions were emitted when rendering it.
+          """)
+        }
+      }
+
+      assertSnapshot(
+        matching: supportsCoreAnimationEngine
+          ? "Supports Core Animation engine"
+          : "Does not support Core Animation engine",
+        as: .description,
+        named: sampleAnimationName)
+    }
+  }
+
+}

--- a/Tests/AutomaticEngineTests.swift
+++ b/Tests/AutomaticEngineTests.swift
@@ -1,11 +1,11 @@
 // Created by Cal Stephens on 5/2/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-import XCTest
 import UIKit
+import XCTest
 
-@testable import Lottie
 import SnapshotTesting
+@testable import Lottie
 
 final class AutomaticEngineTests: XCTestCase {
 
@@ -15,7 +15,7 @@ final class AutomaticEngineTests: XCTestCase {
   func testAutomaticEngineDetection() {
     // While this feature is still in development, we disable assertions
     // for this test case to keep CI green. TODO: Enable assertions in CI.
-    let emitXCTAssertions = { false }()
+    let emitXCTAssertions = false
 
     for sampleAnimationName in Samples.sampleAnimationNames {
       var logs = [String]()
@@ -53,9 +53,9 @@ final class AutomaticEngineTests: XCTestCase {
             """)
         } else {
           XCTAssert(!logs.isEmpty, """
-          Animation "\(sampleAnimationName)" is listed as not supporting the Core Animation engine,
-          but no assertions were emitted when rendering it.
-          """)
+            Animation "\(sampleAnimationName)" is listed as not supporting the Core Animation engine,
+            but no assertions were emitted when rendering it.
+            """)
         }
       }
 

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -164,6 +164,8 @@ enum SnapshotError: Error {
   case unsupportedDevice
 }
 
+// MARK: - Samples
+
 /// MARK: - Samples
 
 enum Samples {

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -29,7 +29,7 @@ class SnapshotTests: XCTestCase {
   /// Validates that all of the snapshots in __Snapshots__ correspond to
   /// a sample JSON file that is visible to this test target.
   func testAllSnapshotsHaveCorrespondingSampleFile() {
-    for snapshotURL in snapshotURLs {
+    for snapshotURL in Samples.snapshotURLs {
       // The snapshot files follow the format `testCaseName.animationName-percentage.png`
       //  - We remove the known prefix and known suffixes to recover the input file name
       //  - `animationName` can contain dashes, so we can't just split the string at each dash
@@ -46,7 +46,7 @@ class SnapshotTests: XCTestCase {
       animationName = animationName.replacingOccurrences(of: "-", with: "/")
 
       XCTAssert(
-        sampleAnimationURLs.contains(where: { $0.absoluteString.hasSuffix("\(animationName).json") }),
+        Samples.sampleAnimationURLs.contains(where: { $0.absoluteString.hasSuffix("\(animationName).json") }),
         "Snapshot \"\(snapshotURL.lastPathComponent)\" has no corresponding sample animation")
     }
   }
@@ -58,7 +58,7 @@ class SnapshotTests: XCTestCase {
       let expectedSampleFile = Bundle.module.bundleURL.appendingPathComponent("Samples/\(animationName).json")
 
       XCTAssert(
-        sampleAnimationURLs.contains(expectedSampleFile),
+        Samples.sampleAnimationURLs.contains(expectedSampleFile),
         "Custom configuration for \"\(animationName)\" has no corresponding sample animation")
     }
   }
@@ -66,8 +66,8 @@ class SnapshotTests: XCTestCase {
   /// Validates that this test target can access sample json files from `Tests/Samples`
   /// and snapshot images from `Tests/__Snapshots__`.
   func testCanAccessSamplesAndSnapshots() {
-    XCTAssert(sampleAnimationURLs.count > 50)
-    XCTAssert(snapshotURLs.count > 300)
+    XCTAssert(Samples.sampleAnimationURLs.count > 50)
+    XCTAssert(Samples.snapshotURLs.count > 300)
   }
 
   override func setUp() {
@@ -85,15 +85,6 @@ class SnapshotTests: XCTestCase {
   /// `currentProgress` percentages that should be snapshot in `compareSampleSnapshots`
   private let progressPercentagesToSnapshot = [0, 0.25, 0.5, 0.75, 1.0]
 
-  /// The name of the directory that contains the sample json files
-  private let samplesDirectoryName = "Samples"
-
-  /// The list of snapshot image files in `Tests/__Snapshots__`
-  private let snapshotURLs = Bundle.module.fileURLs(in: "__Snapshots__", withSuffix: "png")
-
-  /// The list of sample animation files in `Tests/Samples`
-  private lazy var sampleAnimationURLs = Bundle.module.fileURLs(in: "Samples", withSuffix: "json")
-
   /// Captures snapshots of `sampleAnimationURLs` and compares them to the snapshot images stored on disk
   private func compareSampleSnapshots(
     configuration: LottieConfiguration,
@@ -108,57 +99,20 @@ class SnapshotTests: XCTestCase {
       throw SnapshotError.unsupportedDevice
     }
 
-    for sampleAnimationURL in sampleAnimationURLs {
-      // Each of the sample animation URLs has the format
-      // `.../*.bundle/Samples/{subfolder}/{animationName}.json`.
-      // The sample animation name should include the subfolders
-      // (since that helps uniquely identity the animation JSON file).
-      let pathComponents = sampleAnimationURL.pathComponents
-      let samplesIndex = pathComponents.lastIndex(of: samplesDirectoryName)!
-      let subpath = pathComponents[(samplesIndex + 1)...]
-
-      let sampleAnimationName = subpath
-        .joined(separator: "/")
-        .replacingOccurrences(of: ".json", with: "")
-
-      let snapshotConfiguration = SnapshotConfiguration.forSample(named: sampleAnimationName)
-
-      guard
-        let animation = Animation.named(
-          sampleAnimationName,
-          bundle: .module,
-          subdirectory: samplesDirectoryName)
-      else {
-        XCTFail("Could not parse Samples/\(sampleAnimationName).json")
-        continue
-      }
-
+    for sampleAnimationName in Samples.sampleAnimationNames {
       for percent in progressPercentagesToSnapshot {
-        let animationView = AnimationView(
-          animation: animation,
-          configuration: configuration)
-
-        // Set up the animation view with a valid frame
-        // so the geometry is correct when setting up the `CAAnimation`s
-        animationView.frame.size = animation.snapshotSize
+        guard
+          let (_, animationView) = SnapshotConfiguration.makeAnimationView(
+            for: sampleAnimationName,
+            configuration: configuration)
+        else { continue }
 
         animationView.currentProgress = CGFloat(percent)
 
-        for (keypath, customValueProvider) in snapshotConfiguration.customValueProviders {
-          animationView.setValueProvider(customValueProvider, keypath: keypath)
-        }
-
-        if let customImageProvider = snapshotConfiguration.customImageProvider {
-          animationView.imageProvider = customImageProvider
-        }
-
-        if let customFontProvider = snapshotConfiguration.customFontProvider {
-          animationView.fontProvider = customFontProvider
-        }
-
         assertSnapshot(
           matching: animationView,
-          as: .imageOfPresentationLayer(precision: snapshotConfiguration.precision),
+          as: .imageOfPresentationLayer(
+            precision: SnapshotConfiguration.forSample(named: sampleAnimationName).precision),
           named: "\(sampleAnimationName) (\(Int(percent * 100))%)",
           testName: testName)
       }
@@ -208,4 +162,80 @@ enum SnapshotError: Error {
   /// Snapshots are captured at a 2x scale, so we can only support
   /// running tests on a device that has a 2x scale.
   case unsupportedDevice
+}
+
+/// MARK: - Samples
+
+enum Samples {
+  /// The name of the directory that contains the sample json files
+  static let directoryName = "Samples"
+
+  /// The list of snapshot image files in `Tests/__Snapshots__`
+  static let snapshotURLs = Bundle.module.fileURLs(
+    in: "__Snapshots__",
+    withSuffix: "png")
+
+  /// The list of sample animation files in `Tests/Samples`
+  static let sampleAnimationURLs = Bundle.module.fileURLs(
+    in: Samples.directoryName,
+    withSuffix: "json")
+
+  /// The list of sample animation names in `Tests/Samples`
+  static let sampleAnimationNames = sampleAnimationURLs.lazy
+    .map { sampleAnimationURL -> String in
+      // Each of the sample animation URLs has the format
+      // `.../*.bundle/Samples/{subfolder}/{animationName}.json`.
+      // The sample animation name should include the subfolders
+      // (since that helps uniquely identity the animation JSON file).
+      let pathComponents = sampleAnimationURL.pathComponents
+      let samplesIndex = pathComponents.lastIndex(of: Samples.directoryName)!
+      let subpath = pathComponents[(samplesIndex + 1)...]
+
+      return subpath
+        .joined(separator: "/")
+        .replacingOccurrences(of: ".json", with: "")
+    }
+}
+
+extension SnapshotConfiguration {
+  /// Creates an `AnimationView` for the sample snapshot with the given name
+  static func makeAnimationView(
+    for sampleAnimationName: String,
+    configuration: LottieConfiguration)
+    -> (animation: Animation, animationView: AnimationView)?
+  {
+    let snapshotConfiguration = SnapshotConfiguration.forSample(named: sampleAnimationName)
+
+    guard
+      let animation = Animation.named(
+        sampleAnimationName,
+        bundle: .module,
+        subdirectory: Samples.directoryName)
+    else {
+      XCTFail("Could not parse Samples/\(sampleAnimationName).json")
+      return nil
+    }
+
+    let animationView = AnimationView(
+      animation: animation,
+      configuration: configuration)
+
+    // Set up the animation view with a valid frame
+    // so the geometry is correct when setting up the `CAAnimation`s
+    animationView.frame.size = animation.snapshotSize
+
+    for (keypath, customValueProvider) in snapshotConfiguration.customValueProviders {
+      animationView.setValueProvider(customValueProvider, keypath: keypath)
+    }
+
+    if let customImageProvider = snapshotConfiguration.customImageProvider {
+      animationView.imageProvider = customImageProvider
+    }
+
+    if let customFontProvider = snapshotConfiguration.customFontProvider {
+      animationView.fontProvider = customFontProvider
+    }
+
+    return (animation, animationView)
+  }
 }

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.9squares_AlBoardman.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.9squares_AlBoardman.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Boat_Loader.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Boat_Loader.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.HamburgerArrow.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.HamburgerArrow.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.IconTransitions.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.IconTransitions.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Issues-issue_1403.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Issues-issue_1403.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Issues-issue_1407.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Issues-issue_1407.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Issues-issue_1488.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Issues-issue_1488.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Issues-pr_1536.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Issues-pr_1536.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-bounce_strokes.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-bounce_strokes.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-draft_icon.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-draft_icon.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_1.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_1.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_2.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_2.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_pill.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_pill.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_shapes.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_shapes.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_square.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-gradient_square.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-infinity_loader.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-infinity_loader.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-loading_dots_1.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-loading_dots_1.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-loading_dots_2.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-loading_dots_2.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-loading_dots_3.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-loading_dots_3.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-loading_gradient_strokes.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-loading_gradient_strokes.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-settings_slider.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-settings_slider.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-shop.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieFiles-shop.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieLogo1.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieLogo1.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieLogo1_masked.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieLogo1_masked.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieLogo2.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.LottieLogo2.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.MotionCorpse_Jrcanest.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.MotionCorpse_Jrcanest.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-BasicLayers.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-BasicLayers.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-DisableNodesTest.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-DisableNodesTest.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-FirstText.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-FirstText.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-GeometryTransformTest.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-GeometryTransformTest.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Text_AnimatedProperties.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Text_AnimatedProperties.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Text_Glyph.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Text_Glyph.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Text_NoAnimation.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Text_NoAnimation.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Text_NoGlyph.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Text_NoGlyph.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Zoom.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-Zoom.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-_dog.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-_dog.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-base64Test.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-base64Test.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-keypathTest.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-keypathTest.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-verifyLineHeight.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Nonanimating-verifyLineHeight.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.PinJump.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.PinJump.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-BrokenLottieFiles-dog_car_ride.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-BrokenLottieFiles-dog_car_ride.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-BrokenLottieFiles-rocket.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-BrokenLottieFiles-rocket.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-BrokenLottieFiles-step_loader.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-BrokenLottieFiles-step_loader.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-China_EmptyState_Itinerary.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-China_EmptyState_Itinerary.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-LoaderHourglass.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-LoaderHourglass.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-alarm_animated.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-alarm_animated.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-diamond_animated.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-diamond_animated.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-eye_animated.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-eye_animated.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-light_bulb_animated.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-light_bulb_animated.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-light_bulb_static.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-light_bulb_static.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-piggy_bank_static.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-piggy_bank_static.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-price_tag_legacy.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-price_tag_legacy.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-red_envelope_animated.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-red_envelope_animated.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-tag_animated.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-tag_animated.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-trophy_animated.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-trophy_animated.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-wings_key_animated.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-Urgency-wings_key_animated.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-_flexible.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-_flexible.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-aircover.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-aircover.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-belo_spin_rausch.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-belo_spin_rausch.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-celebration.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-celebration.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-checkbox.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-checkbox.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-checkbox_small.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-checkbox_small.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-getting_your_trip_ready.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-getting_your_trip_ready.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-gradient_afternoon.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-gradient_afternoon.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-gradient_brand.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-gradient_brand.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-gradient_evening.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-gradient_evening.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-gradient_morning.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-gradient_morning.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-issue_1467.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-issue_1467.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-issue_1505.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-issue_1505.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-loading_dots.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-loading_dots.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-loading_dots_small.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-loading_dots_small.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-radio_button.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-radio_button.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-selfie_intro.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-selfie_intro.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-stepper_add.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-stepper_add.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-stepper_subtract.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-stepper_subtract.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-switch.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-switch.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-toggle_no.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-toggle_no.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-toggle_yes.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-toggle_yes.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-user_error_black_and_white.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-user_error_black_and_white.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-user_error_cut_off.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Private-user_error_cut_off.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Switch.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Switch.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Switch_States.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Switch_States.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TwitterHeart.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TwitterHeart.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TwitterHeartButton.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TwitterHeartButton.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-A.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-A.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Apostrophe.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Apostrophe.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-B.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-B.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-BlinkingCursor.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-BlinkingCursor.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-C.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-C.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Colon.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Colon.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Comma.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Comma.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-D.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-D.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-E.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-E.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-F.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-F.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-G.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-G.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-H.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-H.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-I.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-I.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-J.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-J.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-K.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-K.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-L.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-L.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-M.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-M.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-N.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-N.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-O.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-O.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-P.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-P.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Q.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Q.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-R.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-R.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-S.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-S.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-T.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-T.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-U.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-U.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-V.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-V.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-W.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-W.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-X.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-X.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Y.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Y.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Z.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.TypeFace-Z.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Watermelon.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.Watermelon.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.setValueTest.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.setValueTest.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.timeremap.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.timeremap.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.vcTransition1.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.vcTransition1.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.vcTransition2.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.vcTransition2.txt
@@ -1,0 +1,1 @@
+Supports Core Animation engine


### PR DESCRIPTION
This PR adds supporting infrastructure for a new `RenderingEngineOption.automatic`, which will default to using the Core Animation engine and fall-back to using the Main Thread engine for animations that use features which are known to be unsupported in the CA engine. Hopefully, we'll be able to make `RenderingEngineOption.automatic` the default for all consumers at some point in the future.

This PR doesn't actually implement any logic in the `Animation.supportedByCoreAnimationEngine` check. Will work on building this out in follow-up PRs.