### PR TITLE
Add alternative dictionary-based decoding

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -545,10 +545,18 @@
 		2EAF5B0427A0798700E00531 /* AnimationFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAF59F227A0798700E00531 /* AnimationFontProvider.swift */; };
 		2EAF5B0527A0798700E00531 /* AnimationFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAF59F227A0798700E00531 /* AnimationFontProvider.swift */; };
 		2EAF5B0627A0798700E00531 /* AnimationFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAF59F227A0798700E00531 /* AnimationFontProvider.swift */; };
+		6D0E635F28246BD0007C5DB6 /* Difference in Frameworks */ = {isa = PBXBuildFile; productRef = 6D0E635E28246BD0007C5DB6 /* Difference */; };
 		6D99D6432823790700E5205B /* LegacyGradientFillRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D99D6422823790700E5205B /* LegacyGradientFillRenderer.swift */; };
 		6D99D6442823790700E5205B /* LegacyGradientFillRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D99D6422823790700E5205B /* LegacyGradientFillRenderer.swift */; };
 		6D99D6452823790700E5205B /* LegacyGradientFillRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D99D6422823790700E5205B /* LegacyGradientFillRenderer.swift */; };
 		6DB3BDB628243FA5002A276D /* ValueProvidersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDB528243FA5002A276D /* ValueProvidersTests.swift */; };
+		6DB3BDB8282454A6002A276D /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDB7282454A6002A276D /* DictionaryInitializable.swift */; };
+		6DB3BDB9282454A6002A276D /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDB7282454A6002A276D /* DictionaryInitializable.swift */; };
+		6DB3BDBA282454A6002A276D /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDB7282454A6002A276D /* DictionaryInitializable.swift */; };
+		6DB3BDBC28245A14002A276D /* CGPointExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDBB28245A14002A276D /* CGPointExtension.swift */; };
+		6DB3BDBD28245A14002A276D /* CGPointExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDBB28245A14002A276D /* CGPointExtension.swift */; };
+		6DB3BDBE28245A14002A276D /* CGPointExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDBB28245A14002A276D /* CGPointExtension.swift */; };
+		6DB3BDC328245AA2002A276D /* ParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDBF28245A6A002A276D /* ParsingTests.swift */; };
 		A1D5BAAC27C731A500777D06 /* DataURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5BAAB27C731A500777D06 /* DataURLTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -755,6 +763,9 @@
 		2EAF59F227A0798700E00531 /* AnimationFontProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationFontProvider.swift; sourceTree = "<group>"; };
 		6D99D6422823790700E5205B /* LegacyGradientFillRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyGradientFillRenderer.swift; sourceTree = "<group>"; };
 		6DB3BDB528243FA5002A276D /* ValueProvidersTests.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ValueProvidersTests.swift; sourceTree = "<group>"; tabWidth = 2; };
+		6DB3BDB7282454A6002A276D /* DictionaryInitializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryInitializable.swift; sourceTree = "<group>"; };
+		6DB3BDBB28245A14002A276D /* CGPointExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGPointExtension.swift; sourceTree = "<group>"; };
+		6DB3BDBF28245A6A002A276D /* ParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingTests.swift; sourceTree = "<group>"; };
 		A1D5BAAB27C731A500777D06 /* DataURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataURLTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -770,6 +781,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6D0E635F28246BD0007C5DB6 /* Difference in Frameworks */,
 				2E8040B027A072B8006E74CB /* Lottie.framework in Frameworks */,
 				2E804A1A27A0740F006E74CB /* SnapshotTesting in Frameworks */,
 			);
@@ -821,6 +833,7 @@
 				2E80412527A07343006E74CB /* SnapshotConfiguration.swift */,
 				2E72128227BB329C0027BC56 /* AnimationKeypathTests.swift */,
 				2E72128427BB32DB0027BC56 /* PerformanceTests.swift */,
+				6DB3BDBF28245A6A002A276D /* ParsingTests.swift */,
 				A1D5BAAB27C731A500777D06 /* DataURLTests.swift */,
 				2E8040BD27A07343006E74CB /* Utils */,
 				2E044E262820536800FA773B /* AutomaticEngineTests.swift */,
@@ -851,6 +864,7 @@
 				2E9C95432822F43000677516 /* Keyframes */,
 				2E9C95462822F43000677516 /* Text */,
 				2E9C954B2822F43000677516 /* Assets */,
+				6DB3BDB7282454A6002A276D /* DictionaryInitializable.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1250,6 +1264,7 @@
 				2E9C95CB2822F43100677516 /* PathElement.swift */,
 				2E9C95CC2822F43100677516 /* CurveVertex.swift */,
 				2E9C95CD2822F43100677516 /* VectorsExtensions.swift */,
+				6DB3BDBB28245A14002A276D /* CGPointExtension.swift */,
 			);
 			path = Primitives;
 			sourceTree = "<group>";
@@ -1500,6 +1515,7 @@
 			name = LottieTests;
 			packageProductDependencies = (
 				2E804A1927A0740F006E74CB /* SnapshotTesting */,
+				6D0E635E28246BD0007C5DB6 /* Difference */,
 			);
 			productName = LottieTests;
 			productReference = 2E8040AC27A072B8006E74CB /* LottieTests.xctest */;
@@ -1576,6 +1592,7 @@
 			mainGroup = 2E80409027A0725D006E74CB;
 			packageReferences = (
 				2E804A1827A0740F006E74CB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
+				6D0E635D28246BD0007C5DB6 /* XCRemoteSwiftPackageReference "Difference" */,
 			);
 			productRefGroup = 2E80409B27A0725D006E74CB /* Products */;
 			projectDirPath = "";
@@ -1653,6 +1670,7 @@
 				2E9C967E2822F43100677516 /* GradientStrokeRenderer.swift in Sources */,
 				2E9C96932822F43100677516 /* PolygonNode.swift in Sources */,
 				2E9C96E42822F43100677516 /* MaskCompositionLayer.swift in Sources */,
+				6DB3BDBC28245A14002A276D /* CGPointExtension.swift in Sources */,
 				2EAF5AE327A0798700E00531 /* AnimationCacheProvider.swift in Sources */,
 				2E9C96422822F43100677516 /* RootAnimationLayer.swift in Sources */,
 				2E9C97712822F43100677516 /* AnimationContext.swift in Sources */,
@@ -1688,6 +1706,7 @@
 				2EAF5AAA27A0798700E00531 /* AnimationViewInitializers.swift in Sources */,
 				2EAF5AA727A0798700E00531 /* LottieConfiguration.swift in Sources */,
 				2E9C95D32822F43100677516 /* Fill.swift in Sources */,
+				6DB3BDB8282454A6002A276D /* DictionaryInitializable.swift in Sources */,
 				2E9C96B72822F43100677516 /* NodePropertyMap.swift in Sources */,
 				2E9C97682822F43100677516 /* VectorsExtensions.swift in Sources */,
 				2E9C97232822F43100677516 /* RectangleAnimation.swift in Sources */,
@@ -1818,6 +1837,7 @@
 				2EAF59A727A076BC00E00531 /* Bundle+Module.swift in Sources */,
 				2E8044AE27A07347006E74CB /* Snapshotting+presentationLayer.swift in Sources */,
 				2E72128527BB32DB0027BC56 /* PerformanceTests.swift in Sources */,
+				6DB3BDC328245AA2002A276D /* ParsingTests.swift in Sources */,
 				6DB3BDB628243FA5002A276D /* ValueProvidersTests.swift in Sources */,
 				2E72128327BB329C0027BC56 /* AnimationKeypathTests.swift in Sources */,
 				2E044E272820536800FA773B /* AutomaticEngineTests.swift in Sources */,
@@ -1854,6 +1874,7 @@
 				2E9C967F2822F43100677516 /* GradientStrokeRenderer.swift in Sources */,
 				2E9C96942822F43100677516 /* PolygonNode.swift in Sources */,
 				2E9C96E52822F43100677516 /* MaskCompositionLayer.swift in Sources */,
+				6DB3BDBD28245A14002A276D /* CGPointExtension.swift in Sources */,
 				2EAF5AE427A0798700E00531 /* AnimationCacheProvider.swift in Sources */,
 				2E9C96432822F43100677516 /* RootAnimationLayer.swift in Sources */,
 				2E9C97722822F43100677516 /* AnimationContext.swift in Sources */,
@@ -1889,6 +1910,7 @@
 				2EAF5AAB27A0798700E00531 /* AnimationViewInitializers.swift in Sources */,
 				2EAF5AA827A0798700E00531 /* LottieConfiguration.swift in Sources */,
 				2E9C95D42822F43100677516 /* Fill.swift in Sources */,
+				6DB3BDB9282454A6002A276D /* DictionaryInitializable.swift in Sources */,
 				2E9C96B82822F43100677516 /* NodePropertyMap.swift in Sources */,
 				2E9C97692822F43100677516 /* VectorsExtensions.swift in Sources */,
 				2E9C97242822F43100677516 /* RectangleAnimation.swift in Sources */,
@@ -2037,6 +2059,7 @@
 				2E9C96802822F43100677516 /* GradientStrokeRenderer.swift in Sources */,
 				2E9C96952822F43100677516 /* PolygonNode.swift in Sources */,
 				2E9C96E62822F43100677516 /* MaskCompositionLayer.swift in Sources */,
+				6DB3BDBE28245A14002A276D /* CGPointExtension.swift in Sources */,
 				2EAF5AE527A0798700E00531 /* AnimationCacheProvider.swift in Sources */,
 				2E9C96442822F43100677516 /* RootAnimationLayer.swift in Sources */,
 				2E9C97732822F43200677516 /* AnimationContext.swift in Sources */,
@@ -2072,6 +2095,7 @@
 				2EAF5AAC27A0798700E00531 /* AnimationViewInitializers.swift in Sources */,
 				2EAF5AA927A0798700E00531 /* LottieConfiguration.swift in Sources */,
 				2E9C95D52822F43100677516 /* Fill.swift in Sources */,
+				6DB3BDBA282454A6002A276D /* DictionaryInitializable.swift in Sources */,
 				2E9C96B92822F43100677516 /* NodePropertyMap.swift in Sources */,
 				2E9C976A2822F43100677516 /* VectorsExtensions.swift in Sources */,
 				2E9C97252822F43100677516 /* RectangleAnimation.swift in Sources */,
@@ -2598,6 +2622,14 @@
 				kind = branch;
 			};
 		};
