### PR TITLE
Actually fix issue where animation could fail to start playing when using RenderingEngineOption.automatic

### DIFF
--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -1062,11 +1062,14 @@ final public class AnimationView: AnimationViewBase {
     self.currentFrame = currentFrame
 
     if let animationContext = animationContext {
-      // We have to wait until the next run loop cycle to start playing the animation,
-      // or it may not actually start as expected.
-      DispatchQueue.main.async {
-        self.addNewAnimationForContext(animationContext)
-      }
+      // `AnimationContext.closure` (`AnimationCompletionDelegate`) is a reference type
+      // that is the animation layer's `CAAnimationDelegate`, and holds a reference to
+      // the animation layer. Reusing a single instance across different animation layers
+      // can cause the animation setup to fail, so we create a copy of the `animationContext`:
+      addNewAnimationForContext(AnimationContext(
+        playFrom: animationContext.playFrom,
+        playTo: animationContext.playTo,
+        closure: animationContext.closure.completionBlock))
     }
   }
 


### PR DESCRIPTION
This PR _actually_ fixes the issue where an animation could fail to start when using `RenderingEngineOption.automatic`. 

The fix in #1560 worked in some cases, but not all. After digging in, I found out that this was because the `AnimationContext`'s `AnimationCompletionDelegate` (the animation layer's `CAAnimationDelegate`) was being put in a bad state: 
 - the `CoreAnimationLayer` would call `delegate.animationDidStop(_:finished:)` when it was removed from the view hierarchy
 - at that point the delegate object had been reconfigured so that `self.animationLayer` is a `MainThreadAnimationLayer`
 - the delegate called `animationLayer.removeAnimation`, cancelling the animation on the new `MainThreadAnimationLayer`

To fix this, we can just initialize a new `AnimationContext` with the same values instead of using the previous instance.