### PR TITLE
Fix issue where animation could fail to start playing when using RenderingEngineOption.automatic

### DIFF
--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -1062,7 +1062,11 @@ final public class AnimationView: AnimationViewBase {
     self.currentFrame = currentFrame
 
     if let animationContext = animationContext {
-      addNewAnimationForContext(animationContext)
+      // We have to wait until the next run loop cycle to start playing the animation,
+      // or it may not actually start as expected.
+      DispatchQueue.main.async {
+        self.addNewAnimationForContext(animationContext)
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where the animation could fail to start playing when using `RenderingEngineOption.automatic`. I encountered an example of this issue when integrating the new option with Airbnb's app codebase.