+		6D0E635D28246BD0007C5DB6 /* XCRemoteSwiftPackageReference "Difference" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/krzysztofzablocki/Difference";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2605,6 +2637,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2E804A1827A0740F006E74CB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
 			productName = SnapshotTesting;
+		};
+		6D0E635E28246BD0007C5DB6 /* Difference */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6D0E635D28246BD0007C5DB6 /* XCRemoteSwiftPackageReference "Difference" */;
+			productName = Difference;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "Difference",
+        "repositoryURL": "https://github.com/krzysztofzablocki/Difference",
+        "state": {
+          "branch": null,
+          "revision": "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
+          "version": "1.0.1"
+        }
+      },
+      {
         "package": "Epoxy",
         "repositoryURL": "https://github.com/airbnb/epoxy-ios.git",
         "state": {

--- a/Sources/Private/CoreAnimation/Animations/CombinedShapeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CombinedShapeAnimation.swift
@@ -41,6 +41,10 @@ final class CombinedShapeItem: ShapeItem {
     fatalError("init(from:) has not been implemented")
   }
 
+  required init(dictionary _: [String: Any]) throws {
+    fatalError("init(dictionary:) has not been implemented")
+  }
+
   // MARK: Internal
 
   let shapes: KeyframeGroup<[BezierPath]>

--- a/Sources/Private/Model/Animation.swift
+++ b/Sources/Private/Model/Animation.swift
@@ -20,7 +20,7 @@ public enum CoordinateSpace: Int, Codable {
 ///
 /// An `Animation` holds all of the animation data backing a Lottie Animation.
 /// Codable, see JSON schema [here](https://github.com/airbnb/lottie-web/tree/master/docs/json).
-public final class Animation: Codable {
+public final class Animation: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle
 
@@ -46,6 +46,52 @@ public final class Animation: Codable {
       }
       self.markerMap = markerMap
     } else {
+      markerMap = nil
+    }
+  }
+
+  public init(dictionary: [String: Any]) throws {
+    version = try dictionary.valueFor(key: CodingKeys.version.rawValue)
+    if
+      let typeRawValue = dictionary[CodingKeys.type.rawValue] as? Int,
+      let type = CoordinateSpace(rawValue: typeRawValue)
+    {
+      self.type = type
+    } else {
+      type = .type2d
+    }
+    startFrame = try dictionary.valueFor(key: CodingKeys.startFrame.rawValue)
+    endFrame = try dictionary.valueFor(key: CodingKeys.endFrame.rawValue)
+    framerate = try dictionary.valueFor(key: CodingKeys.framerate.rawValue)
+    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    let layerDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.layers.rawValue)
+    layers = try [LayerModel].fromDictionaries(layerDictionaries)
+    if let glyphDictionaries = dictionary[CodingKeys.glyphs.rawValue] as? [[String: Any]] {
+      glyphs = try glyphDictionaries.map({ try Glyph(dictionary: $0) })
+    } else {
+      glyphs = nil
+    }
+    if let fontsDictionary = dictionary[CodingKeys.fonts.rawValue] as? [String: Any] {
+      fonts = try FontList(dictionary: fontsDictionary)
+    } else {
+      fonts = nil
+    }
+    if let assetLibraryDictionaries = dictionary[CodingKeys.assetLibrary.rawValue] as? [[String: Any]] {
+      assetLibrary = try AssetLibrary(value: assetLibraryDictionaries)
+    } else {
+      assetLibrary = nil
+    }
+    if let markerDictionaries = dictionary[CodingKeys.markers.rawValue] as? [[String: Any]] {
+      let markers = try markerDictionaries.map({ try Marker(dictionary: $0) })
+      var markerMap: [String: Marker] = [:]
+      for marker in markers {
+        markerMap[marker.name] = marker
+      }
+      self.markers = markers
+      self.markerMap = markerMap
+    } else {
+      markers = nil
       markerMap = nil
     }
   }

--- a/Sources/Private/Model/Animation.swift
+++ b/Sources/Private/Model/Animation.swift
@@ -51,7 +51,7 @@ public final class Animation: Codable, DictionaryInitializable {
   }
 
   public init(dictionary: [String: Any]) throws {
-    version = try dictionary.valueFor(key: CodingKeys.version.rawValue)
+    version = try dictionary.value(for: CodingKeys.version.rawValue)
     if
       let typeRawValue = dictionary[CodingKeys.type.rawValue] as? Int,
       let type = CoordinateSpace(rawValue: typeRawValue)
@@ -60,12 +60,12 @@ public final class Animation: Codable, DictionaryInitializable {
     } else {
       type = .type2d
     }
-    startFrame = try dictionary.valueFor(key: CodingKeys.startFrame.rawValue)
-    endFrame = try dictionary.valueFor(key: CodingKeys.endFrame.rawValue)
-    framerate = try dictionary.valueFor(key: CodingKeys.framerate.rawValue)
-    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
-    height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
-    let layerDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.layers.rawValue)
+    startFrame = try dictionary.value(for: CodingKeys.startFrame.rawValue)
+    endFrame = try dictionary.value(for: CodingKeys.endFrame.rawValue)
+    framerate = try dictionary.value(for: CodingKeys.framerate.rawValue)
+    width = try dictionary.value(for: CodingKeys.width.rawValue)
+    height = try dictionary.value(for: CodingKeys.height.rawValue)
+    let layerDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.layers.rawValue)
     layers = try [LayerModel].fromDictionaries(layerDictionaries)
     if let glyphDictionaries = dictionary[CodingKeys.glyphs.rawValue] as? [[String: Any]] {
       glyphs = try glyphDictionaries.map({ try Glyph(dictionary: $0) })

--- a/Sources/Private/Model/Animation.swift
+++ b/Sources/Private/Model/Animation.swift
@@ -51,7 +51,7 @@ public final class Animation: Codable, DictionaryInitializable {
   }
 
   public init(dictionary: [String: Any]) throws {
-    version = try dictionary.value(for: CodingKeys.version.rawValue)
+    version = try dictionary.value(for: CodingKeys.version)
     if
       let typeRawValue = dictionary[CodingKeys.type.rawValue] as? Int,
       let type = CoordinateSpace(rawValue: typeRawValue)
@@ -60,12 +60,12 @@ public final class Animation: Codable, DictionaryInitializable {
     } else {
       type = .type2d
     }
-    startFrame = try dictionary.value(for: CodingKeys.startFrame.rawValue)
-    endFrame = try dictionary.value(for: CodingKeys.endFrame.rawValue)
-    framerate = try dictionary.value(for: CodingKeys.framerate.rawValue)
-    width = try dictionary.value(for: CodingKeys.width.rawValue)
-    height = try dictionary.value(for: CodingKeys.height.rawValue)
-    let layerDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.layers.rawValue)
+    startFrame = try dictionary.value(for: CodingKeys.startFrame)
+    endFrame = try dictionary.value(for: CodingKeys.endFrame)
+    framerate = try dictionary.value(for: CodingKeys.framerate)
+    width = try dictionary.value(for: CodingKeys.width)
+    height = try dictionary.value(for: CodingKeys.height)
+    let layerDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.layers)
     layers = try [LayerModel].fromDictionaries(layerDictionaries)
     if let glyphDictionaries = dictionary[CodingKeys.glyphs.rawValue] as? [[String: Any]] {
       glyphs = try glyphDictionaries.map({ try Glyph(dictionary: $0) })

--- a/Sources/Private/Model/Assets/Asset.swift
+++ b/Sources/Private/Model/Assets/Asset.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class Asset: Codable {
+public class Asset: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle
 
@@ -17,6 +17,16 @@ public class Asset: Codable {
       self.id = id
     } else {
       id = String(try container.decode(Int.self, forKey: .id))
+    }
+  }
+
+  required init(dictionary: [String: Any]) throws {
+    if let id = dictionary[CodingKeys.id.rawValue] as? String {
+      self.id = id
+    } else if let id = dictionary[CodingKeys.id.rawValue] as? Int {
+      self.id = String(id)
+    } else {
+      throw InitializableError.invalidInput
     }
   }
 

--- a/Sources/Private/Model/Assets/AssetLibrary.swift
+++ b/Sources/Private/Model/Assets/AssetLibrary.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class AssetLibrary: Codable {
+final class AssetLibrary: Codable, AnyInitializable {
 
   // MARK: Lifecycle
 
@@ -30,6 +30,29 @@ final class AssetLibrary: Codable {
         let imageAsset = try container.decode(ImageAsset.self)
         decodedAssets[imageAsset.id] = imageAsset
         imageAssets[imageAsset.id] = imageAsset
+      }
+    }
+    assets = decodedAssets
+    self.precompAssets = precompAssets
+    self.imageAssets = imageAssets
+  }
+
+  init(value: Any) throws {
+    guard let dictionaries = value as? [[String: Any]] else {
+      throw InitializableError.invalidInput
+    }
+    var decodedAssets = [String : Asset]()
+    var imageAssets = [String : ImageAsset]()
+    var precompAssets = [String : PrecompAsset]()
+    try dictionaries.forEach { dictionary in
+      if dictionary[PrecompAsset.CodingKeys.layers.rawValue] != nil {
+        let asset = try PrecompAsset(dictionary: dictionary)
+        decodedAssets[asset.id] = asset
+        precompAssets[asset.id] = asset
+      } else {
+        let asset = try ImageAsset(dictionary: dictionary)
+        decodedAssets[asset.id] = asset
+        imageAssets[asset.id] = asset
       }
     }
     assets = decodedAssets

--- a/Sources/Private/Model/Assets/ImageAsset.swift
+++ b/Sources/Private/Model/Assets/ImageAsset.swift
@@ -23,10 +23,10 @@ public final class ImageAsset: Asset {
   }
 
   required init(dictionary: [String: Any]) throws {
-    name = try dictionary.valueFor(key: CodingKeys.name.rawValue)
-    directory = try dictionary.valueFor(key: CodingKeys.directory.rawValue)
-    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
-    height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    name = try dictionary.value(for: CodingKeys.name.rawValue)
+    directory = try dictionary.value(for: CodingKeys.directory.rawValue)
+    width = try dictionary.value(for: CodingKeys.width.rawValue)
+    height = try dictionary.value(for: CodingKeys.height.rawValue)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/Assets/ImageAsset.swift
+++ b/Sources/Private/Model/Assets/ImageAsset.swift
@@ -22,6 +22,14 @@ public final class ImageAsset: Asset {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    name = try dictionary.valueFor(key: CodingKeys.name.rawValue)
+    directory = try dictionary.valueFor(key: CodingKeys.directory.rawValue)
+    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Public
 
   /// Image name

--- a/Sources/Private/Model/Assets/ImageAsset.swift
+++ b/Sources/Private/Model/Assets/ImageAsset.swift
@@ -23,10 +23,10 @@ public final class ImageAsset: Asset {
   }
 
   required init(dictionary: [String: Any]) throws {
-    name = try dictionary.value(for: CodingKeys.name.rawValue)
-    directory = try dictionary.value(for: CodingKeys.directory.rawValue)
-    width = try dictionary.value(for: CodingKeys.width.rawValue)
-    height = try dictionary.value(for: CodingKeys.height.rawValue)
+    name = try dictionary.value(for: CodingKeys.name)
+    directory = try dictionary.value(for: CodingKeys.directory)
+    width = try dictionary.value(for: CodingKeys.width)
+    height = try dictionary.value(for: CodingKeys.height)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/Assets/PrecompAsset.swift
+++ b/Sources/Private/Model/Assets/PrecompAsset.swift
@@ -18,7 +18,7 @@ final class PrecompAsset: Asset {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let layerDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.layers.rawValue)
+    let layerDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.layers)
     layers = try [LayerModel].fromDictionaries(layerDictionaries)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/Assets/PrecompAsset.swift
+++ b/Sources/Private/Model/Assets/PrecompAsset.swift
@@ -18,7 +18,7 @@ final class PrecompAsset: Asset {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let layerDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.layers.rawValue)
+    let layerDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.layers.rawValue)
     layers = try [LayerModel].fromDictionaries(layerDictionaries)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/Assets/PrecompAsset.swift
+++ b/Sources/Private/Model/Assets/PrecompAsset.swift
@@ -17,6 +17,12 @@ final class PrecompAsset: Asset {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let layerDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.layers.rawValue)
+    layers = try [LayerModel].fromDictionaries(layerDictionaries)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   enum CodingKeys: String, CodingKey {

--- a/Sources/Private/Model/DictionaryInitializable.swift
+++ b/Sources/Private/Model/DictionaryInitializable.swift
@@ -32,19 +32,19 @@ protocol AnyInitializable {
 extension Dictionary {
 
   @_disfavoredOverload
-  func value<T>(for key: Key) throws -> T {
-    guard let value = self[key] as? T else {
+  func value<T, KeyType: RawRepresentable>(for key: KeyType) throws -> T where KeyType.RawValue == Key {
+    guard let value = self[key.rawValue] as? T else {
       throw InitializableError.invalidInput
     }
     return value
   }
 
-  func value<T: AnyInitializable>(for key: Key) throws -> T {
-    if let value = self[key] as? T {
+  func value<T: AnyInitializable, KeyType: RawRepresentable>(for key: KeyType) throws -> T where KeyType.RawValue == Key {
+    if let value = self[key.rawValue] as? T {
       return value
     }
 
-    if let value = self[key] {
+    if let value = self[key.rawValue] {
       return try T(value: value)
     }
 

--- a/Sources/Private/Model/DictionaryInitializable.swift
+++ b/Sources/Private/Model/DictionaryInitializable.swift
@@ -1,0 +1,67 @@
+//
+//  DictionaryInitializable.swift
+//  Lottie
+//
+//  Created by Marcelo Fabri on 5/5/22.
+//
+
+import Foundation
+
+// MARK: - InitializableError
+
+enum InitializableError: Error {
+  case invalidInput
+}
+
+// MARK: - DictionaryInitializable
+
+protocol DictionaryInitializable {
+
+  init(dictionary: [String: Any]) throws
+
+}
+
+// MARK: - AnyInitializable
+
+protocol AnyInitializable {
+
+  init(value: Any) throws
+
+}
+
+extension Dictionary {
+
+  @_disfavoredOverload
+  func valueFor<T>(key: Key) throws -> T {
+    guard let value = self[key] as? T else {
+      throw InitializableError.invalidInput
+    }
+    return value
+  }
+
+  func valueFor<T: AnyInitializable>(key: Key) throws -> T {
+    if let value = self[key] as? T {
+      return value
+    }
+
+    if let value = self[key] {
+      return try T(value: value)
+    }
+
+    throw InitializableError.invalidInput
+  }
+
+}
+
+// MARK: - Array + AnyInitializable
+
+extension Array: AnyInitializable where Element == Double {
+
+  init(value: Any) throws {
+    guard let array = value as? [Double] else {
+      throw InitializableError.invalidInput
+    }
+    self = array
+  }
+
+}

--- a/Sources/Private/Model/DictionaryInitializable.swift
+++ b/Sources/Private/Model/DictionaryInitializable.swift
@@ -32,14 +32,14 @@ protocol AnyInitializable {
 extension Dictionary {
 
   @_disfavoredOverload
-  func valueFor<T>(key: Key) throws -> T {
+  func value<T>(for key: Key) throws -> T {
     guard let value = self[key] as? T else {
       throw InitializableError.invalidInput
     }
     return value
   }
 
-  func valueFor<T: AnyInitializable>(key: Key) throws -> T {
+  func value<T: AnyInitializable>(for key: Key) throws -> T {
     if let value = self[key] as? T {
       return value
     }

--- a/Sources/Private/Model/Keyframes/KeyframeData.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeData.swift
@@ -93,12 +93,12 @@ extension KeyframeData: DictionaryInitializable where T: AnyInitializable {
   convenience init(dictionary: [String: Any]) throws {
     let startValue = try? dictionary[CodingKeys.startValue.rawValue].flatMap(T.init)
     let endValue = try? dictionary[CodingKeys.endValue.rawValue].flatMap(T.init)
-    let time: AnimationFrameTime? = try? dictionary.value(for: CodingKeys.time.rawValue)
-    let hold: Int? = try? dictionary.value(for: CodingKeys.hold.rawValue)
-    let inTangent: Vector2D? = try? dictionary.value(for: CodingKeys.inTangent.rawValue)
-    let outTangent: Vector2D? = try? dictionary.value(for: CodingKeys.outTangent.rawValue)
-    let spatialInTangent: Vector3D? = try? dictionary.value(for: CodingKeys.spatialInTangent.rawValue)
-    let spatialOutTangent: Vector3D? = try? dictionary.value(for: CodingKeys.spatialOutTangent.rawValue)
+    let time: AnimationFrameTime? = try? dictionary.value(for: CodingKeys.time)
+    let hold: Int? = try? dictionary.value(for: CodingKeys.hold)
+    let inTangent: Vector2D? = try? dictionary.value(for: CodingKeys.inTangent)
+    let outTangent: Vector2D? = try? dictionary.value(for: CodingKeys.outTangent)
+    let spatialInTangent: Vector3D? = try? dictionary.value(for: CodingKeys.spatialInTangent)
+    let spatialOutTangent: Vector3D? = try? dictionary.value(for: CodingKeys.spatialOutTangent)
 
     self.init(
       startValue: startValue,

--- a/Sources/Private/Model/Keyframes/KeyframeData.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeData.swift
@@ -93,12 +93,12 @@ extension KeyframeData: DictionaryInitializable where T: AnyInitializable {
   convenience init(dictionary: [String: Any]) throws {
     let startValue = try? dictionary[CodingKeys.startValue.rawValue].flatMap(T.init)
     let endValue = try? dictionary[CodingKeys.endValue.rawValue].flatMap(T.init)
-    let time: Double? = try? dictionary.valueFor(key: CodingKeys.time.rawValue)
-    let hold: Int? = try? dictionary.valueFor(key: CodingKeys.hold.rawValue)
-    let inTangent: Vector2D? = try? dictionary.valueFor(key: CodingKeys.inTangent.rawValue)
-    let outTangent: Vector2D? = try? dictionary.valueFor(key: CodingKeys.outTangent.rawValue)
-    let spatialInTangent: Vector3D? = try? dictionary.valueFor(key: CodingKeys.spatialInTangent.rawValue)
-    let spatialOutTangent: Vector3D? = try? dictionary.valueFor(key: CodingKeys.spatialOutTangent.rawValue)
+    let time: Double? = try? dictionary.value(for: CodingKeys.time.rawValue)
+    let hold: Int? = try? dictionary.value(for: CodingKeys.hold.rawValue)
+    let inTangent: Vector2D? = try? dictionary.value(for: CodingKeys.inTangent.rawValue)
+    let outTangent: Vector2D? = try? dictionary.value(for: CodingKeys.outTangent.rawValue)
+    let spatialInTangent: Vector3D? = try? dictionary.value(for: CodingKeys.spatialInTangent.rawValue)
+    let spatialOutTangent: Vector3D? = try? dictionary.value(for: CodingKeys.spatialOutTangent.rawValue)
 
     self.init(
       startValue: startValue,

--- a/Sources/Private/Model/Keyframes/KeyframeData.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeData.swift
@@ -86,3 +86,28 @@ extension KeyframeData: Encodable where T: Encodable { }
 // MARK: Decodable
 
 extension KeyframeData: Decodable where T: Decodable { }
+
+// MARK: DictionaryInitializable
+
+extension KeyframeData: DictionaryInitializable where T: AnyInitializable {
+  convenience init(dictionary: [String: Any]) throws {
+    let startValue = try? dictionary[CodingKeys.startValue.rawValue].flatMap(T.init)
+    let endValue = try? dictionary[CodingKeys.endValue.rawValue].flatMap(T.init)
+    let time: Double? = try? dictionary.valueFor(key: CodingKeys.time.rawValue)
+    let hold: Int? = try? dictionary.valueFor(key: CodingKeys.hold.rawValue)
+    let inTangent: Vector2D? = try? dictionary.valueFor(key: CodingKeys.inTangent.rawValue)
+    let outTangent: Vector2D? = try? dictionary.valueFor(key: CodingKeys.outTangent.rawValue)
+    let spatialInTangent: Vector3D? = try? dictionary.valueFor(key: CodingKeys.spatialInTangent.rawValue)
+    let spatialOutTangent: Vector3D? = try? dictionary.valueFor(key: CodingKeys.spatialOutTangent.rawValue)
+
+    self.init(
+      startValue: startValue,
+      endValue: endValue,
+      time: time,
+      hold: hold,
+      inTangent: inTangent,
+      outTangent: outTangent,
+      spatialInTangent: spatialInTangent,
+      spatialOutTangent: spatialOutTangent)
+  }
+}

--- a/Sources/Private/Model/Keyframes/KeyframeData.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeData.swift
@@ -22,7 +22,7 @@ final class KeyframeData<T> {
   init(
     startValue: T?,
     endValue: T?,
-    time: Double?,
+    time: AnimationFrameTime?,
     hold: Int?,
     inTangent: Vector2D?,
     outTangent: Vector2D?,
@@ -57,7 +57,7 @@ final class KeyframeData<T> {
   /// The End value of the keyframe. Note: Newer versions animation json do not have this field.
   let endValue: T?
   /// The time in frames of the keyframe.
-  let time: Double?
+  let time: AnimationFrameTime?
   /// A hold keyframe freezes interpolation until the next keyframe that is not a hold.
   let hold: Int?
 
@@ -93,7 +93,7 @@ extension KeyframeData: DictionaryInitializable where T: AnyInitializable {
   convenience init(dictionary: [String: Any]) throws {
     let startValue = try? dictionary[CodingKeys.startValue.rawValue].flatMap(T.init)
     let endValue = try? dictionary[CodingKeys.endValue.rawValue].flatMap(T.init)
-    let time: Double? = try? dictionary.value(for: CodingKeys.time.rawValue)
+    let time: AnimationFrameTime? = try? dictionary.value(for: CodingKeys.time.rawValue)
     let hold: Int? = try? dictionary.value(for: CodingKeys.hold.rawValue)
     let inTangent: Vector2D? = try? dictionary.value(for: CodingKeys.inTangent.rawValue)
     let outTangent: Vector2D? = try? dictionary.value(for: CodingKeys.outTangent.rawValue)

--- a/Sources/Private/Model/Keyframes/KeyframeGroup.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeGroup.swift
@@ -112,7 +112,7 @@ extension KeyframeGroup: Encodable where T: Encodable {
         let keyframeData = KeyframeData<T>(
           startValue: keyframe.value,
           endValue: nextKeyframe.value,
-          time: Double(keyframe.time),
+          time: keyframe.time,
           hold: keyframe.isHold ? 1 : nil,
           inTangent: nextKeyframe.inTangent,
           outTangent: keyframe.outTangent,

--- a/Sources/Private/Model/Keyframes/KeyframeGroup.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeGroup.swift
@@ -139,7 +139,7 @@ extension KeyframeGroup: DictionaryInitializable where T: AnyInitializable {
       if let singleFrameDictionary = dictionary[KeyframeWrapperKey.keyframeData.rawValue] as? [String: Any] {
         frameDictionaries = [singleFrameDictionary]
       } else {
-        frameDictionaries = try dictionary.value(for: KeyframeWrapperKey.keyframeData.rawValue)
+        frameDictionaries = try dictionary.value(for: KeyframeWrapperKey.keyframeData)
       }
       var previousKeyframeData: KeyframeData<T>?
       for frameDictionary in frameDictionaries {

--- a/Sources/Private/Model/Keyframes/KeyframeGroup.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeGroup.swift
@@ -29,13 +29,12 @@ final class KeyframeGroup<T> {
 
   // MARK: Internal
 
-  let keyframes: ContiguousArray<Keyframe<T>>
-
-  // MARK: Private
-
-  private enum KeyframeWrapperKey: String, CodingKey {
+  enum KeyframeWrapperKey: String, CodingKey {
     case keyframeData = "k"
   }
+
+  let keyframes: ContiguousArray<Keyframe<T>>
+
 }
 
 // MARK: Decodable
@@ -122,6 +121,48 @@ extension KeyframeGroup: Encodable where T: Encodable {
         try keyframeContainer.encode(keyframeData)
       }
     }
+  }
+}
+
+// MARK: DictionaryInitializable
+
+extension KeyframeGroup: DictionaryInitializable where T: AnyInitializable {
+  convenience init(dictionary: [String: Any]) throws {
+    var keyframes = ContiguousArray<Keyframe<T>>()
+    if
+      let rawValue = dictionary[KeyframeWrapperKey.keyframeData.rawValue],
+      let value = try? T(value: rawValue)
+    {
+      keyframes = [Keyframe<T>(value)]
+    } else {
+      var frameDictionaries: [[String: Any]]
+      if let singleFrameDictionary = dictionary[KeyframeWrapperKey.keyframeData.rawValue] as? [String: Any] {
+        frameDictionaries = [singleFrameDictionary]
+      } else {
+        frameDictionaries = try dictionary.valueFor(key: KeyframeWrapperKey.keyframeData.rawValue)
+      }
+      var previousKeyframeData: KeyframeData<T>?
+      for frameDictionary in frameDictionaries {
+        let data = try KeyframeData<T>(dictionary: frameDictionary)
+        guard
+          let value: T = data.startValue ?? previousKeyframeData?.endValue,
+          let time = data.time else
+        {
+          throw InitializableError.invalidInput
+        }
+        keyframes.append(Keyframe<T>(
+          value: value,
+          time: time,
+          isHold: data.isHold,
+          inTangent: previousKeyframeData?.inTangent,
+          outTangent: data.outTangent,
+          spatialInTangent: previousKeyframeData?.spatialInTangent,
+          spatialOutTangent: data.spatialOutTangent))
+        previousKeyframeData = data
+      }
+    }
+
+    self.init(keyframes: keyframes)
   }
 }
 

--- a/Sources/Private/Model/Keyframes/KeyframeGroup.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeGroup.swift
@@ -139,7 +139,7 @@ extension KeyframeGroup: DictionaryInitializable where T: AnyInitializable {
       if let singleFrameDictionary = dictionary[KeyframeWrapperKey.keyframeData.rawValue] as? [String: Any] {
         frameDictionaries = [singleFrameDictionary]
       } else {
-        frameDictionaries = try dictionary.valueFor(key: KeyframeWrapperKey.keyframeData.rawValue)
+        frameDictionaries = try dictionary.value(for: KeyframeWrapperKey.keyframeData.rawValue)
       }
       var previousKeyframeData: KeyframeData<T>?
       for frameDictionary in frameDictionaries {

--- a/Sources/Private/Model/Layers/ImageLayerModel.swift
+++ b/Sources/Private/Model/Layers/ImageLayerModel.swift
@@ -18,6 +18,11 @@ final class ImageLayerModel: LayerModel {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    referenceID = try dictionary.valueFor(key: CodingKeys.referenceID.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The reference ID of the image.

--- a/Sources/Private/Model/Layers/ImageLayerModel.swift
+++ b/Sources/Private/Model/Layers/ImageLayerModel.swift
@@ -19,7 +19,7 @@ final class ImageLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    referenceID = try dictionary.valueFor(key: CodingKeys.referenceID.rawValue)
+    referenceID = try dictionary.value(for: CodingKeys.referenceID.rawValue)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/Layers/ImageLayerModel.swift
+++ b/Sources/Private/Model/Layers/ImageLayerModel.swift
@@ -19,7 +19,7 @@ final class ImageLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    referenceID = try dictionary.value(for: CodingKeys.referenceID.rawValue)
+    referenceID = try dictionary.value(for: CodingKeys.referenceID)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/Layers/LayerModel.swift
+++ b/Sources/Private/Model/Layers/LayerModel.swift
@@ -102,9 +102,9 @@ class LayerModel: Codable, DictionaryInitializable {
   }
 
   required init(dictionary: [String: Any]) throws {
-    name = (try? dictionary.valueFor(key: CodingKeys.name.rawValue)) ?? "Layer"
-    index = try dictionary.valueFor(key: CodingKeys.index.rawValue) ?? .random(in: Int.min...Int.max)
-    type = LayerType(rawValue: try dictionary.valueFor(key: CodingKeys.type.rawValue)) ?? .null
+    name = (try? dictionary.value(for: CodingKeys.name.rawValue)) ?? "Layer"
+    index = try dictionary.value(for: CodingKeys.index.rawValue) ?? .random(in: Int.min...Int.max)
+    type = LayerType(rawValue: try dictionary.value(for: CodingKeys.type.rawValue)) ?? .null
     if
       let coordinateSpaceRawValue = dictionary[CodingKeys.coordinateSpace.rawValue] as? Int,
       let coordinateSpace = CoordinateSpace(rawValue: coordinateSpaceRawValue)
@@ -113,11 +113,11 @@ class LayerModel: Codable, DictionaryInitializable {
     } else {
       coordinateSpace = .type2d
     }
-    inFrame = try dictionary.valueFor(key: CodingKeys.inFrame.rawValue)
-    outFrame = try dictionary.valueFor(key: CodingKeys.outFrame.rawValue)
-    startTime = try dictionary.valueFor(key: CodingKeys.startTime.rawValue)
-    transform = try Transform(dictionary: try dictionary.valueFor(key: CodingKeys.transform.rawValue))
-    parent = try? dictionary.valueFor(key: CodingKeys.parent.rawValue)
+    inFrame = try dictionary.value(for: CodingKeys.inFrame.rawValue)
+    outFrame = try dictionary.value(for: CodingKeys.outFrame.rawValue)
+    startTime = try dictionary.value(for: CodingKeys.startTime.rawValue)
+    transform = try Transform(dictionary: try dictionary.value(for: CodingKeys.transform.rawValue))
+    parent = try? dictionary.value(for: CodingKeys.parent.rawValue)
     if
       let blendModeRawValue = dictionary[CodingKeys.blendMode.rawValue] as? Int,
       let blendMode = BlendMode(rawValue: blendModeRawValue)
@@ -131,13 +131,13 @@ class LayerModel: Codable, DictionaryInitializable {
     } else {
       masks = nil
     }
-    timeStretch = (try? dictionary.valueFor(key: CodingKeys.timeStretch.rawValue)) ?? 1
+    timeStretch = (try? dictionary.value(for: CodingKeys.timeStretch.rawValue)) ?? 1
     if let matteRawValue = dictionary[CodingKeys.matte.rawValue] as? Int {
       matte = MatteType(rawValue: matteRawValue)
     } else {
       matte = nil
     }
-    hidden = (try? dictionary.valueFor(key: CodingKeys.hidden.rawValue)) ?? false
+    hidden = (try? dictionary.value(for: CodingKeys.hidden.rawValue)) ?? false
   }
 
   // MARK: Internal

--- a/Sources/Private/Model/Layers/LayerModel.swift
+++ b/Sources/Private/Model/Layers/LayerModel.swift
@@ -102,9 +102,9 @@ class LayerModel: Codable, DictionaryInitializable {
   }
 
   required init(dictionary: [String: Any]) throws {
-    name = (try? dictionary.value(for: CodingKeys.name.rawValue)) ?? "Layer"
-    index = try dictionary.value(for: CodingKeys.index.rawValue) ?? .random(in: Int.min...Int.max)
-    type = LayerType(rawValue: try dictionary.value(for: CodingKeys.type.rawValue)) ?? .null
+    name = (try? dictionary.value(for: CodingKeys.name)) ?? "Layer"
+    index = try dictionary.value(for: CodingKeys.index) ?? .random(in: Int.min...Int.max)
+    type = LayerType(rawValue: try dictionary.value(for: CodingKeys.type)) ?? .null
     if
       let coordinateSpaceRawValue = dictionary[CodingKeys.coordinateSpace.rawValue] as? Int,
       let coordinateSpace = CoordinateSpace(rawValue: coordinateSpaceRawValue)
@@ -113,11 +113,11 @@ class LayerModel: Codable, DictionaryInitializable {
     } else {
       coordinateSpace = .type2d
     }
-    inFrame = try dictionary.value(for: CodingKeys.inFrame.rawValue)
-    outFrame = try dictionary.value(for: CodingKeys.outFrame.rawValue)
-    startTime = try dictionary.value(for: CodingKeys.startTime.rawValue)
-    transform = try Transform(dictionary: try dictionary.value(for: CodingKeys.transform.rawValue))
-    parent = try? dictionary.value(for: CodingKeys.parent.rawValue)
+    inFrame = try dictionary.value(for: CodingKeys.inFrame)
+    outFrame = try dictionary.value(for: CodingKeys.outFrame)
+    startTime = try dictionary.value(for: CodingKeys.startTime)
+    transform = try Transform(dictionary: try dictionary.value(for: CodingKeys.transform))
+    parent = try? dictionary.value(for: CodingKeys.parent)
     if
       let blendModeRawValue = dictionary[CodingKeys.blendMode.rawValue] as? Int,
       let blendMode = BlendMode(rawValue: blendModeRawValue)
@@ -131,13 +131,13 @@ class LayerModel: Codable, DictionaryInitializable {
     } else {
       masks = nil
     }
-    timeStretch = (try? dictionary.value(for: CodingKeys.timeStretch.rawValue)) ?? 1
+    timeStretch = (try? dictionary.value(for: CodingKeys.timeStretch)) ?? 1
     if let matteRawValue = dictionary[CodingKeys.matte.rawValue] as? Int {
       matte = MatteType(rawValue: matteRawValue)
     } else {
       matte = nil
     }
-    hidden = (try? dictionary.value(for: CodingKeys.hidden.rawValue)) ?? false
+    hidden = (try? dictionary.value(for: CodingKeys.hidden)) ?? false
   }
 
   // MARK: Internal

--- a/Sources/Private/Model/Layers/LayerModel.swift
+++ b/Sources/Private/Model/Layers/LayerModel.swift
@@ -79,7 +79,7 @@ public enum BlendMode: Int, Codable {
 // MARK: - LayerModel
 
 /// A base top container for shapes, images, and other view objects.
-class LayerModel: Codable {
+class LayerModel: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle
 
@@ -99,6 +99,45 @@ class LayerModel: Codable {
     timeStretch = try container.decodeIfPresent(Double.self, forKey: .timeStretch) ?? 1
     matte = try container.decodeIfPresent(MatteType.self, forKey: .matte)
     hidden = try container.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
+  }
+
+  required init(dictionary: [String: Any]) throws {
+    name = (try? dictionary.valueFor(key: CodingKeys.name.rawValue)) ?? "Layer"
+    index = try dictionary.valueFor(key: CodingKeys.index.rawValue) ?? .random(in: Int.min...Int.max)
+    type = LayerType(rawValue: try dictionary.valueFor(key: CodingKeys.type.rawValue)) ?? .null
+    if
+      let coordinateSpaceRawValue = dictionary[CodingKeys.coordinateSpace.rawValue] as? Int,
+      let coordinateSpace = CoordinateSpace(rawValue: coordinateSpaceRawValue)
+    {
+      self.coordinateSpace = coordinateSpace
+    } else {
+      coordinateSpace = .type2d
+    }
+    inFrame = try dictionary.valueFor(key: CodingKeys.inFrame.rawValue)
+    outFrame = try dictionary.valueFor(key: CodingKeys.outFrame.rawValue)
+    startTime = try dictionary.valueFor(key: CodingKeys.startTime.rawValue)
+    transform = try Transform(dictionary: try dictionary.valueFor(key: CodingKeys.transform.rawValue))
+    parent = try? dictionary.valueFor(key: CodingKeys.parent.rawValue)
+    if
+      let blendModeRawValue = dictionary[CodingKeys.blendMode.rawValue] as? Int,
+      let blendMode = BlendMode(rawValue: blendModeRawValue)
+    {
+      self.blendMode = blendMode
+    } else {
+      blendMode = .normal
+    }
+    if let maskDictionaries = dictionary[CodingKeys.masks.rawValue] as? [[String: Any]] {
+      masks = try maskDictionaries.map({ try Mask(dictionary: $0) })
+    } else {
+      masks = nil
+    }
+    timeStretch = (try? dictionary.valueFor(key: CodingKeys.timeStretch.rawValue)) ?? 1
+    if let matteRawValue = dictionary[CodingKeys.matte.rawValue] as? Int {
+      matte = MatteType(rawValue: matteRawValue)
+    } else {
+      matte = nil
+    }
+    hidden = (try? dictionary.valueFor(key: CodingKeys.hidden.rawValue)) ?? false
   }
 
   // MARK: Internal
@@ -143,9 +182,9 @@ class LayerModel: Codable {
 
   let hidden: Bool
 
-  // MARK: Private
+  // MARK: Fileprivate
 
-  private enum CodingKeys: String, CodingKey {
+  fileprivate enum CodingKeys: String, CodingKey {
     case name = "nm"
     case index = "ind"
     case type = "ty"
@@ -160,5 +199,30 @@ class LayerModel: Codable {
     case timeStretch = "sr"
     case matte = "tt"
     case hidden = "hd"
+  }
+}
+
+extension Array where Element == LayerModel {
+
+  static func fromDictionaries(_ dictionaries: [[String: Any]]) throws -> [LayerModel] {
+    try dictionaries.compactMap { dictionary in
+      let layerType = dictionary[LayerModel.CodingKeys.type.rawValue] as? Int
+      switch LayerType(rawValue: layerType ?? LayerType.null.rawValue) {
+      case .precomp:
+        return try PreCompLayerModel(dictionary: dictionary)
+      case .solid:
+        return try SolidLayerModel(dictionary: dictionary)
+      case .image:
+        return try ImageLayerModel(dictionary: dictionary)
+      case .null:
+        return try LayerModel(dictionary: dictionary)
+      case .shape:
+        return try ShapeLayerModel(dictionary: dictionary)
+      case .text:
+        return try TextLayerModel(dictionary: dictionary)
+      case .none:
+        return nil
+      }
+    }
   }
 }

--- a/Sources/Private/Model/Layers/PreCompLayerModel.swift
+++ b/Sources/Private/Model/Layers/PreCompLayerModel.swift
@@ -22,14 +22,14 @@ final class PreCompLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    referenceID = try dictionary.valueFor(key: CodingKeys.referenceID.rawValue)
+    referenceID = try dictionary.value(for: CodingKeys.referenceID.rawValue)
     if let timeRemappingDictionary = dictionary[CodingKeys.timeRemapping.rawValue] as? [String: Any] {
       timeRemapping = try KeyframeGroup<Vector1D>(dictionary: timeRemappingDictionary)
     } else {
       timeRemapping = nil
     }
-    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
-    height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    width = try dictionary.value(for: CodingKeys.width.rawValue)
+    height = try dictionary.value(for: CodingKeys.height.rawValue)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/Layers/PreCompLayerModel.swift
+++ b/Sources/Private/Model/Layers/PreCompLayerModel.swift
@@ -21,6 +21,18 @@ final class PreCompLayerModel: LayerModel {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    referenceID = try dictionary.valueFor(key: CodingKeys.referenceID.rawValue)
+    if let timeRemappingDictionary = dictionary[CodingKeys.timeRemapping.rawValue] as? [String: Any] {
+      timeRemapping = try KeyframeGroup<Vector1D>(dictionary: timeRemappingDictionary)
+    } else {
+      timeRemapping = nil
+    }
+    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The reference ID of the precomp.

--- a/Sources/Private/Model/Layers/PreCompLayerModel.swift
+++ b/Sources/Private/Model/Layers/PreCompLayerModel.swift
@@ -22,14 +22,14 @@ final class PreCompLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    referenceID = try dictionary.value(for: CodingKeys.referenceID.rawValue)
+    referenceID = try dictionary.value(for: CodingKeys.referenceID)
     if let timeRemappingDictionary = dictionary[CodingKeys.timeRemapping.rawValue] as? [String: Any] {
       timeRemapping = try KeyframeGroup<Vector1D>(dictionary: timeRemappingDictionary)
     } else {
       timeRemapping = nil
     }
-    width = try dictionary.value(for: CodingKeys.width.rawValue)
-    height = try dictionary.value(for: CodingKeys.height.rawValue)
+    width = try dictionary.value(for: CodingKeys.width)
+    height = try dictionary.value(for: CodingKeys.height)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/Layers/ShapeLayerModel.swift
+++ b/Sources/Private/Model/Layers/ShapeLayerModel.swift
@@ -19,7 +19,7 @@ final class ShapeLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let itemDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.items.rawValue)
+    let itemDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.items)
     items = try [ShapeItem].fromDictionaries(itemDictionaries)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/Layers/ShapeLayerModel.swift
+++ b/Sources/Private/Model/Layers/ShapeLayerModel.swift
@@ -19,7 +19,7 @@ final class ShapeLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let itemDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.items.rawValue)
+    let itemDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.items.rawValue)
     items = try [ShapeItem].fromDictionaries(itemDictionaries)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/Layers/ShapeLayerModel.swift
+++ b/Sources/Private/Model/Layers/ShapeLayerModel.swift
@@ -18,6 +18,12 @@ final class ShapeLayerModel: LayerModel {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let itemDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.items.rawValue)
+    items = try [ShapeItem].fromDictionaries(itemDictionaries)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// A list of shape items.

--- a/Sources/Private/Model/Layers/SolidLayerModel.swift
+++ b/Sources/Private/Model/Layers/SolidLayerModel.swift
@@ -20,6 +20,13 @@ final class SolidLayerModel: LayerModel {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    colorHex = try dictionary.valueFor(key: CodingKeys.colorHex.rawValue)
+    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The color of the solid in Hex // Change to value provider.

--- a/Sources/Private/Model/Layers/SolidLayerModel.swift
+++ b/Sources/Private/Model/Layers/SolidLayerModel.swift
@@ -21,9 +21,9 @@ final class SolidLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    colorHex = try dictionary.valueFor(key: CodingKeys.colorHex.rawValue)
-    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
-    height = try dictionary.valueFor(key: CodingKeys.height.rawValue)
+    colorHex = try dictionary.value(for: CodingKeys.colorHex.rawValue)
+    width = try dictionary.value(for: CodingKeys.width.rawValue)
+    height = try dictionary.value(for: CodingKeys.height.rawValue)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/Layers/SolidLayerModel.swift
+++ b/Sources/Private/Model/Layers/SolidLayerModel.swift
@@ -21,9 +21,9 @@ final class SolidLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    colorHex = try dictionary.value(for: CodingKeys.colorHex.rawValue)
-    width = try dictionary.value(for: CodingKeys.width.rawValue)
-    height = try dictionary.value(for: CodingKeys.height.rawValue)
+    colorHex = try dictionary.value(for: CodingKeys.colorHex)
+    width = try dictionary.value(for: CodingKeys.width)
+    height = try dictionary.value(for: CodingKeys.height)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/Layers/TextLayerModel.swift
+++ b/Sources/Private/Model/Layers/TextLayerModel.swift
@@ -20,6 +20,15 @@ final class TextLayerModel: LayerModel {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let containerDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.textGroup.rawValue)
+    let textDictionary: [String: Any] = try containerDictionary.valueFor(key: TextCodingKeys.text.rawValue)
+    text = try KeyframeGroup<TextDocument>(dictionary: textDictionary)
+    let animatorDictionaries: [[String: Any]] = try containerDictionary.valueFor(key: TextCodingKeys.animators.rawValue)
+    animators = try animatorDictionaries.map({ try TextAnimator(dictionary: $0) })
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The text for the layer

--- a/Sources/Private/Model/Layers/TextLayerModel.swift
+++ b/Sources/Private/Model/Layers/TextLayerModel.swift
@@ -21,10 +21,10 @@ final class TextLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let containerDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.textGroup.rawValue)
-    let textDictionary: [String: Any] = try containerDictionary.valueFor(key: TextCodingKeys.text.rawValue)
+    let containerDictionary: [String: Any] = try dictionary.value(for: CodingKeys.textGroup.rawValue)
+    let textDictionary: [String: Any] = try containerDictionary.value(for: TextCodingKeys.text.rawValue)
     text = try KeyframeGroup<TextDocument>(dictionary: textDictionary)
-    let animatorDictionaries: [[String: Any]] = try containerDictionary.valueFor(key: TextCodingKeys.animators.rawValue)
+    let animatorDictionaries: [[String: Any]] = try containerDictionary.value(for: TextCodingKeys.animators.rawValue)
     animators = try animatorDictionaries.map({ try TextAnimator(dictionary: $0) })
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/Layers/TextLayerModel.swift
+++ b/Sources/Private/Model/Layers/TextLayerModel.swift
@@ -21,10 +21,10 @@ final class TextLayerModel: LayerModel {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let containerDictionary: [String: Any] = try dictionary.value(for: CodingKeys.textGroup.rawValue)
-    let textDictionary: [String: Any] = try containerDictionary.value(for: TextCodingKeys.text.rawValue)
+    let containerDictionary: [String: Any] = try dictionary.value(for: CodingKeys.textGroup)
+    let textDictionary: [String: Any] = try containerDictionary.value(for: TextCodingKeys.text)
     text = try KeyframeGroup<TextDocument>(dictionary: textDictionary)
-    let animatorDictionaries: [[String: Any]] = try containerDictionary.value(for: TextCodingKeys.animators.rawValue)
+    let animatorDictionaries: [[String: Any]] = try containerDictionary.value(for: TextCodingKeys.animators)
     animators = try animatorDictionaries.map({ try TextAnimator(dictionary: $0) })
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/Objects/DashPattern.swift
+++ b/Sources/Private/Model/Objects/DashPattern.swift
@@ -17,7 +17,21 @@ enum DashElementType: String, Codable {
 
 // MARK: - DashElement
 
-final class DashElement: Codable {
+final class DashElement: Codable, DictionaryInitializable {
+
+  // MARK: Lifecycle
+
+  init(dictionary: [String: Any]) throws {
+    let typeRawValue: String = try dictionary.valueFor(key: CodingKeys.type.rawValue)
+    guard let type = DashElementType(rawValue: typeRawValue) else {
+      throw InitializableError.invalidInput
+    }
+    self.type = type
+    let valueDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.value.rawValue)
+    value = try KeyframeGroup<Vector1D>(dictionary: valueDictionary)
+  }
+
+  // MARK: Internal
 
   enum CodingKeys: String, CodingKey {
     case type = "n"
@@ -26,4 +40,5 @@ final class DashElement: Codable {
 
   let type: DashElementType
   let value: KeyframeGroup<Vector1D>
+
 }

--- a/Sources/Private/Model/Objects/DashPattern.swift
+++ b/Sources/Private/Model/Objects/DashPattern.swift
@@ -22,12 +22,12 @@ final class DashElement: Codable, DictionaryInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    let typeRawValue: String = try dictionary.value(for: CodingKeys.type.rawValue)
+    let typeRawValue: String = try dictionary.value(for: CodingKeys.type)
     guard let type = DashElementType(rawValue: typeRawValue) else {
       throw InitializableError.invalidInput
     }
     self.type = type
-    let valueDictionary: [String: Any] = try dictionary.value(for: CodingKeys.value.rawValue)
+    let valueDictionary: [String: Any] = try dictionary.value(for: CodingKeys.value)
     value = try KeyframeGroup<Vector1D>(dictionary: valueDictionary)
   }
 

--- a/Sources/Private/Model/Objects/DashPattern.swift
+++ b/Sources/Private/Model/Objects/DashPattern.swift
@@ -22,12 +22,12 @@ final class DashElement: Codable, DictionaryInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    let typeRawValue: String = try dictionary.valueFor(key: CodingKeys.type.rawValue)
+    let typeRawValue: String = try dictionary.value(for: CodingKeys.type.rawValue)
     guard let type = DashElementType(rawValue: typeRawValue) else {
       throw InitializableError.invalidInput
     }
     self.type = type
-    let valueDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.value.rawValue)
+    let valueDictionary: [String: Any] = try dictionary.value(for: CodingKeys.value.rawValue)
     value = try KeyframeGroup<Vector1D>(dictionary: valueDictionary)
   }
 

--- a/Sources/Private/Model/Objects/Marker.swift
+++ b/Sources/Private/Model/Objects/Marker.swift
@@ -13,8 +13,8 @@ final class Marker: Codable, DictionaryInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    name = try dictionary.valueFor(key: CodingKeys.name.rawValue)
-    frameTime = try dictionary.valueFor(key: CodingKeys.frameTime.rawValue)
+    name = try dictionary.value(for: CodingKeys.name.rawValue)
+    frameTime = try dictionary.value(for: CodingKeys.frameTime.rawValue)
   }
 
   // MARK: Internal

--- a/Sources/Private/Model/Objects/Marker.swift
+++ b/Sources/Private/Model/Objects/Marker.swift
@@ -8,7 +8,16 @@
 import Foundation
 
 /// A time marker
-final class Marker: Codable {
+final class Marker: Codable, DictionaryInitializable {
+
+  // MARK: Lifecycle
+
+  init(dictionary: [String: Any]) throws {
+    name = try dictionary.valueFor(key: CodingKeys.name.rawValue)
+    frameTime = try dictionary.valueFor(key: CodingKeys.frameTime.rawValue)
+  }
+
+  // MARK: Internal
 
   enum CodingKeys: String, CodingKey {
     case name = "cm"
@@ -20,4 +29,5 @@ final class Marker: Codable {
 
   /// The Frame time of the marker
   let frameTime: AnimationFrameTime
+
 }

--- a/Sources/Private/Model/Objects/Marker.swift
+++ b/Sources/Private/Model/Objects/Marker.swift
@@ -13,8 +13,8 @@ final class Marker: Codable, DictionaryInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    name = try dictionary.value(for: CodingKeys.name.rawValue)
-    frameTime = try dictionary.value(for: CodingKeys.frameTime.rawValue)
+    name = try dictionary.value(for: CodingKeys.name)
+    frameTime = try dictionary.value(for: CodingKeys.frameTime)
   }
 
   // MARK: Internal

--- a/Sources/Private/Model/Objects/Mask.swift
+++ b/Sources/Private/Model/Objects/Mask.swift
@@ -48,9 +48,9 @@ final class Mask: Codable, DictionaryInitializable {
     } else {
       opacity = KeyframeGroup(Vector1D(100))
     }
-    let shapeDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.shape.rawValue)
+    let shapeDictionary: [String: Any] = try dictionary.value(for: CodingKeys.shape.rawValue)
     shape = try KeyframeGroup<BezierPath>(dictionary: shapeDictionary)
-    inverted = (try? dictionary.valueFor(key: CodingKeys.inverted.rawValue)) ?? false
+    inverted = (try? dictionary.value(for: CodingKeys.inverted.rawValue)) ?? false
     if let expansionDictionary = dictionary[CodingKeys.expansion.rawValue] as? [String: Any] {
       expansion = try KeyframeGroup<Vector1D>(dictionary: expansionDictionary)
     } else {

--- a/Sources/Private/Model/Objects/Mask.swift
+++ b/Sources/Private/Model/Objects/Mask.swift
@@ -48,9 +48,9 @@ final class Mask: Codable, DictionaryInitializable {
     } else {
       opacity = KeyframeGroup(Vector1D(100))
     }
-    let shapeDictionary: [String: Any] = try dictionary.value(for: CodingKeys.shape.rawValue)
+    let shapeDictionary: [String: Any] = try dictionary.value(for: CodingKeys.shape)
     shape = try KeyframeGroup<BezierPath>(dictionary: shapeDictionary)
-    inverted = (try? dictionary.value(for: CodingKeys.inverted.rawValue)) ?? false
+    inverted = (try? dictionary.value(for: CodingKeys.inverted)) ?? false
     if let expansionDictionary = dictionary[CodingKeys.expansion.rawValue] as? [String: Any] {
       expansion = try KeyframeGroup<Vector1D>(dictionary: expansionDictionary)
     } else {

--- a/Sources/Private/Model/Objects/Mask.swift
+++ b/Sources/Private/Model/Objects/Mask.swift
@@ -21,7 +21,7 @@ enum MaskMode: String, Codable {
 
 // MARK: - Mask
 
-final class Mask: Codable {
+final class Mask: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle
 
@@ -32,6 +32,30 @@ final class Mask: Codable {
     shape = try container.decode(KeyframeGroup<BezierPath>.self, forKey: .shape)
     inverted = try container.decodeIfPresent(Bool.self, forKey: .inverted) ?? false
     expansion = try container.decodeIfPresent(KeyframeGroup<Vector1D>.self, forKey: .expansion) ?? KeyframeGroup(Vector1D(0))
+  }
+
+  init(dictionary: [String: Any]) throws {
+    if
+      let modeRawType = dictionary[CodingKeys.mode.rawValue] as? String,
+      let mode = MaskMode(rawValue: modeRawType)
+    {
+      self.mode = mode
+    } else {
+      mode = .add
+    }
+    if let opacityDictionary = dictionary[CodingKeys.opacity.rawValue] as? [String: Any] {
+      opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    } else {
+      opacity = KeyframeGroup(Vector1D(100))
+    }
+    let shapeDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.shape.rawValue)
+    shape = try KeyframeGroup<BezierPath>(dictionary: shapeDictionary)
+    inverted = (try? dictionary.valueFor(key: CodingKeys.inverted.rawValue)) ?? false
+    if let expansionDictionary = dictionary[CodingKeys.expansion.rawValue] as? [String: Any] {
+      expansion = try KeyframeGroup<Vector1D>(dictionary: expansionDictionary)
+    } else {
+      expansion = KeyframeGroup(Vector1D(0))
+    }
   }
 
   // MARK: Internal

--- a/Sources/Private/Model/Objects/Transform.swift
+++ b/Sources/Private/Model/Objects/Transform.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The animatable transform for a layer. Controls position, rotation, scale, and opacity.
-final class Transform: Codable {
+final class Transform: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle
 
@@ -62,6 +62,76 @@ final class Transform: Codable {
 
     // Opacity
     opacity = try container.decodeIfPresent(KeyframeGroup<Vector1D>.self, forKey: .opacity) ?? KeyframeGroup(Vector1D(100))
+  }
+
+  init(dictionary: [String: Any]) throws {
+    if
+      let anchorPointDictionary = dictionary[CodingKeys.anchorPoint.rawValue] as? [String: Any],
+      let anchorPoint = try? KeyframeGroup<Vector3D>(dictionary: anchorPointDictionary)
+    {
+      self.anchorPoint = anchorPoint
+    } else {
+      anchorPoint = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+
+    if
+      let xDictionary = dictionary[CodingKeys.positionX.rawValue] as? [String: Any],
+      let yDictionary = dictionary[CodingKeys.positionY.rawValue] as? [String: Any]
+    {
+      positionX = try KeyframeGroup<Vector1D>(dictionary: xDictionary)
+      positionY = try KeyframeGroup<Vector1D>(dictionary: yDictionary)
+      position = nil
+    } else if
+      let positionDictionary = dictionary[CodingKeys.position.rawValue] as? [String: Any],
+      positionDictionary[KeyframeGroup<Vector3D>.KeyframeWrapperKey.keyframeData.rawValue] != nil
+    {
+      position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+      positionX = nil
+      positionY = nil
+    } else if
+      let positionDictionary = dictionary[CodingKeys.position.rawValue] as? [String: Any],
+      let xDictionary = positionDictionary[PositionCodingKeys.positionX.rawValue] as? [String: Any],
+      let yDictionary = positionDictionary[PositionCodingKeys.positionY.rawValue] as? [String: Any]
+    {
+      positionX = try KeyframeGroup<Vector1D>(dictionary: xDictionary)
+      positionY = try KeyframeGroup<Vector1D>(dictionary: yDictionary)
+      position = nil
+    } else {
+      position = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+      positionX = nil
+      positionY = nil
+    }
+
+    if
+      let scaleDictionary = dictionary[CodingKeys.scale.rawValue] as? [String: Any],
+      let scale = try? KeyframeGroup<Vector3D>(dictionary: scaleDictionary)
+    {
+      self.scale = scale
+    } else {
+      scale = KeyframeGroup(Vector3D(x: Double(100), y: 100, z: 100))
+    }
+    if
+      let rotationDictionary = dictionary[CodingKeys.rotationZ.rawValue] as? [String: Any],
+      let rotation = try? KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
+    {
+      self.rotation = rotation
+    } else if
+      let rotationDictionary = dictionary[CodingKeys.rotation.rawValue] as? [String: Any],
+      let rotation = try? KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
+    {
+      self.rotation = rotation
+    } else {
+      rotation = KeyframeGroup(Vector1D(0))
+    }
+    rotationZ = nil
+    if
+      let opacityDictionary = dictionary[CodingKeys.opacity.rawValue] as? [String: Any],
+      let opacity = try? KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    {
+      self.opacity = opacity
+    } else {
+      opacity = KeyframeGroup(Vector1D(100))
+    }
   }
 
   // MARK: Internal

--- a/Sources/Private/Model/ShapeItems/Ellipse.swift
+++ b/Sources/Private/Model/ShapeItems/Ellipse.swift
@@ -39,9 +39,9 @@ final class Ellipse: ShapeItem {
     } else {
       direction = .clockwise
     }
-    let positionDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.position.rawValue)
+    let positionDictionary: [String: Any] = try dictionary.value(for: CodingKeys.position.rawValue)
     position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
-    let sizeDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.size.rawValue)
+    let sizeDictionary: [String: Any] = try dictionary.value(for: CodingKeys.size.rawValue)
     size = try KeyframeGroup<Vector3D>(dictionary: sizeDictionary)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/ShapeItems/Ellipse.swift
+++ b/Sources/Private/Model/ShapeItems/Ellipse.swift
@@ -30,6 +30,22 @@ final class Ellipse: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    if
+      let directionRawType = dictionary[CodingKeys.direction.rawValue] as? Int,
+      let direction = PathDirection(rawValue: directionRawType)
+    {
+      self.direction = direction
+    } else {
+      direction = .clockwise
+    }
+    let positionDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.position.rawValue)
+    position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    let sizeDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.size.rawValue)
+    size = try KeyframeGroup<Vector3D>(dictionary: sizeDictionary)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The direction of the ellipse.

--- a/Sources/Private/Model/ShapeItems/Ellipse.swift
+++ b/Sources/Private/Model/ShapeItems/Ellipse.swift
@@ -39,9 +39,9 @@ final class Ellipse: ShapeItem {
     } else {
       direction = .clockwise
     }
-    let positionDictionary: [String: Any] = try dictionary.value(for: CodingKeys.position.rawValue)
+    let positionDictionary: [String: Any] = try dictionary.value(for: CodingKeys.position)
     position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
-    let sizeDictionary: [String: Any] = try dictionary.value(for: CodingKeys.size.rawValue)
+    let sizeDictionary: [String: Any] = try dictionary.value(for: CodingKeys.size)
     size = try KeyframeGroup<Vector3D>(dictionary: sizeDictionary)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/ShapeItems/Fill.swift
+++ b/Sources/Private/Model/ShapeItems/Fill.swift
@@ -31,9 +31,9 @@ final class Fill: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity.rawValue)
+    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity)
     opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
-    let colorDictionary: [String: Any] = try dictionary.value(for: CodingKeys.color.rawValue)
+    let colorDictionary: [String: Any] = try dictionary.value(for: CodingKeys.color)
     color = try KeyframeGroup<Color>(dictionary: colorDictionary)
     if
       let fillRuleRawValue = dictionary[CodingKeys.fillRule.rawValue] as? Int,

--- a/Sources/Private/Model/ShapeItems/Fill.swift
+++ b/Sources/Private/Model/ShapeItems/Fill.swift
@@ -31,9 +31,9 @@ final class Fill: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity.rawValue)
     opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
-    let colorDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.color.rawValue)
+    let colorDictionary: [String: Any] = try dictionary.value(for: CodingKeys.color.rawValue)
     color = try KeyframeGroup<Color>(dictionary: colorDictionary)
     if
       let fillRuleRawValue = dictionary[CodingKeys.fillRule.rawValue] as? Int,

--- a/Sources/Private/Model/ShapeItems/Fill.swift
+++ b/Sources/Private/Model/ShapeItems/Fill.swift
@@ -30,6 +30,22 @@ final class Fill: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    let colorDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.color.rawValue)
+    color = try KeyframeGroup<Color>(dictionary: colorDictionary)
+    if
+      let fillRuleRawValue = dictionary[CodingKeys.fillRule.rawValue] as? Int,
+      let fillRule = FillRule(rawValue: fillRuleRawValue)
+    {
+      self.fillRule = fillRule
+    } else {
+      fillRule = .nonZeroWinding
+    }
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The opacity of the fill

--- a/Sources/Private/Model/ShapeItems/GradientFill.swift
+++ b/Sources/Private/Model/ShapeItems/GradientFill.swift
@@ -36,6 +36,35 @@ final class GradientFill: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    let startPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.startPoint.rawValue)
+    startPoint = try KeyframeGroup<Vector3D>(dictionary: startPointDictionary)
+    let endPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.endPoint.rawValue)
+    endPoint = try KeyframeGroup<Vector3D>(dictionary: endPointDictionary)
+    let gradientRawType: Int = try dictionary.valueFor(key: CodingKeys.gradientType.rawValue)
+    guard let gradient = GradientType(rawValue: gradientRawType) else {
+      throw InitializableError.invalidInput
+    }
+    gradientType = gradient
+    if let highlightLengthDictionary = dictionary[CodingKeys.highlightLength.rawValue] as? [String: Any] {
+      highlightLength = try? KeyframeGroup<Vector1D>(dictionary: highlightLengthDictionary)
+    } else {
+      highlightLength = nil
+    }
+    if let highlightAngleDictionary = dictionary[CodingKeys.highlightAngle.rawValue] as? [String: Any] {
+      highlightAngle = try? KeyframeGroup<Vector1D>(dictionary: highlightAngleDictionary)
+    } else {
+      highlightAngle = nil
+    }
+    let colorsDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.colors.rawValue)
+    let nestedColorsDictionary: [String: Any] = try colorsDictionary.valueFor(key: GradientDataKeys.colors.rawValue)
+    colors = try KeyframeGroup<[Double]>(dictionary: nestedColorsDictionary)
+    numberOfColors = try colorsDictionary.valueFor(key: GradientDataKeys.numberOfColors.rawValue)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The opacity of the fill

--- a/Sources/Private/Model/ShapeItems/GradientFill.swift
+++ b/Sources/Private/Model/ShapeItems/GradientFill.swift
@@ -37,13 +37,13 @@ final class GradientFill: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity.rawValue)
+    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity)
     opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
-    let startPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.startPoint.rawValue)
+    let startPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.startPoint)
     startPoint = try KeyframeGroup<Vector3D>(dictionary: startPointDictionary)
-    let endPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.endPoint.rawValue)
+    let endPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.endPoint)
     endPoint = try KeyframeGroup<Vector3D>(dictionary: endPointDictionary)
-    let gradientRawType: Int = try dictionary.value(for: CodingKeys.gradientType.rawValue)
+    let gradientRawType: Int = try dictionary.value(for: CodingKeys.gradientType)
     guard let gradient = GradientType(rawValue: gradientRawType) else {
       throw InitializableError.invalidInput
     }
@@ -58,10 +58,10 @@ final class GradientFill: ShapeItem {
     } else {
       highlightAngle = nil
     }
-    let colorsDictionary: [String: Any] = try dictionary.value(for: CodingKeys.colors.rawValue)
-    let nestedColorsDictionary: [String: Any] = try colorsDictionary.value(for: GradientDataKeys.colors.rawValue)
+    let colorsDictionary: [String: Any] = try dictionary.value(for: CodingKeys.colors)
+    let nestedColorsDictionary: [String: Any] = try colorsDictionary.value(for: GradientDataKeys.colors)
     colors = try KeyframeGroup<[Double]>(dictionary: nestedColorsDictionary)
-    numberOfColors = try colorsDictionary.value(for: GradientDataKeys.numberOfColors.rawValue)
+    numberOfColors = try colorsDictionary.value(for: GradientDataKeys.numberOfColors)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/ShapeItems/GradientFill.swift
+++ b/Sources/Private/Model/ShapeItems/GradientFill.swift
@@ -37,13 +37,13 @@ final class GradientFill: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity.rawValue)
     opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
-    let startPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.startPoint.rawValue)
+    let startPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.startPoint.rawValue)
     startPoint = try KeyframeGroup<Vector3D>(dictionary: startPointDictionary)
-    let endPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.endPoint.rawValue)
+    let endPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.endPoint.rawValue)
     endPoint = try KeyframeGroup<Vector3D>(dictionary: endPointDictionary)
-    let gradientRawType: Int = try dictionary.valueFor(key: CodingKeys.gradientType.rawValue)
+    let gradientRawType: Int = try dictionary.value(for: CodingKeys.gradientType.rawValue)
     guard let gradient = GradientType(rawValue: gradientRawType) else {
       throw InitializableError.invalidInput
     }
@@ -58,10 +58,10 @@ final class GradientFill: ShapeItem {
     } else {
       highlightAngle = nil
     }
-    let colorsDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.colors.rawValue)
-    let nestedColorsDictionary: [String: Any] = try colorsDictionary.valueFor(key: GradientDataKeys.colors.rawValue)
+    let colorsDictionary: [String: Any] = try dictionary.value(for: CodingKeys.colors.rawValue)
+    let nestedColorsDictionary: [String: Any] = try colorsDictionary.value(for: GradientDataKeys.colors.rawValue)
     colors = try KeyframeGroup<[Double]>(dictionary: nestedColorsDictionary)
-    numberOfColors = try colorsDictionary.valueFor(key: GradientDataKeys.numberOfColors.rawValue)
+    numberOfColors = try colorsDictionary.value(for: GradientDataKeys.numberOfColors.rawValue)
     try super.init(dictionary: dictionary)
   }
 

--- a/Sources/Private/Model/ShapeItems/GradientStroke.swift
+++ b/Sources/Private/Model/ShapeItems/GradientStroke.swift
@@ -53,13 +53,13 @@ final class GradientStroke: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity.rawValue)
     opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
-    let startPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.startPoint.rawValue)
+    let startPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.startPoint.rawValue)
     startPoint = try KeyframeGroup<Vector3D>(dictionary: startPointDictionary)
-    let endPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.endPoint.rawValue)
+    let endPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.endPoint.rawValue)
     endPoint = try KeyframeGroup<Vector3D>(dictionary: endPointDictionary)
-    let gradientRawType: Int = try dictionary.valueFor(key: CodingKeys.gradientType.rawValue)
+    let gradientRawType: Int = try dictionary.value(for: CodingKeys.gradientType.rawValue)
     guard let gradient = GradientType(rawValue: gradientRawType) else {
       throw InitializableError.invalidInput
     }
@@ -74,7 +74,7 @@ final class GradientStroke: ShapeItem {
     } else {
       highlightAngle = nil
     }
-    let widthDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    let widthDictionary: [String: Any] = try dictionary.value(for: CodingKeys.width.rawValue)
     width = try KeyframeGroup<Vector1D>(dictionary: widthDictionary)
     if
       let lineCapRawValue = dictionary[CodingKeys.lineCap.rawValue] as? Int,
@@ -92,11 +92,11 @@ final class GradientStroke: ShapeItem {
     } else {
       lineJoin = .round
     }
-    miterLimit = (try? dictionary.valueFor(key: CodingKeys.miterLimit.rawValue)) ?? 4
-    let colorsDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.colors.rawValue)
-    let nestedColorsDictionary: [String: Any] = try colorsDictionary.valueFor(key: GradientDataKeys.colors.rawValue)
+    miterLimit = (try? dictionary.value(for: CodingKeys.miterLimit.rawValue)) ?? 4
+    let colorsDictionary: [String: Any] = try dictionary.value(for: CodingKeys.colors.rawValue)
+    let nestedColorsDictionary: [String: Any] = try colorsDictionary.value(for: GradientDataKeys.colors.rawValue)
     colors = try KeyframeGroup<[Double]>(dictionary: nestedColorsDictionary)
-    numberOfColors = try colorsDictionary.valueFor(key: GradientDataKeys.numberOfColors.rawValue)
+    numberOfColors = try colorsDictionary.value(for: GradientDataKeys.numberOfColors.rawValue)
     let dashPatternDictionaries = dictionary[CodingKeys.dashPattern.rawValue] as? [[String: Any]]
     dashPattern = try? dashPatternDictionaries?.map({ try DashElement(dictionary: $0) })
     try super.init(dictionary: dictionary)

--- a/Sources/Private/Model/ShapeItems/GradientStroke.swift
+++ b/Sources/Private/Model/ShapeItems/GradientStroke.swift
@@ -52,6 +52,56 @@ final class GradientStroke: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    let startPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.startPoint.rawValue)
+    startPoint = try KeyframeGroup<Vector3D>(dictionary: startPointDictionary)
+    let endPointDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.endPoint.rawValue)
+    endPoint = try KeyframeGroup<Vector3D>(dictionary: endPointDictionary)
+    let gradientRawType: Int = try dictionary.valueFor(key: CodingKeys.gradientType.rawValue)
+    guard let gradient = GradientType(rawValue: gradientRawType) else {
+      throw InitializableError.invalidInput
+    }
+    gradientType = gradient
+    if let highlightLengthDictionary = dictionary[CodingKeys.highlightLength.rawValue] as? [String: Any] {
+      highlightLength = try? KeyframeGroup<Vector1D>(dictionary: highlightLengthDictionary)
+    } else {
+      highlightLength = nil
+    }
+    if let highlightAngleDictionary = dictionary[CodingKeys.highlightAngle.rawValue] as? [String: Any] {
+      highlightAngle = try? KeyframeGroup<Vector1D>(dictionary: highlightAngleDictionary)
+    } else {
+      highlightAngle = nil
+    }
+    let widthDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    width = try KeyframeGroup<Vector1D>(dictionary: widthDictionary)
+    if
+      let lineCapRawValue = dictionary[CodingKeys.lineCap.rawValue] as? Int,
+      let lineCap = LineCap(rawValue: lineCapRawValue)
+    {
+      self.lineCap = lineCap
+    } else {
+      lineCap = .round
+    }
+    if
+      let lineJoinRawValue = dictionary[CodingKeys.lineJoin.rawValue] as? Int,
+      let lineJoin = LineJoin(rawValue: lineJoinRawValue)
+    {
+      self.lineJoin = lineJoin
+    } else {
+      lineJoin = .round
+    }
+    miterLimit = (try? dictionary.valueFor(key: CodingKeys.miterLimit.rawValue)) ?? 4
+    let colorsDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.colors.rawValue)
+    let nestedColorsDictionary: [String: Any] = try colorsDictionary.valueFor(key: GradientDataKeys.colors.rawValue)
+    colors = try KeyframeGroup<[Double]>(dictionary: nestedColorsDictionary)
+    numberOfColors = try colorsDictionary.valueFor(key: GradientDataKeys.numberOfColors.rawValue)
+    let dashPatternDictionaries = dictionary[CodingKeys.dashPattern.rawValue] as? [[String: Any]]
+    dashPattern = try? dashPatternDictionaries?.map({ try DashElement(dictionary: $0) })
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The opacity of the fill

--- a/Sources/Private/Model/ShapeItems/GradientStroke.swift
+++ b/Sources/Private/Model/ShapeItems/GradientStroke.swift
@@ -53,13 +53,13 @@ final class GradientStroke: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity.rawValue)
+    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity)
     opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
-    let startPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.startPoint.rawValue)
+    let startPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.startPoint)
     startPoint = try KeyframeGroup<Vector3D>(dictionary: startPointDictionary)
-    let endPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.endPoint.rawValue)
+    let endPointDictionary: [String: Any] = try dictionary.value(for: CodingKeys.endPoint)
     endPoint = try KeyframeGroup<Vector3D>(dictionary: endPointDictionary)
-    let gradientRawType: Int = try dictionary.value(for: CodingKeys.gradientType.rawValue)
+    let gradientRawType: Int = try dictionary.value(for: CodingKeys.gradientType)
     guard let gradient = GradientType(rawValue: gradientRawType) else {
       throw InitializableError.invalidInput
     }
@@ -74,7 +74,7 @@ final class GradientStroke: ShapeItem {
     } else {
       highlightAngle = nil
     }
-    let widthDictionary: [String: Any] = try dictionary.value(for: CodingKeys.width.rawValue)
+    let widthDictionary: [String: Any] = try dictionary.value(for: CodingKeys.width)
     width = try KeyframeGroup<Vector1D>(dictionary: widthDictionary)
     if
       let lineCapRawValue = dictionary[CodingKeys.lineCap.rawValue] as? Int,
@@ -92,11 +92,11 @@ final class GradientStroke: ShapeItem {
     } else {
       lineJoin = .round
     }
-    miterLimit = (try? dictionary.value(for: CodingKeys.miterLimit.rawValue)) ?? 4
-    let colorsDictionary: [String: Any] = try dictionary.value(for: CodingKeys.colors.rawValue)
-    let nestedColorsDictionary: [String: Any] = try colorsDictionary.value(for: GradientDataKeys.colors.rawValue)
+    miterLimit = (try? dictionary.value(for: CodingKeys.miterLimit)) ?? 4
+    let colorsDictionary: [String: Any] = try dictionary.value(for: CodingKeys.colors)
+    let nestedColorsDictionary: [String: Any] = try colorsDictionary.value(for: GradientDataKeys.colors)
     colors = try KeyframeGroup<[Double]>(dictionary: nestedColorsDictionary)
-    numberOfColors = try colorsDictionary.value(for: GradientDataKeys.numberOfColors.rawValue)
+    numberOfColors = try colorsDictionary.value(for: GradientDataKeys.numberOfColors)
     let dashPatternDictionaries = dictionary[CodingKeys.dashPattern.rawValue] as? [[String: Any]]
     dashPattern = try? dashPatternDictionaries?.map({ try DashElement(dictionary: $0) })
     try super.init(dictionary: dictionary)

--- a/Sources/Private/Model/ShapeItems/Group.swift
+++ b/Sources/Private/Model/ShapeItems/Group.swift
@@ -19,7 +19,7 @@ final class Group: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let itemDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.items.rawValue)
+    let itemDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.items)
     items = try [ShapeItem].fromDictionaries(itemDictionaries)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/ShapeItems/Group.swift
