### PR TITLE
Allow loading animations with “.json” extension in name

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -557,6 +557,7 @@
 		6DB3BDBD28245A14002A276D /* CGPointExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDBB28245A14002A276D /* CGPointExtension.swift */; };
 		6DB3BDBE28245A14002A276D /* CGPointExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDBB28245A14002A276D /* CGPointExtension.swift */; };
 		6DB3BDC328245AA2002A276D /* ParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB3BDBF28245A6A002A276D /* ParsingTests.swift */; };
+		6DEF696E2824A76C007D640F /* BundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEF696D2824A76C007D640F /* BundleTests.swift */; };
 		A1D5BAAC27C731A500777D06 /* DataURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5BAAB27C731A500777D06 /* DataURLTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -766,6 +767,7 @@
 		6DB3BDB7282454A6002A276D /* DictionaryInitializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryInitializable.swift; sourceTree = "<group>"; };
 		6DB3BDBB28245A14002A276D /* CGPointExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGPointExtension.swift; sourceTree = "<group>"; };
 		6DB3BDBF28245A6A002A276D /* ParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingTests.swift; sourceTree = "<group>"; };
+		6DEF696D2824A76C007D640F /* BundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleTests.swift; sourceTree = "<group>"; };
 		A1D5BAAB27C731A500777D06 /* DataURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataURLTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -833,6 +835,7 @@
 				2E80412527A07343006E74CB /* SnapshotConfiguration.swift */,
 				2E72128227BB329C0027BC56 /* AnimationKeypathTests.swift */,
 				2E72128427BB32DB0027BC56 /* PerformanceTests.swift */,
+				6DEF696D2824A76C007D640F /* BundleTests.swift */,
 				6DB3BDBF28245A6A002A276D /* ParsingTests.swift */,
 				A1D5BAAB27C731A500777D06 /* DataURLTests.swift */,
 				2E8040BD27A07343006E74CB /* Utils */,
@@ -1834,6 +1837,7 @@
 				2E80450C27A07347006E74CB /* SnapshotTests.swift in Sources */,
 				2E09FA0627B6CEB600BA84E5 /* HardcodedFontProvider.swift in Sources */,
 				2E80450D27A07347006E74CB /* SnapshotConfiguration.swift in Sources */,
+				6DEF696E2824A76C007D640F /* BundleTests.swift in Sources */,
 				2EAF59A727A076BC00E00531 /* Bundle+Module.swift in Sources */,
 				2E8044AE27A07347006E74CB /* Snapshotting+presentationLayer.swift in Sources */,
 				2E72128527BB32DB0027BC56 /* PerformanceTests.swift in Sources */,

--- a/Sources/Private/Model/Extensions/Bundle.swift
+++ b/Sources/Private/Model/Extensions/Bundle.swift
@@ -6,6 +6,7 @@ import UIKit
 extension Bundle {
   func getAnimationData(_ name: String, subdirectory: String? = nil) throws -> Data? {
     // Check for files in the bundle at the given path
+    let name = name.removingJSONSuffix()
     if let url = url(forResource: name, withExtension: "json", subdirectory: subdirectory) {
       return try Data(contentsOf: url)
     }
@@ -17,5 +18,15 @@ extension Bundle {
     #else
     return nil
     #endif
+  }
+}
+
+extension String {
+  fileprivate func removingJSONSuffix() -> String {
+    guard hasSuffix(".json") else {
+      return self
+    }
+
+    return (self as NSString).deletingPathExtension
   }
 }

--- a/Sources/Private/Model/Extensions/Bundle.swift
+++ b/Sources/Private/Model/Extensions/Bundle.swift
@@ -23,6 +23,8 @@ extension Bundle {
 
 extension String {
   fileprivate func removingJSONSuffix() -> String {
+    // Allow filenames to be passed with a ".json" extension (but not other extensions)
+    // to keep the behavior from Lottie 2.x - instead of failing to load the animation
     guard hasSuffix(".json") else {
       return self
     }

--- a/Tests/BundleTests.swift
+++ b/Tests/BundleTests.swift
@@ -1,0 +1,25 @@
+//
+//  BundleTests.swift
+//  LottieTests
+//
+//  Created by Marcelo Fabri on 5/5/22.
+//
+
+import XCTest
+
+@testable import Lottie
+
+final class BundleTests: XCTestCase {
+
+  var bundle: Bundle { .module }
+
+  func testGetAnimationDataWithSuffix() throws {
+    let data = try bundle.getAnimationData("HamburgerArrow.json", subdirectory: "Samples")
+    XCTAssertNotNil(data)
+  }
+
+  func testGetAnimationDataWithoutSuffix() throws {
+    let data = try bundle.getAnimationData("HamburgerArrow", subdirectory: "Samples")
+    XCTAssertNotNil(data)
+  }
+}


### PR DESCRIPTION
This is another small (surprising) compatibility issue I've found when updating a large codebase to Lottie 3.

We had a few places loading local animations using "animationName.json" and it started falling after the update. Turns out Lottie 2.x had [a weird logic](https://github.com/airbnb/lottie-ios/blob/2.5.3/lottie-ios/Classes/Private/LOTComposition.m#L27-L28) dropping everything after a `.` in the filename. I don't think we need to go that far because it's not a great behavior, but supporting `".json"` would cover the most common case.