+++ b/Sources/Private/Model/ShapeItems/Group.swift
@@ -19,7 +19,7 @@ final class Group: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let itemDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.items.rawValue)
+    let itemDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.items.rawValue)
     items = try [ShapeItem].fromDictionaries(itemDictionaries)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/ShapeItems/Group.swift
+++ b/Sources/Private/Model/ShapeItems/Group.swift
@@ -18,6 +18,12 @@ final class Group: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let itemDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.items.rawValue)
+    items = try [ShapeItem].fromDictionaries(itemDictionaries)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// A list of shape items.

--- a/Sources/Private/Model/ShapeItems/Merge.swift
+++ b/Sources/Private/Model/ShapeItems/Merge.swift
@@ -32,7 +32,7 @@ final class Merge: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let modeRawType: Int = try dictionary.valueFor(key: CodingKeys.mode.rawValue)
+    let modeRawType: Int = try dictionary.value(for: CodingKeys.mode.rawValue)
     guard let mode = MergeMode(rawValue: modeRawType) else {
       throw InitializableError.invalidInput
     }

--- a/Sources/Private/Model/ShapeItems/Merge.swift
+++ b/Sources/Private/Model/ShapeItems/Merge.swift
@@ -32,7 +32,7 @@ final class Merge: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let modeRawType: Int = try dictionary.value(for: CodingKeys.mode.rawValue)
+    let modeRawType: Int = try dictionary.value(for: CodingKeys.mode)
     guard let mode = MergeMode(rawValue: modeRawType) else {
       throw InitializableError.invalidInput
     }

--- a/Sources/Private/Model/ShapeItems/Merge.swift
+++ b/Sources/Private/Model/ShapeItems/Merge.swift
@@ -31,6 +31,15 @@ final class Merge: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let modeRawType: Int = try dictionary.valueFor(key: CodingKeys.mode.rawValue)
+    guard let mode = MergeMode(rawValue: modeRawType) else {
+      throw InitializableError.invalidInput
+    }
+    self.mode = mode
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The mode of the merge path

--- a/Sources/Private/Model/ShapeItems/Rectangle.swift
+++ b/Sources/Private/Model/ShapeItems/Rectangle.swift
@@ -30,11 +30,11 @@ final class Rectangle: ShapeItem {
     } else {
       direction = .clockwise
     }
-    let positionDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.position.rawValue)
+    let positionDictionary: [String: Any] = try dictionary.value(for: CodingKeys.position.rawValue)
     position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
-    let sizeDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.size.rawValue)
+    let sizeDictionary: [String: Any] = try dictionary.value(for: CodingKeys.size.rawValue)
     size = try KeyframeGroup<Vector3D>(dictionary: sizeDictionary)
-    let cornerRadiusDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.cornerRadius.rawValue)
+    let cornerRadiusDictionary: [String: Any] = try dictionary.value(for: CodingKeys.cornerRadius.rawValue)
     cornerRadius = try KeyframeGroup<Vector1D>(dictionary: cornerRadiusDictionary)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/ShapeItems/Rectangle.swift
+++ b/Sources/Private/Model/ShapeItems/Rectangle.swift
@@ -30,11 +30,11 @@ final class Rectangle: ShapeItem {
     } else {
       direction = .clockwise
     }
-    let positionDictionary: [String: Any] = try dictionary.value(for: CodingKeys.position.rawValue)
+    let positionDictionary: [String: Any] = try dictionary.value(for: CodingKeys.position)
     position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
-    let sizeDictionary: [String: Any] = try dictionary.value(for: CodingKeys.size.rawValue)
+    let sizeDictionary: [String: Any] = try dictionary.value(for: CodingKeys.size)
     size = try KeyframeGroup<Vector3D>(dictionary: sizeDictionary)
-    let cornerRadiusDictionary: [String: Any] = try dictionary.value(for: CodingKeys.cornerRadius.rawValue)
+    let cornerRadiusDictionary: [String: Any] = try dictionary.value(for: CodingKeys.cornerRadius)
     cornerRadius = try KeyframeGroup<Vector1D>(dictionary: cornerRadiusDictionary)
     try super.init(dictionary: dictionary)
   }

--- a/Sources/Private/Model/ShapeItems/Rectangle.swift
+++ b/Sources/Private/Model/ShapeItems/Rectangle.swift
@@ -21,6 +21,24 @@ final class Rectangle: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    if
+      let directionRawType = dictionary[CodingKeys.direction.rawValue] as? Int,
+      let direction = PathDirection(rawValue: directionRawType)
+    {
+      self.direction = direction
+    } else {
+      direction = .clockwise
+    }
+    let positionDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.position.rawValue)
+    position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    let sizeDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.size.rawValue)
+    size = try KeyframeGroup<Vector3D>(dictionary: sizeDictionary)
+    let cornerRadiusDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.cornerRadius.rawValue)
+    cornerRadius = try KeyframeGroup<Vector1D>(dictionary: cornerRadiusDictionary)
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The direction of the rect.

--- a/Sources/Private/Model/ShapeItems/Repeater.swift
+++ b/Sources/Private/Model/ShapeItems/Repeater.swift
@@ -43,7 +43,7 @@ final class Repeater: ShapeItem {
     } else {
       offset = KeyframeGroup(Vector1D(0))
     }
-    let transformDictionary: [String: Any] = try dictionary.value(for: CodingKeys.transform.rawValue)
+    let transformDictionary: [String: Any] = try dictionary.value(for: CodingKeys.transform)
     if let startOpacityDictionary = transformDictionary[TransformKeys.startOpacity.rawValue] as? [String: Any] {
       startOpacity = try KeyframeGroup<Vector1D>(dictionary: startOpacityDictionary)
     } else {

--- a/Sources/Private/Model/ShapeItems/Repeater.swift
+++ b/Sources/Private/Model/ShapeItems/Repeater.swift
@@ -32,6 +32,51 @@ final class Repeater: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    if let copiesDictionary = dictionary[CodingKeys.copies.rawValue] as? [String: Any] {
+      copies = try KeyframeGroup<Vector1D>(dictionary: copiesDictionary)
+    } else {
+      copies = KeyframeGroup(Vector1D(0))
+    }
+    if let offsetDictionary = dictionary[CodingKeys.offset.rawValue] as? [String: Any] {
+      offset = try KeyframeGroup<Vector1D>(dictionary: offsetDictionary)
+    } else {
+      offset = KeyframeGroup(Vector1D(0))
+    }
+    let transformDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.transform.rawValue)
+    if let startOpacityDictionary = transformDictionary[TransformKeys.startOpacity.rawValue] as? [String: Any] {
+      startOpacity = try KeyframeGroup<Vector1D>(dictionary: startOpacityDictionary)
+    } else {
+      startOpacity = KeyframeGroup(Vector1D(100))
+    }
+    if let endOpacityDictionary = transformDictionary[TransformKeys.endOpacity.rawValue] as? [String: Any] {
+      endOpacity = try KeyframeGroup<Vector1D>(dictionary: endOpacityDictionary)
+    } else {
+      endOpacity = KeyframeGroup(Vector1D(100))
+    }
+    if let rotationDictionary = transformDictionary[TransformKeys.rotation.rawValue] as? [String: Any] {
+      rotation = try KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
+    } else {
+      rotation = KeyframeGroup(Vector1D(0))
+    }
+    if let positionDictionary = transformDictionary[TransformKeys.position.rawValue] as? [String: Any] {
+      position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    } else {
+      position = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+    if let anchorPointDictionary = transformDictionary[TransformKeys.anchorPoint.rawValue] as? [String: Any] {
+      anchorPoint = try KeyframeGroup<Vector3D>(dictionary: anchorPointDictionary)
+    } else {
+      anchorPoint = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+    if let scaleDictionary = transformDictionary[TransformKeys.scale.rawValue] as? [String: Any] {
+      scale = try KeyframeGroup<Vector3D>(dictionary: scaleDictionary)
+    } else {
+      scale = KeyframeGroup(Vector3D(x: Double(100), y: 100, z: 100))
+    }
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The number of copies to repeat

--- a/Sources/Private/Model/ShapeItems/Repeater.swift
+++ b/Sources/Private/Model/ShapeItems/Repeater.swift
@@ -43,7 +43,7 @@ final class Repeater: ShapeItem {
     } else {
       offset = KeyframeGroup(Vector1D(0))
     }
-    let transformDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.transform.rawValue)
+    let transformDictionary: [String: Any] = try dictionary.value(for: CodingKeys.transform.rawValue)
     if let startOpacityDictionary = transformDictionary[TransformKeys.startOpacity.rawValue] as? [String: Any] {
       startOpacity = try KeyframeGroup<Vector1D>(dictionary: startOpacityDictionary)
     } else {

--- a/Sources/Private/Model/ShapeItems/Shape.swift
+++ b/Sources/Private/Model/ShapeItems/Shape.swift
@@ -20,7 +20,7 @@ final class Shape: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let pathDictionary: [String: Any] = try dictionary.value(for: CodingKeys.path.rawValue)
+    let pathDictionary: [String: Any] = try dictionary.value(for: CodingKeys.path)
     path = try KeyframeGroup<BezierPath>(dictionary: pathDictionary)
     if
       let directionRawValue = dictionary[CodingKeys.direction.rawValue] as? Int,

--- a/Sources/Private/Model/ShapeItems/Shape.swift
+++ b/Sources/Private/Model/ShapeItems/Shape.swift
@@ -20,7 +20,7 @@ final class Shape: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let pathDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.path.rawValue)
+    let pathDictionary: [String: Any] = try dictionary.value(for: CodingKeys.path.rawValue)
     path = try KeyframeGroup<BezierPath>(dictionary: pathDictionary)
     if
       let directionRawValue = dictionary[CodingKeys.direction.rawValue] as? Int,

--- a/Sources/Private/Model/ShapeItems/Shape.swift
+++ b/Sources/Private/Model/ShapeItems/Shape.swift
@@ -19,6 +19,20 @@ final class Shape: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let pathDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.path.rawValue)
+    path = try KeyframeGroup<BezierPath>(dictionary: pathDictionary)
+    if
+      let directionRawValue = dictionary[CodingKeys.direction.rawValue] as? Int,
+      let direction = PathDirection(rawValue: directionRawValue)
+    {
+      self.direction = direction
+    } else {
+      direction = nil
+    }
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The Path

--- a/Sources/Private/Model/ShapeItems/ShapeItem.swift
+++ b/Sources/Private/Model/ShapeItems/ShapeItem.swift
@@ -87,9 +87,9 @@ class ShapeItem: Codable, DictionaryInitializable {
   }
 
   required init(dictionary: [String: Any]) throws {
-    name = (try? dictionary.value(for: CodingKeys.name.rawValue)) ?? "Layer"
-    type = ShapeType(rawValue: try dictionary.value(for: CodingKeys.type.rawValue)) ?? .unknown
-    hidden = (try? dictionary.value(for: CodingKeys.hidden.rawValue)) ?? false
+    name = (try? dictionary.value(for: CodingKeys.name)) ?? "Layer"
+    type = ShapeType(rawValue: try dictionary.value(for: CodingKeys.type)) ?? .unknown
+    hidden = (try? dictionary.value(for: CodingKeys.hidden)) ?? false
   }
 
   init(

--- a/Sources/Private/Model/ShapeItems/ShapeItem.swift
+++ b/Sources/Private/Model/ShapeItems/ShapeItem.swift
@@ -75,7 +75,7 @@ enum ShapeType: String, Codable {
 // MARK: - ShapeItem
 
 /// An item belonging to a Shape Layer
-class ShapeItem: Codable {
+class ShapeItem: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle
 
@@ -84,6 +84,12 @@ class ShapeItem: Codable {
     name = try container.decodeIfPresent(String.self, forKey: .name) ?? "Layer"
     type = try container.decode(ShapeType.self, forKey: .type)
     hidden = try container.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
+  }
+
+  required init(dictionary: [String: Any]) throws {
+    name = (try? dictionary.valueFor(key: CodingKeys.name.rawValue)) ?? "Layer"
+    type = ShapeType(rawValue: try dictionary.valueFor(key: CodingKeys.type.rawValue)) ?? .unknown
+    hidden = (try? dictionary.valueFor(key: CodingKeys.hidden.rawValue)) ?? false
   }
 
   init(
@@ -106,11 +112,52 @@ class ShapeItem: Codable {
 
   let hidden: Bool
 
-  // MARK: Private
+  // MARK: Fileprivate
 
-  private enum CodingKeys: String, CodingKey {
+  fileprivate enum CodingKeys: String, CodingKey {
     case name = "nm"
     case type = "ty"
     case hidden = "hd"
+  }
+}
+
+extension Array where Element == ShapeItem {
+
+  static func fromDictionaries(_ dictionaries: [[String: Any]]) throws -> [ShapeItem] {
+    try dictionaries.compactMap { dictionary in
+      let shapeType = dictionary[ShapeItem.CodingKeys.type.rawValue] as? String
+      switch ShapeType(rawValue: shapeType ?? ShapeType.unknown.rawValue) {
+      case .ellipse:
+        return try Ellipse(dictionary: dictionary)
+      case .fill:
+        return try Fill(dictionary: dictionary)
+      case .gradientFill:
+        return try GradientFill(dictionary: dictionary)
+      case .group:
+        return try Group(dictionary: dictionary)
+      case .gradientStroke:
+        return try GradientStroke(dictionary: dictionary)
+      case .merge:
+        return try Merge(dictionary: dictionary)
+      case .rectangle:
+        return try Rectangle(dictionary: dictionary)
+      case .repeater:
+        return try Repeater(dictionary: dictionary)
+      case .shape:
+        return try Shape(dictionary: dictionary)
+      case .star:
+        return try Star(dictionary: dictionary)
+      case .stroke:
+        return try Stroke(dictionary: dictionary)
+      case .trim:
+        return try Trim(dictionary: dictionary)
+      case .transform:
+        return try ShapeTransform(dictionary: dictionary)
+      case .none:
+        return nil
+      default:
+        return try ShapeItem(dictionary: dictionary)
+      }
+    }
   }
 }

--- a/Sources/Private/Model/ShapeItems/ShapeItem.swift
+++ b/Sources/Private/Model/ShapeItems/ShapeItem.swift
@@ -87,9 +87,9 @@ class ShapeItem: Codable, DictionaryInitializable {
   }
 
   required init(dictionary: [String: Any]) throws {
-    name = (try? dictionary.valueFor(key: CodingKeys.name.rawValue)) ?? "Layer"
-    type = ShapeType(rawValue: try dictionary.valueFor(key: CodingKeys.type.rawValue)) ?? .unknown
-    hidden = (try? dictionary.valueFor(key: CodingKeys.hidden.rawValue)) ?? false
+    name = (try? dictionary.value(for: CodingKeys.name.rawValue)) ?? "Layer"
+    type = ShapeType(rawValue: try dictionary.value(for: CodingKeys.type.rawValue)) ?? .unknown
+    hidden = (try? dictionary.value(for: CodingKeys.hidden.rawValue)) ?? false
   }
 
   init(

--- a/Sources/Private/Model/ShapeItems/ShapeTransform.swift
+++ b/Sources/Private/Model/ShapeItems/ShapeTransform.swift
@@ -27,6 +27,66 @@ final class ShapeTransform: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    if
+      let anchorDictionary = dictionary[CodingKeys.anchor.rawValue] as? [String: Any],
+      let anchor = try? KeyframeGroup<Vector3D>(dictionary: anchorDictionary)
+    {
+      self.anchor = anchor
+    } else {
+      anchor = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+    if
+      let positionDictionary = dictionary[CodingKeys.position.rawValue] as? [String: Any],
+      let position = try? KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    {
+      self.position = position
+    } else {
+      position = KeyframeGroup(Vector3D(x: Double(0), y: 0, z: 0))
+    }
+    if
+      let scaleDictionary = dictionary[CodingKeys.scale.rawValue] as? [String: Any],
+      let scale = try? KeyframeGroup<Vector3D>(dictionary: scaleDictionary)
+    {
+      self.scale = scale
+    } else {
+      scale = KeyframeGroup(Vector3D(x: Double(100), y: 100, z: 100))
+    }
+    if
+      let rotationDictionary = dictionary[CodingKeys.rotation.rawValue] as? [String: Any],
+      let rotation = try? KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
+    {
+      self.rotation = rotation
+    } else {
+      rotation = KeyframeGroup(Vector1D(0))
+    }
+    if
+      let opacityDictionary = dictionary[CodingKeys.opacity.rawValue] as? [String: Any],
+      let opacity = try? KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    {
+      self.opacity = opacity
+    } else {
+      opacity = KeyframeGroup(Vector1D(100))
+    }
+    if
+      let skewDictionary = dictionary[CodingKeys.skew.rawValue] as? [String: Any],
+      let skew = try? KeyframeGroup<Vector1D>(dictionary: skewDictionary)
+    {
+      self.skew = skew
+    } else {
+      skew = KeyframeGroup(Vector1D(0))
+    }
+    if
+      let skewAxisDictionary = dictionary[CodingKeys.skewAxis.rawValue] as? [String: Any],
+      let skewAxis = try? KeyframeGroup<Vector1D>(dictionary: skewAxisDictionary)
+    {
+      self.skewAxis = skewAxis
+    } else {
+      skewAxis = KeyframeGroup(Vector1D(0))
+    }
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// Anchor Point

--- a/Sources/Private/Model/ShapeItems/Star.swift
+++ b/Sources/Private/Model/ShapeItems/Star.swift
@@ -45,11 +45,11 @@ final class Star: ShapeItem {
     } else {
       direction = .clockwise
     }
-    let positionDictionary: [String: Any] = try dictionary.value(for: CodingKeys.position.rawValue)
+    let positionDictionary: [String: Any] = try dictionary.value(for: CodingKeys.position)
     position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
-    let outerRadiusDictionary: [String: Any] = try dictionary.value(for: CodingKeys.outerRadius.rawValue)
+    let outerRadiusDictionary: [String: Any] = try dictionary.value(for: CodingKeys.outerRadius)
     outerRadius = try KeyframeGroup<Vector1D>(dictionary: outerRadiusDictionary)
-    let outerRoundnessDictionary: [String: Any] = try dictionary.value(for: CodingKeys.outerRoundness.rawValue)
+    let outerRoundnessDictionary: [String: Any] = try dictionary.value(for: CodingKeys.outerRoundness)
     outerRoundness = try KeyframeGroup<Vector1D>(dictionary: outerRoundnessDictionary)
     if let innerRadiusDictionary = dictionary[CodingKeys.innerRadius.rawValue] as? [String: Any] {
       innerRadius = try KeyframeGroup<Vector1D>(dictionary: innerRadiusDictionary)
@@ -61,11 +61,11 @@ final class Star: ShapeItem {
     } else {
       innerRoundness = nil
     }
-    let rotationDictionary: [String: Any] = try dictionary.value(for: CodingKeys.rotation.rawValue)
+    let rotationDictionary: [String: Any] = try dictionary.value(for: CodingKeys.rotation)
     rotation = try KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
-    let pointsDictionary: [String: Any] = try dictionary.value(for: CodingKeys.points.rawValue)
+    let pointsDictionary: [String: Any] = try dictionary.value(for: CodingKeys.points)
     points = try KeyframeGroup<Vector1D>(dictionary: pointsDictionary)
-    let starTypeRawValue: Int = try dictionary.value(for: CodingKeys.starType.rawValue)
+    let starTypeRawValue: Int = try dictionary.value(for: CodingKeys.starType)
     guard let starType = StarType(rawValue: starTypeRawValue) else {
       throw InitializableError.invalidInput
     }

--- a/Sources/Private/Model/ShapeItems/Star.swift
+++ b/Sources/Private/Model/ShapeItems/Star.swift
@@ -45,11 +45,11 @@ final class Star: ShapeItem {
     } else {
       direction = .clockwise
     }
-    let positionDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.position.rawValue)
+    let positionDictionary: [String: Any] = try dictionary.value(for: CodingKeys.position.rawValue)
     position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
-    let outerRadiusDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.outerRadius.rawValue)
+    let outerRadiusDictionary: [String: Any] = try dictionary.value(for: CodingKeys.outerRadius.rawValue)
     outerRadius = try KeyframeGroup<Vector1D>(dictionary: outerRadiusDictionary)
-    let outerRoundnessDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.outerRoundness.rawValue)
+    let outerRoundnessDictionary: [String: Any] = try dictionary.value(for: CodingKeys.outerRoundness.rawValue)
     outerRoundness = try KeyframeGroup<Vector1D>(dictionary: outerRoundnessDictionary)
     if let innerRadiusDictionary = dictionary[CodingKeys.innerRadius.rawValue] as? [String: Any] {
       innerRadius = try KeyframeGroup<Vector1D>(dictionary: innerRadiusDictionary)
@@ -61,11 +61,11 @@ final class Star: ShapeItem {
     } else {
       innerRoundness = nil
     }
-    let rotationDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.rotation.rawValue)
+    let rotationDictionary: [String: Any] = try dictionary.value(for: CodingKeys.rotation.rawValue)
     rotation = try KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
-    let pointsDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.points.rawValue)
+    let pointsDictionary: [String: Any] = try dictionary.value(for: CodingKeys.points.rawValue)
     points = try KeyframeGroup<Vector1D>(dictionary: pointsDictionary)
-    let starTypeRawValue: Int = try dictionary.valueFor(key: CodingKeys.starType.rawValue)
+    let starTypeRawValue: Int = try dictionary.value(for: CodingKeys.starType.rawValue)
     guard let starType = StarType(rawValue: starTypeRawValue) else {
       throw InitializableError.invalidInput
     }

--- a/Sources/Private/Model/ShapeItems/Star.swift
+++ b/Sources/Private/Model/ShapeItems/Star.swift
@@ -36,6 +36,43 @@ final class Star: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    if
+      let directionRawValue = dictionary[CodingKeys.direction.rawValue] as? Int,
+      let direction = PathDirection(rawValue: directionRawValue)
+    {
+      self.direction = direction
+    } else {
+      direction = .clockwise
+    }
+    let positionDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.position.rawValue)
+    position = try KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    let outerRadiusDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.outerRadius.rawValue)
+    outerRadius = try KeyframeGroup<Vector1D>(dictionary: outerRadiusDictionary)
+    let outerRoundnessDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.outerRoundness.rawValue)
+    outerRoundness = try KeyframeGroup<Vector1D>(dictionary: outerRoundnessDictionary)
+    if let innerRadiusDictionary = dictionary[CodingKeys.innerRadius.rawValue] as? [String: Any] {
+      innerRadius = try KeyframeGroup<Vector1D>(dictionary: innerRadiusDictionary)
+    } else {
+      innerRadius = nil
+    }
+    if let innerRoundnessDictionary = dictionary[CodingKeys.innerRoundness.rawValue] as? [String: Any] {
+      innerRoundness = try KeyframeGroup<Vector1D>(dictionary: innerRoundnessDictionary)
+    } else {
+      innerRoundness = nil
+    }
+    let rotationDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.rotation.rawValue)
+    rotation = try KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
+    let pointsDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.points.rawValue)
+    points = try KeyframeGroup<Vector1D>(dictionary: pointsDictionary)
+    let starTypeRawValue: Int = try dictionary.valueFor(key: CodingKeys.starType.rawValue)
+    guard let starType = StarType(rawValue: starTypeRawValue) else {
+      throw InitializableError.invalidInput
+    }
+    self.starType = starType
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The direction of the star.

--- a/Sources/Private/Model/ShapeItems/Stroke.swift
+++ b/Sources/Private/Model/ShapeItems/Stroke.swift
@@ -24,6 +24,35 @@ final class Stroke: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    let colorDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.color.rawValue)
+    color = try KeyframeGroup<Color>(dictionary: colorDictionary)
+    let widthDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    width = try KeyframeGroup<Vector1D>(dictionary: widthDictionary)
+    if
+      let lineCapRawValue = dictionary[CodingKeys.lineCap.rawValue] as? Int,
+      let lineCap = LineCap(rawValue: lineCapRawValue)
+    {
+      self.lineCap = lineCap
+    } else {
+      lineCap = .round
+    }
+    if
+      let lineJoinRawValue = dictionary[CodingKeys.lineJoin.rawValue] as? Int,
+      let lineJoin = LineJoin(rawValue: lineJoinRawValue)
+    {
+      self.lineJoin = lineJoin
+    } else {
+      lineJoin = .round
+    }
+    miterLimit = (try? dictionary.valueFor(key: CodingKeys.miterLimit.rawValue)) ?? 4
+    let dashPatternDictionaries = dictionary[CodingKeys.dashPattern.rawValue] as? [[String: Any]]
+    dashPattern = try? dashPatternDictionaries?.map({ try DashElement(dictionary: $0) })
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The opacity of the stroke

--- a/Sources/Private/Model/ShapeItems/Stroke.swift
+++ b/Sources/Private/Model/ShapeItems/Stroke.swift
@@ -25,11 +25,11 @@ final class Stroke: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let opacityDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.opacity.rawValue)
+    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity.rawValue)
     opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
-    let colorDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.color.rawValue)
+    let colorDictionary: [String: Any] = try dictionary.value(for: CodingKeys.color.rawValue)
     color = try KeyframeGroup<Color>(dictionary: colorDictionary)
-    let widthDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    let widthDictionary: [String: Any] = try dictionary.value(for: CodingKeys.width.rawValue)
     width = try KeyframeGroup<Vector1D>(dictionary: widthDictionary)
     if
       let lineCapRawValue = dictionary[CodingKeys.lineCap.rawValue] as? Int,
@@ -47,7 +47,7 @@ final class Stroke: ShapeItem {
     } else {
       lineJoin = .round
     }
-    miterLimit = (try? dictionary.valueFor(key: CodingKeys.miterLimit.rawValue)) ?? 4
+    miterLimit = (try? dictionary.value(for: CodingKeys.miterLimit.rawValue)) ?? 4
     let dashPatternDictionaries = dictionary[CodingKeys.dashPattern.rawValue] as? [[String: Any]]
     dashPattern = try? dashPatternDictionaries?.map({ try DashElement(dictionary: $0) })
     try super.init(dictionary: dictionary)

--- a/Sources/Private/Model/ShapeItems/Stroke.swift
+++ b/Sources/Private/Model/ShapeItems/Stroke.swift
@@ -25,11 +25,11 @@ final class Stroke: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity.rawValue)
+    let opacityDictionary: [String: Any] = try dictionary.value(for: CodingKeys.opacity)
     opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
-    let colorDictionary: [String: Any] = try dictionary.value(for: CodingKeys.color.rawValue)
+    let colorDictionary: [String: Any] = try dictionary.value(for: CodingKeys.color)
     color = try KeyframeGroup<Color>(dictionary: colorDictionary)
-    let widthDictionary: [String: Any] = try dictionary.value(for: CodingKeys.width.rawValue)
+    let widthDictionary: [String: Any] = try dictionary.value(for: CodingKeys.width)
     width = try KeyframeGroup<Vector1D>(dictionary: widthDictionary)
     if
       let lineCapRawValue = dictionary[CodingKeys.lineCap.rawValue] as? Int,
@@ -47,7 +47,7 @@ final class Stroke: ShapeItem {
     } else {
       lineJoin = .round
     }
-    miterLimit = (try? dictionary.value(for: CodingKeys.miterLimit.rawValue)) ?? 4
+    miterLimit = (try? dictionary.value(for: CodingKeys.miterLimit)) ?? 4
     let dashPatternDictionaries = dictionary[CodingKeys.dashPattern.rawValue] as? [[String: Any]]
     dashPattern = try? dashPatternDictionaries?.map({ try DashElement(dictionary: $0) })
     try super.init(dictionary: dictionary)

--- a/Sources/Private/Model/ShapeItems/Trim.swift
+++ b/Sources/Private/Model/ShapeItems/Trim.swift
@@ -31,13 +31,13 @@ final class Trim: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let startDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.start.rawValue)
+    let startDictionary: [String: Any] = try dictionary.value(for: CodingKeys.start.rawValue)
     start = try KeyframeGroup<Vector1D>(dictionary: startDictionary)
-    let endDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.end.rawValue)
+    let endDictionary: [String: Any] = try dictionary.value(for: CodingKeys.end.rawValue)
     end = try KeyframeGroup<Vector1D>(dictionary: endDictionary)
-    let offsetDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.offset.rawValue)
+    let offsetDictionary: [String: Any] = try dictionary.value(for: CodingKeys.offset.rawValue)
     offset = try KeyframeGroup<Vector1D>(dictionary: offsetDictionary)
-    let trimTypeRawValue: Int = try dictionary.valueFor(key: CodingKeys.trimType.rawValue)
+    let trimTypeRawValue: Int = try dictionary.value(for: CodingKeys.trimType.rawValue)
     guard let trimType = TrimType(rawValue: trimTypeRawValue) else {
       throw InitializableError.invalidInput
     }

--- a/Sources/Private/Model/ShapeItems/Trim.swift
+++ b/Sources/Private/Model/ShapeItems/Trim.swift
@@ -30,6 +30,21 @@ final class Trim: ShapeItem {
     try super.init(from: decoder)
   }
 
+  required init(dictionary: [String: Any]) throws {
+    let startDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.start.rawValue)
+    start = try KeyframeGroup<Vector1D>(dictionary: startDictionary)
+    let endDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.end.rawValue)
+    end = try KeyframeGroup<Vector1D>(dictionary: endDictionary)
+    let offsetDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.offset.rawValue)
+    offset = try KeyframeGroup<Vector1D>(dictionary: offsetDictionary)
+    let trimTypeRawValue: Int = try dictionary.valueFor(key: CodingKeys.trimType.rawValue)
+    guard let trimType = TrimType(rawValue: trimTypeRawValue) else {
+      throw InitializableError.invalidInput
+    }
+    self.trimType = trimType
+    try super.init(dictionary: dictionary)
+  }
+
   // MARK: Internal
 
   /// The start of the trim

--- a/Sources/Private/Model/ShapeItems/Trim.swift
+++ b/Sources/Private/Model/ShapeItems/Trim.swift
@@ -31,13 +31,13 @@ final class Trim: ShapeItem {
   }
 
   required init(dictionary: [String: Any]) throws {
-    let startDictionary: [String: Any] = try dictionary.value(for: CodingKeys.start.rawValue)
+    let startDictionary: [String: Any] = try dictionary.value(for: CodingKeys.start)
     start = try KeyframeGroup<Vector1D>(dictionary: startDictionary)
-    let endDictionary: [String: Any] = try dictionary.value(for: CodingKeys.end.rawValue)
+    let endDictionary: [String: Any] = try dictionary.value(for: CodingKeys.end)
     end = try KeyframeGroup<Vector1D>(dictionary: endDictionary)
-    let offsetDictionary: [String: Any] = try dictionary.value(for: CodingKeys.offset.rawValue)
+    let offsetDictionary: [String: Any] = try dictionary.value(for: CodingKeys.offset)
     offset = try KeyframeGroup<Vector1D>(dictionary: offsetDictionary)
-    let trimTypeRawValue: Int = try dictionary.value(for: CodingKeys.trimType.rawValue)
+    let trimTypeRawValue: Int = try dictionary.value(for: CodingKeys.trimType)
     guard let trimType = TrimType(rawValue: trimTypeRawValue) else {
       throw InitializableError.invalidInput
     }

--- a/Sources/Private/Model/Text/Font.swift
+++ b/Sources/Private/Model/Text/Font.swift
@@ -14,10 +14,10 @@ final class Font: Codable, DictionaryInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    name = try dictionary.valueFor(key: CodingKeys.name.rawValue)
-    familyName = try dictionary.valueFor(key: CodingKeys.familyName.rawValue)
-    style = try dictionary.valueFor(key: CodingKeys.style.rawValue)
-    ascent = try dictionary.valueFor(key: CodingKeys.ascent.rawValue)
+    name = try dictionary.value(for: CodingKeys.name.rawValue)
+    familyName = try dictionary.value(for: CodingKeys.familyName.rawValue)
+    style = try dictionary.value(for: CodingKeys.style.rawValue)
+    ascent = try dictionary.value(for: CodingKeys.ascent.rawValue)
   }
 
   // MARK: Internal
@@ -46,7 +46,7 @@ final class FontList: Codable, DictionaryInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    let fontDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.fonts.rawValue)
+    let fontDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.fonts.rawValue)
     fonts = try fontDictionaries.map({ try Font(dictionary: $0) })
   }
 

--- a/Sources/Private/Model/Text/Font.swift
+++ b/Sources/Private/Model/Text/Font.swift
@@ -9,7 +9,16 @@ import Foundation
 
 // MARK: - Font
 
-final class Font: Codable {
+final class Font: Codable, DictionaryInitializable {
+
+  // MARK: Lifecycle
+
+  init(dictionary: [String: Any]) throws {
+    name = try dictionary.valueFor(key: CodingKeys.name.rawValue)
+    familyName = try dictionary.valueFor(key: CodingKeys.familyName.rawValue)
+    style = try dictionary.valueFor(key: CodingKeys.style.rawValue)
+    ascent = try dictionary.valueFor(key: CodingKeys.ascent.rawValue)
+  }
 
   // MARK: Internal
 
@@ -32,11 +41,21 @@ final class Font: Codable {
 // MARK: - FontList
 
 /// A list of fonts
-final class FontList: Codable {
+final class FontList: Codable, DictionaryInitializable {
+
+  // MARK: Lifecycle
+
+  init(dictionary: [String: Any]) throws {
+    let fontDictionaries: [[String: Any]] = try dictionary.valueFor(key: CodingKeys.fonts.rawValue)
+    fonts = try fontDictionaries.map({ try Font(dictionary: $0) })
+  }
+
+  // MARK: Internal
 
   enum CodingKeys: String, CodingKey {
     case fonts = "list"
   }
 
   let fonts: [Font]
+
 }

--- a/Sources/Private/Model/Text/Font.swift
+++ b/Sources/Private/Model/Text/Font.swift
@@ -14,10 +14,10 @@ final class Font: Codable, DictionaryInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    name = try dictionary.value(for: CodingKeys.name.rawValue)
-    familyName = try dictionary.value(for: CodingKeys.familyName.rawValue)
-    style = try dictionary.value(for: CodingKeys.style.rawValue)
-    ascent = try dictionary.value(for: CodingKeys.ascent.rawValue)
+    name = try dictionary.value(for: CodingKeys.name)
+    familyName = try dictionary.value(for: CodingKeys.familyName)
+    style = try dictionary.value(for: CodingKeys.style)
+    ascent = try dictionary.value(for: CodingKeys.ascent)
   }
 
   // MARK: Internal
@@ -46,7 +46,7 @@ final class FontList: Codable, DictionaryInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    let fontDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.fonts.rawValue)
+    let fontDictionaries: [[String: Any]] = try dictionary.value(for: CodingKeys.fonts)
     fonts = try fontDictionaries.map({ try Font(dictionary: $0) })
   }
 

--- a/Sources/Private/Model/Text/Glyph.swift
+++ b/Sources/Private/Model/Text/Glyph.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A model that holds a vector character
-final class Glyph: Codable {
+final class Glyph: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle
 
@@ -27,6 +27,22 @@ final class Glyph: Codable {
       shapes = try shapeContainer.decode([ShapeItem].self, ofFamily: ShapeType.self, forKey: .shapes)
     } else {
       shapes = []
+    }
+  }
+
+  init(dictionary: [String: Any]) throws {
+    character = try dictionary.valueFor(key: CodingKeys.character.rawValue)
+    fontSize = try dictionary.valueFor(key: CodingKeys.fontSize.rawValue)
+    fontFamily = try dictionary.valueFor(key: CodingKeys.fontFamily.rawValue)
+    fontStyle = try dictionary.valueFor(key: CodingKeys.fontStyle.rawValue)
+    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    if
+      let shapes = dictionary[CodingKeys.shapeWrapper.rawValue] as? [String: Any],
+      let shapeDictionaries = shapes[ShapeKey.shapes.rawValue] as? [[String: Any]]
+    {
+      self.shapes = try [ShapeItem].fromDictionaries(shapeDictionaries)
+    } else {
+      shapes = [ShapeItem]()
     }
   }
 

--- a/Sources/Private/Model/Text/Glyph.swift
+++ b/Sources/Private/Model/Text/Glyph.swift
@@ -31,11 +31,11 @@ final class Glyph: Codable, DictionaryInitializable {
   }
 
   init(dictionary: [String: Any]) throws {
-    character = try dictionary.valueFor(key: CodingKeys.character.rawValue)
-    fontSize = try dictionary.valueFor(key: CodingKeys.fontSize.rawValue)
-    fontFamily = try dictionary.valueFor(key: CodingKeys.fontFamily.rawValue)
-    fontStyle = try dictionary.valueFor(key: CodingKeys.fontStyle.rawValue)
-    width = try dictionary.valueFor(key: CodingKeys.width.rawValue)
+    character = try dictionary.value(for: CodingKeys.character.rawValue)
+    fontSize = try dictionary.value(for: CodingKeys.fontSize.rawValue)
+    fontFamily = try dictionary.value(for: CodingKeys.fontFamily.rawValue)
+    fontStyle = try dictionary.value(for: CodingKeys.fontStyle.rawValue)
+    width = try dictionary.value(for: CodingKeys.width.rawValue)
     if
       let shapes = dictionary[CodingKeys.shapeWrapper.rawValue] as? [String: Any],
       let shapeDictionaries = shapes[ShapeKey.shapes.rawValue] as? [[String: Any]]

--- a/Sources/Private/Model/Text/Glyph.swift
+++ b/Sources/Private/Model/Text/Glyph.swift
@@ -31,11 +31,11 @@ final class Glyph: Codable, DictionaryInitializable {
   }
 
   init(dictionary: [String: Any]) throws {
-    character = try dictionary.value(for: CodingKeys.character.rawValue)
-    fontSize = try dictionary.value(for: CodingKeys.fontSize.rawValue)
-    fontFamily = try dictionary.value(for: CodingKeys.fontFamily.rawValue)
-    fontStyle = try dictionary.value(for: CodingKeys.fontStyle.rawValue)
-    width = try dictionary.value(for: CodingKeys.width.rawValue)
+    character = try dictionary.value(for: CodingKeys.character)
+    fontSize = try dictionary.value(for: CodingKeys.fontSize)
+    fontFamily = try dictionary.value(for: CodingKeys.fontFamily)
+    fontStyle = try dictionary.value(for: CodingKeys.fontStyle)
+    width = try dictionary.value(for: CodingKeys.width)
     if
       let shapes = dictionary[CodingKeys.shapeWrapper.rawValue] as? [String: Any],
       let shapeDictionaries = shapes[ShapeKey.shapes.rawValue] as? [[String: Any]]

--- a/Sources/Private/Model/Text/TextAnimator.swift
+++ b/Sources/Private/Model/Text/TextAnimator.swift
@@ -30,8 +30,8 @@ final class TextAnimator: Codable, DictionaryInitializable {
   }
 
   init(dictionary: [String: Any]) throws {
-    name = (try? dictionary.valueFor(key: CodingKeys.name.rawValue)) ?? ""
-    let animatorDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.textAnimator.rawValue)
+    name = (try? dictionary.value(for: CodingKeys.name.rawValue)) ?? ""
+    let animatorDictionary: [String: Any] = try dictionary.value(for: CodingKeys.textAnimator.rawValue)
     if let fillColorDictionary = animatorDictionary[TextAnimatorKeys.fillColor.rawValue] as? [String: Any] {
       fillColor = try? KeyframeGroup<Color>(dictionary: fillColorDictionary)
     } else {

--- a/Sources/Private/Model/Text/TextAnimator.swift
+++ b/Sources/Private/Model/Text/TextAnimator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class TextAnimator: Codable {
+final class TextAnimator: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle
 
@@ -27,6 +27,66 @@ final class TextAnimator: Codable {
     rotation = try animatorContainer.decodeIfPresent(KeyframeGroup<Vector1D>.self, forKey: .rotation)
     opacity = try animatorContainer.decodeIfPresent(KeyframeGroup<Vector1D>.self, forKey: .opacity)
 
+  }
+
+  init(dictionary: [String: Any]) throws {
+    name = (try? dictionary.valueFor(key: CodingKeys.name.rawValue)) ?? ""
+    let animatorDictionary: [String: Any] = try dictionary.valueFor(key: CodingKeys.textAnimator.rawValue)
+    if let fillColorDictionary = animatorDictionary[TextAnimatorKeys.fillColor.rawValue] as? [String: Any] {
+      fillColor = try? KeyframeGroup<Color>(dictionary: fillColorDictionary)
+    } else {
+      fillColor = nil
+    }
+    if let strokeColorDictionary = animatorDictionary[TextAnimatorKeys.strokeColor.rawValue] as? [String: Any] {
+      strokeColor = try? KeyframeGroup<Color>(dictionary: strokeColorDictionary)
+    } else {
+      strokeColor = nil
+    }
+    if let strokeWidthDictionary = animatorDictionary[TextAnimatorKeys.strokeWidth.rawValue] as? [String: Any] {
+      strokeWidth = try? KeyframeGroup<Vector1D>(dictionary: strokeWidthDictionary)
+    } else {
+      strokeWidth = nil
+    }
+    if let trackingDictionary = animatorDictionary[TextAnimatorKeys.tracking.rawValue] as? [String: Any] {
+      tracking = try? KeyframeGroup<Vector1D>(dictionary: trackingDictionary)
+    } else {
+      tracking = nil
+    }
+    if let anchorDictionary = animatorDictionary[TextAnimatorKeys.anchor.rawValue] as? [String: Any] {
+      anchor = try? KeyframeGroup<Vector3D>(dictionary: anchorDictionary)
+    } else {
+      anchor = nil
+    }
+    if let positionDictionary = animatorDictionary[TextAnimatorKeys.position.rawValue] as? [String: Any] {
+      position = try? KeyframeGroup<Vector3D>(dictionary: positionDictionary)
+    } else {
+      position = nil
+    }
+    if let scaleDictionary = animatorDictionary[TextAnimatorKeys.scale.rawValue] as? [String: Any] {
+      scale = try? KeyframeGroup<Vector3D>(dictionary: scaleDictionary)
+    } else {
+      scale = nil
+    }
+    if let skewDictionary = animatorDictionary[TextAnimatorKeys.skew.rawValue] as? [String: Any] {
+      skew = try? KeyframeGroup<Vector1D>(dictionary: skewDictionary)
+    } else {
+      skew = nil
+    }
+    if let skewAxisDictionary = animatorDictionary[TextAnimatorKeys.skewAxis.rawValue] as? [String: Any] {
+      skewAxis = try? KeyframeGroup<Vector1D>(dictionary: skewAxisDictionary)
+    } else {
+      skewAxis = nil
+    }
+    if let rotationDictionary = animatorDictionary[TextAnimatorKeys.rotation.rawValue] as? [String: Any] {
+      rotation = try? KeyframeGroup<Vector1D>(dictionary: rotationDictionary)
+    } else {
+      rotation = nil
+    }
+    if let opacityDictionary = animatorDictionary[TextAnimatorKeys.opacity.rawValue] as? [String: Any] {
+      opacity = try KeyframeGroup<Vector1D>(dictionary: opacityDictionary)
+    } else {
+      opacity = nil
+    }
   }
 
   // MARK: Internal

--- a/Sources/Private/Model/Text/TextAnimator.swift
+++ b/Sources/Private/Model/Text/TextAnimator.swift
@@ -30,8 +30,8 @@ final class TextAnimator: Codable, DictionaryInitializable {
   }
 
   init(dictionary: [String: Any]) throws {
-    name = (try? dictionary.value(for: CodingKeys.name.rawValue)) ?? ""
-    let animatorDictionary: [String: Any] = try dictionary.value(for: CodingKeys.textAnimator.rawValue)
+    name = (try? dictionary.value(for: CodingKeys.name)) ?? ""
+    let animatorDictionary: [String: Any] = try dictionary.value(for: CodingKeys.textAnimator)
     if let fillColorDictionary = animatorDictionary[TextAnimatorKeys.fillColor.rawValue] as? [String: Any] {
       fillColor = try? KeyframeGroup<Color>(dictionary: fillColorDictionary)
     } else {

--- a/Sources/Private/Model/Text/TextDocument.swift
+++ b/Sources/Private/Model/Text/TextDocument.swift
@@ -22,17 +22,17 @@ final class TextDocument: Codable, DictionaryInitializable, AnyInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    text = try dictionary.value(for: CodingKeys.text.rawValue)
-    fontSize = try dictionary.value(for: CodingKeys.fontSize.rawValue)
-    fontFamily = try dictionary.value(for: CodingKeys.fontFamily.rawValue)
-    let justificationValue: Int = try dictionary.value(for: CodingKeys.justification.rawValue)
+    text = try dictionary.value(for: CodingKeys.text)
+    fontSize = try dictionary.value(for: CodingKeys.fontSize)
+    fontFamily = try dictionary.value(for: CodingKeys.fontFamily)
+    let justificationValue: Int = try dictionary.value(for: CodingKeys.justification)
     guard let justification = TextJustification(rawValue: justificationValue) else {
       throw InitializableError.invalidInput
     }
     self.justification = justification
-    tracking = try dictionary.value(for: CodingKeys.tracking.rawValue)
-    lineHeight = try dictionary.value(for: CodingKeys.lineHeight.rawValue)
-    baseline = try dictionary.value(for: CodingKeys.baseline.rawValue)
+    tracking = try dictionary.value(for: CodingKeys.tracking)
+    lineHeight = try dictionary.value(for: CodingKeys.lineHeight)
+    baseline = try dictionary.value(for: CodingKeys.baseline)
     if let fillColorRawValue = dictionary[CodingKeys.fillColorData.rawValue] {
       fillColorData = try? Color(value: fillColorRawValue)
     } else {
@@ -43,8 +43,8 @@ final class TextDocument: Codable, DictionaryInitializable, AnyInitializable {
     } else {
       strokeColorData = nil
     }
-    strokeWidth = try? dictionary.value(for: CodingKeys.strokeWidth.rawValue)
-    strokeOverFill = try? dictionary.value(for: CodingKeys.strokeOverFill.rawValue)
+    strokeWidth = try? dictionary.value(for: CodingKeys.strokeWidth)
+    strokeOverFill = try? dictionary.value(for: CodingKeys.strokeOverFill)
     if let textFramePositionRawValue = dictionary[CodingKeys.textFramePosition.rawValue] {
       textFramePosition = try? Vector3D(value: textFramePositionRawValue)
     } else {

--- a/Sources/Private/Model/Text/TextDocument.swift
+++ b/Sources/Private/Model/Text/TextDocument.swift
@@ -22,17 +22,17 @@ final class TextDocument: Codable, DictionaryInitializable, AnyInitializable {
   // MARK: Lifecycle
 
   init(dictionary: [String: Any]) throws {
-    text = try dictionary.valueFor(key: CodingKeys.text.rawValue)
-    fontSize = try dictionary.valueFor(key: CodingKeys.fontSize.rawValue)
-    fontFamily = try dictionary.valueFor(key: CodingKeys.fontFamily.rawValue)
-    let justificationValue: Int = try dictionary.valueFor(key: CodingKeys.justification.rawValue)
+    text = try dictionary.value(for: CodingKeys.text.rawValue)
+    fontSize = try dictionary.value(for: CodingKeys.fontSize.rawValue)
+    fontFamily = try dictionary.value(for: CodingKeys.fontFamily.rawValue)
+    let justificationValue: Int = try dictionary.value(for: CodingKeys.justification.rawValue)
     guard let justification = TextJustification(rawValue: justificationValue) else {
       throw InitializableError.invalidInput
     }
     self.justification = justification
-    tracking = try dictionary.valueFor(key: CodingKeys.tracking.rawValue)
-    lineHeight = try dictionary.valueFor(key: CodingKeys.lineHeight.rawValue)
-    baseline = try dictionary.valueFor(key: CodingKeys.baseline.rawValue)
+    tracking = try dictionary.value(for: CodingKeys.tracking.rawValue)
+    lineHeight = try dictionary.value(for: CodingKeys.lineHeight.rawValue)
+    baseline = try dictionary.value(for: CodingKeys.baseline.rawValue)
     if let fillColorRawValue = dictionary[CodingKeys.fillColorData.rawValue] {
       fillColorData = try? Color(value: fillColorRawValue)
     } else {
@@ -43,8 +43,8 @@ final class TextDocument: Codable, DictionaryInitializable, AnyInitializable {
     } else {
       strokeColorData = nil
     }
-    strokeWidth = try? dictionary.valueFor(key: CodingKeys.strokeWidth.rawValue)
-    strokeOverFill = try? dictionary.valueFor(key: CodingKeys.strokeOverFill.rawValue)
+    strokeWidth = try? dictionary.value(for: CodingKeys.strokeWidth.rawValue)
+    strokeOverFill = try? dictionary.value(for: CodingKeys.strokeOverFill.rawValue)
     if let textFramePositionRawValue = dictionary[CodingKeys.textFramePosition.rawValue] {
       textFramePosition = try? Vector3D(value: textFramePositionRawValue)
     } else {

--- a/Sources/Private/Model/Text/TextDocument.swift
+++ b/Sources/Private/Model/Text/TextDocument.swift
@@ -17,7 +17,52 @@ enum TextJustification: Int, Codable {
 
 // MARK: - TextDocument
 
-final class TextDocument: Codable {
+final class TextDocument: Codable, DictionaryInitializable, AnyInitializable {
+
+  // MARK: Lifecycle
+
+  init(dictionary: [String: Any]) throws {
+    text = try dictionary.valueFor(key: CodingKeys.text.rawValue)
+    fontSize = try dictionary.valueFor(key: CodingKeys.fontSize.rawValue)
+    fontFamily = try dictionary.valueFor(key: CodingKeys.fontFamily.rawValue)
+    let justificationValue: Int = try dictionary.valueFor(key: CodingKeys.justification.rawValue)
+    guard let justification = TextJustification(rawValue: justificationValue) else {
+      throw InitializableError.invalidInput
+    }
+    self.justification = justification
+    tracking = try dictionary.valueFor(key: CodingKeys.tracking.rawValue)
+    lineHeight = try dictionary.valueFor(key: CodingKeys.lineHeight.rawValue)
+    baseline = try dictionary.valueFor(key: CodingKeys.baseline.rawValue)
+    if let fillColorRawValue = dictionary[CodingKeys.fillColorData.rawValue] {
+      fillColorData = try? Color(value: fillColorRawValue)
+    } else {
+      fillColorData = nil
+    }
+    if let strokeColorRawValue = dictionary[CodingKeys.strokeColorData.rawValue] {
+      strokeColorData = try? Color(value: strokeColorRawValue)
+    } else {
+      strokeColorData = nil
+    }
+    strokeWidth = try? dictionary.valueFor(key: CodingKeys.strokeWidth.rawValue)
+    strokeOverFill = try? dictionary.valueFor(key: CodingKeys.strokeOverFill.rawValue)
+    if let textFramePositionRawValue = dictionary[CodingKeys.textFramePosition.rawValue] {
+      textFramePosition = try? Vector3D(value: textFramePositionRawValue)
+    } else {
+      textFramePosition = nil
+    }
+    if let textFrameSizeRawValue = dictionary[CodingKeys.textFrameSize.rawValue] {
+      textFrameSize = try? Vector3D(value: textFrameSizeRawValue)
+    } else {
+      textFrameSize = nil
+    }
+  }
+
+  convenience init(value: Any) throws {
+    guard let dictionary = value as? [String: Any] else {
+      throw InitializableError.invalidInput
+    }
+    try self.init(dictionary: dictionary)
+  }
 
   // MARK: Internal
 

--- a/Sources/Private/Utility/Primitives/BezierPath.swift
+++ b/Sources/Private/Utility/Primitives/BezierPath.swift
@@ -392,6 +392,75 @@ extension BezierPath: Codable {
   }
 }
 
+// MARK: AnyInitializable
+
+extension BezierPath: AnyInitializable {
+
+  init(value: Any) throws {
+    var pathDictionary: [String: Any]
+    if
+      let array = value as? [[String: Any]],
+      let firstDictionary = array.first
+    {
+      pathDictionary = firstDictionary
+    } else if let dictionary = value as? [String: Any] {
+      pathDictionary = dictionary
+    } else {
+      throw InitializableError.invalidInput
+    }
+    closed = (try? pathDictionary.valueFor(key: CodingKeys.closed.rawValue)) ?? true
+    var vertexDictionaries: [Any] = try pathDictionary.valueFor(key: CodingKeys.vertices.rawValue)
+    var inPointsDictionaries: [Any] = try pathDictionary.valueFor(key: CodingKeys.inPoints.rawValue)
+    var outPointsDictionaries: [Any] = try pathDictionary.valueFor(key: CodingKeys.outPoints.rawValue)
+    guard
+      vertexDictionaries.count == inPointsDictionaries.count,
+      inPointsDictionaries.count == outPointsDictionaries.count else
+    {
+      throw InitializableError.invalidInput
+    }
+    guard vertexDictionaries.count > 0 else {
+      length = 0
+      elements = []
+      return
+    }
+
+    var decodedElements = [PathElement]()
+    let firstVertexDictionary = vertexDictionaries.removeFirst()
+    let firstInPointsDictionary = inPointsDictionaries.removeFirst()
+    let firstOutPointsDictionary = outPointsDictionaries.removeFirst()
+    let firstVertex = CurveVertex(
+      point: try CGPoint(value: firstVertexDictionary),
+      inTangentRelative: try CGPoint(value: firstInPointsDictionary),
+      outTangentRelative: try CGPoint(value: firstOutPointsDictionary))
+    var previousElement = PathElement(vertex: firstVertex)
+    decodedElements.append(previousElement)
+
+    var totalLength: CGFloat = 0
+    while vertexDictionaries.count > 0 {
+      let vertexDictionary = vertexDictionaries.removeFirst()
+      let inPointsDictionary = inPointsDictionaries.removeFirst()
+      let outPointsDictionary = outPointsDictionaries.removeFirst()
+      let vertex = CurveVertex(
+        point: try CGPoint(value: vertexDictionary),
+        inTangentRelative: try CGPoint(value: inPointsDictionary),
+        outTangentRelative: try CGPoint(value: outPointsDictionary))
+      let pathElement = previousElement.pathElementTo(vertex)
+      decodedElements.append(pathElement)
+      previousElement = pathElement
+      totalLength = totalLength + pathElement.length
+    }
+    if closed {
+      let closeElement = previousElement.pathElementTo(firstVertex)
+      decodedElements.append(closeElement)
+      totalLength = totalLength + closeElement.length
+    }
+
+    length = totalLength
+    elements = decodedElements
+  }
+
+}
+
 extension BezierPath {
 
   func cgPath() -> CGPath {

--- a/Sources/Private/Utility/Primitives/BezierPath.swift
+++ b/Sources/Private/Utility/Primitives/BezierPath.swift
@@ -408,10 +408,10 @@ extension BezierPath: AnyInitializable {
     } else {
       throw InitializableError.invalidInput
     }
-    closed = (try? pathDictionary.value(for: CodingKeys.closed.rawValue)) ?? true
-    var vertexDictionaries: [Any] = try pathDictionary.value(for: CodingKeys.vertices.rawValue)
-    var inPointsDictionaries: [Any] = try pathDictionary.value(for: CodingKeys.inPoints.rawValue)
-    var outPointsDictionaries: [Any] = try pathDictionary.value(for: CodingKeys.outPoints.rawValue)
+    closed = (try? pathDictionary.value(for: CodingKeys.closed)) ?? true
+    var vertexDictionaries: [Any] = try pathDictionary.value(for: CodingKeys.vertices)
+    var inPointsDictionaries: [Any] = try pathDictionary.value(for: CodingKeys.inPoints)
+    var outPointsDictionaries: [Any] = try pathDictionary.value(for: CodingKeys.outPoints)
     guard
       vertexDictionaries.count == inPointsDictionaries.count,
       inPointsDictionaries.count == outPointsDictionaries.count else

--- a/Sources/Private/Utility/Primitives/BezierPath.swift
+++ b/Sources/Private/Utility/Primitives/BezierPath.swift
@@ -408,10 +408,10 @@ extension BezierPath: AnyInitializable {
     } else {
       throw InitializableError.invalidInput
     }
-    closed = (try? pathDictionary.valueFor(key: CodingKeys.closed.rawValue)) ?? true
-    var vertexDictionaries: [Any] = try pathDictionary.valueFor(key: CodingKeys.vertices.rawValue)
-    var inPointsDictionaries: [Any] = try pathDictionary.valueFor(key: CodingKeys.inPoints.rawValue)
-    var outPointsDictionaries: [Any] = try pathDictionary.valueFor(key: CodingKeys.outPoints.rawValue)
+    closed = (try? pathDictionary.value(for: CodingKeys.closed.rawValue)) ?? true
+    var vertexDictionaries: [Any] = try pathDictionary.value(for: CodingKeys.vertices.rawValue)
+    var inPointsDictionaries: [Any] = try pathDictionary.value(for: CodingKeys.inPoints.rawValue)
+    var outPointsDictionaries: [Any] = try pathDictionary.value(for: CodingKeys.outPoints.rawValue)
     guard
       vertexDictionaries.count == inPointsDictionaries.count,
       inPointsDictionaries.count == outPointsDictionaries.count else

--- a/Sources/Private/Utility/Primitives/CGPointExtension.swift
+++ b/Sources/Private/Utility/Primitives/CGPointExtension.swift
@@ -1,0 +1,27 @@
+//
+//  CGPointExtension.swift
+//  Lottie
+//
+//  Created by Marcelo Fabri on 5/5/22.
+//
+
+import CoreGraphics
+
+extension CGPoint: AnyInitializable {
+
+  init(value: Any) throws {
+    if let dictionary = value as? [String: CGFloat] {
+      let x: CGFloat = try dictionary.valueFor(key: "x")
+      let y: CGFloat = try dictionary.valueFor(key: "y")
+      self.init(x: x, y: y)
+    } else if
+      let array = value as? [CGFloat],
+      array.count > 1
+    {
+      self.init(x: array[0], y: array[1])
+    } else {
+      throw InitializableError.invalidInput
+    }
+  }
+
+}

--- a/Sources/Private/Utility/Primitives/CGPointExtension.swift
+++ b/Sources/Private/Utility/Primitives/CGPointExtension.swift
@@ -11,8 +11,8 @@ extension CGPoint: AnyInitializable {
 
   init(value: Any) throws {
     if let dictionary = value as? [String: CGFloat] {
-      let x: CGFloat = try dictionary.valueFor(key: "x")
-      let y: CGFloat = try dictionary.valueFor(key: "y")
+      let x: CGFloat = try dictionary.value(for: "x")
+      let y: CGFloat = try dictionary.value(for: "y")
       self.init(x: x, y: y)
     } else if
       let array = value as? [CGFloat],

--- a/Sources/Private/Utility/Primitives/CGPointExtension.swift
+++ b/Sources/Private/Utility/Primitives/CGPointExtension.swift
@@ -9,10 +9,12 @@ import CoreGraphics
 
 extension CGPoint: AnyInitializable {
 
+  // MARK: Lifecycle
+
   init(value: Any) throws {
     if let dictionary = value as? [String: CGFloat] {
-      let x: CGFloat = try dictionary.value(for: "x")
-      let y: CGFloat = try dictionary.value(for: "y")
+      let x: CGFloat = try dictionary.value(for: CodingKeys.x)
+      let y: CGFloat = try dictionary.value(for: CodingKeys.y)
       self.init(x: x, y: y)
     } else if
       let array = value as? [CGFloat],
@@ -24,4 +26,10 @@ extension CGPoint: AnyInitializable {
     }
   }
 
+  // MARK: Private
+
+  private enum CodingKeys: String {
+    case x
+    case y
+  }
 }

--- a/Sources/Private/Utility/Primitives/ColorExtension.swift
+++ b/Sources/Private/Utility/Primitives/ColorExtension.swift
@@ -68,6 +68,32 @@ extension Color: Codable {
 
 }
 
+// MARK: - Color + AnyInitializable
+
+extension Color: AnyInitializable {
+
+  init(value: Any) throws {
+    guard var array = value as? [Double] else {
+      throw InitializableError.invalidInput
+    }
+    var r: Double = array.count > 0 ? array.removeFirst() : 0
+    var g: Double = array.count > 0 ? array.removeFirst() : 0
+    var b: Double = array.count > 0 ? array.removeFirst() : 0
+    var a: Double = array.count > 0 ? array.removeFirst() : 1
+    if r > 1, g > 1, b > 1, a > 1 {
+      r /= 255
+      g /= 255
+      b /= 255
+      a /= 255
+    }
+    self.r = r
+    self.g = g
+    self.b = b
+    self.a = a
+  }
+
+}
+
 extension Color {
 
   static var clearColor: CGColor {

--- a/Sources/Private/Utility/Primitives/VectorsExtensions.swift
+++ b/Sources/Private/Utility/Primitives/VectorsExtensions.swift
@@ -41,6 +41,25 @@ extension Vector1D: Codable {
 
 }
 
+// MARK: - Vector1D + AnyInitializable
+
+extension Vector1D: AnyInitializable {
+
+  init(value: Any) throws {
+    if
+      let array = value as? [Double],
+      let double = array.first
+    {
+      self.value = double
+    } else if let double = value as? Double {
+      self.value = double
+    } else {
+      throw InitializableError.invalidInput
+    }
+  }
+
+}
+
 extension Double {
   var vectorValue: Vector1D {
     Vector1D(self)
@@ -102,8 +121,36 @@ public struct Vector2D: Codable, Hashable {
   }
 }
 
-extension Vector2D {
+// MARK: AnyInitializable
 
+extension Vector2D: AnyInitializable {
+
+  init(value: Any) throws {
+    guard let dictionary = value as? [String: Any] else {
+      throw InitializableError.invalidInput
+    }
+
+    if
+      let array = dictionary[CodingKeys.x.rawValue] as? [Double],
+      let double = array.first
+    {
+      x = double
+    } else if let double = dictionary[CodingKeys.x.rawValue] as? Double {
+      x = double
+    } else {
+      throw InitializableError.invalidInput
+    }
+    if
+      let array = dictionary[CodingKeys.y.rawValue] as? [Double],
+      let double = array.first
+    {
+      y = double
+    } else if let double = dictionary[CodingKeys.y.rawValue] as? Double {
+      y = double
+    } else {
+      throw InitializableError.invalidInput
+    }
+  }
 }
 
 extension CGPoint {
@@ -156,6 +203,21 @@ extension Vector3D: Codable {
     try container.encode(x)
     try container.encode(y)
     try container.encode(z)
+  }
+
+}
+
+// MARK: - Vector3D + AnyInitializable
+
+extension Vector3D: AnyInitializable {
+
+  init(value: Any) throws {
+    guard var array = value as? [Double] else {
+      throw InitializableError.invalidInput
+    }
+    x = array.count > 0 ? array.removeFirst() : 0
+    y = array.count > 0 ? array.removeFirst() : 0
+    z = array.count > 0 ? array.removeFirst() : 0
   }
 
 }

--- a/Sources/Public/Animation/AnimationPublic.swift
+++ b/Sources/Public/Animation/AnimationPublic.swift
@@ -142,6 +142,29 @@ extension Animation {
     }
   }
 
+  /// Loads a Lottie animation from a `Data` object containing a JSON animation.
+  ///
+  /// - Parameter data: The object to load the animation from.
+  /// - Parameter strategy: How the data should be decoded. Defaults to using the strategy set in `LottieConfiguration.shared`.
+  /// - Returns: Deserialized `Animation`. Optional.
+  ///
+  public static func from(
+    data: Data,
+    strategy: DecodingStrategy = LottieConfiguration.shared.decodingStrategy) throws
+    -> Animation
+  {
+    switch strategy {
+    case .codable:
+      return try JSONDecoder().decode(Animation.self, from: data)
+    case .dictionaryBased:
+      let json = try JSONSerialization.jsonObject(with: data)
+      guard let dict = json as? [String: Any] else {
+        throw InitializableError.invalidInput
+      }
+      return try Animation(dictionary: dict)
+    }
+  }
+
   /// Loads a Lottie animation asynchronously from the URL.
   ///
   /// - Parameter url: The url to load the animation from.
@@ -242,24 +265,5 @@ extension Animation {
   /// Converts Time (Seconds) into Frame Time (Seconds * Framerate)
   public func frameTime(forTime time: TimeInterval) -> AnimationFrameTime {
     CGFloat(time * framerate) + startFrame
-  }
-}
-
-extension Animation {
-  internal static func from(
-    data: Data,
-    strategy: DecodingStrategy = LottieConfiguration.shared.decodingStrategy) throws
-    -> Animation
-  {
-    switch strategy {
-    case .codable:
-      return try JSONDecoder().decode(Animation.self, from: data)
-    case .dictionaryBased:
-      let json = try JSONSerialization.jsonObject(with: data)
-      guard let dict = json as? [String: Any] else {
-        throw InitializableError.invalidInput
-      }
-      return try Animation(dictionary: dict)
-    }
   }
 }

--- a/Sources/Public/LottieConfiguration.swift
+++ b/Sources/Public/LottieConfiguration.swift
@@ -107,7 +107,8 @@ public enum DecodingStrategy: Hashable {
   /// Use Codable. This is the default strategy introduced on Lottie 3.
   case codable
 
-  /// Manually deserialize a dictionary into an Animation. This should be faster,
+  /// Manually deserialize a dictionary into an Animation.
+  /// This should be at least 2-3x faster than using Codable,
   /// but since it's manually implemented, there might be issues while it's experimental.
   case dictionaryBased
 }

--- a/Sources/Public/LottieConfiguration.swift
+++ b/Sources/Public/LottieConfiguration.swift
@@ -6,8 +6,12 @@
 /// Global configuration options for Lottie animations
 public struct LottieConfiguration: Hashable {
 
-  public init(renderingEngine: RenderingEngineOption = .mainThread) {
+  public init(
+    renderingEngine: RenderingEngineOption = .mainThread,
+    decodingStrategy: DecodingStrategy = .codable)
+  {
     self.renderingEngine = renderingEngine
+    self.decodingStrategy = decodingStrategy
   }
 
   /// The global configuration of Lottie,
@@ -16,6 +20,7 @@ public struct LottieConfiguration: Hashable {
 
   /// The rendering engine implementation to use when displaying an animation
   public var renderingEngine: RenderingEngineOption
+  public var decodingStrategy: DecodingStrategy
 
 }
 
@@ -91,5 +96,16 @@ extension RenderingEngineOption: RawRepresentable, CustomStringConvertible {
   public var description: String {
     rawValue
   }
+}
 
+// MARK: - DecodingStrategy
+
+/// How animation files should be decoded
+public enum DecodingStrategy: Hashable {
+  /// Use Codable. This is the default strategy introduced on Lottie 3.
+  case codable
+
+  /// Manually deserialize a dictionary into an Animation. This should be faster,
+  /// but since it's manually implemented, there might be issues while it's experimental.
+  case dictionaryBased
 }

--- a/Sources/Public/LottieConfiguration.swift
+++ b/Sources/Public/LottieConfiguration.swift
@@ -20,6 +20,8 @@ public struct LottieConfiguration: Hashable {
 
   /// The rendering engine implementation to use when displaying an animation
   public var renderingEngine: RenderingEngineOption
+
+  /// The decoding implementation to use when parsing an animation JSON file
   public var decodingStrategy: DecodingStrategy
 
 }

--- a/Tests/ParsingTests.swift
+++ b/Tests/ParsingTests.swift
@@ -1,0 +1,42 @@
+//
+//  ParsingTests.swift
+//  Lottie
+//
+//  Created by Marcelo Fabri on 5/5/22.
+//
+
+import Difference
+import Foundation
+import XCTest
+@testable import Lottie
+
+// MARK: - ParsingTests
+
+final class ParsingTests: XCTestCase {
+
+  func testParsingIsTheSameForBothImplementations() throws {
+    for url in Samples.sampleAnimationURLs {
+      do {
+        let data = try Data(contentsOf: url)
+        let codableAnimation = try Animation.from(data: data, strategy: .codable)
+        let dictAnimation = try Animation.from(data: data, strategy: .dictionaryBased)
+
+        XCTAssertNoDiff(codableAnimation, dictAnimation)
+      } catch {
+        XCTFail("Error for \(url.lastPathComponent): \(error)")
+      }
+    }
+  }
+}
+
+func XCTAssertNoDiff<T>(
+  _ expected: @autoclosure () throws -> T,
+  _ received: @autoclosure () throws -> T,
+  file: StaticString = #filePath,
+  line: UInt = #line) rethrows {
+  let expected = try expected()
+  let received = try received()
+  let diff = diff(expected, received)
+  let isEqual = diff.isEmpty || diff.allSatisfy(\.isEmpty)
+  XCTAssertTrue(isEqual, "Found difference for \n" + diff.joined(separator: ", "), file: file, line: line)
+}

--- a/Tests/ParsingTests.swift
+++ b/Tests/ParsingTests.swift
@@ -7,8 +7,8 @@
 
 import Difference
 import Foundation
+import Lottie
 import XCTest
-@testable import Lottie
 
 // MARK: - ParsingTests
 


### PR DESCRIPTION
This is mostly a rebase from https://github.com/airbnb/lottie-ios/pull/1373, with some fixes and additional tests

When running the tests, decoding with Codable is ~2x as slow as this new approach. However, I think it makes sense to keep `Codable` as the default strategy for now, until we're fully confident this doesn't introduce any regressions.

I'll test this with the ~150 animations I have from a private app to double check.