### PR TITLE
Fix issue where rebuildCurrentAnimation() would discard pending animation configuration

### DIFF
--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -259,7 +259,11 @@ final class CoreAnimationLayer: BaseAnimationLayer {
   private func rebuildCurrentAnimation() {
     guard
       let currentConfiguration = currentAnimationConfiguration,
-      let playbackState = playbackState
+      let playbackState = playbackState,
+      // Don't replace any pending animations that are queued to begin
+      // on the next run loop cycle, since an existing pending animation
+      // will cause the animation to be rebuilt anyway.
+      pendingAnimationConfiguration == nil
     else { return }
 
     removeAnimations()


### PR DESCRIPTION
This PR fixes an issue where `CoreAnimationLayer.rebuildCurrentAnimation()` would discard any pending animation configuration.

This could cause the animation from an `AnimationView.play` call to be dropped unexpectedly, in situations like:

```swift
// Queues an animation to begin on the next run loop cycle
animationView.play(...)

// Calls `rebuildCurrentAnimation()` so that the new value provider is reflected in the animation,
// but unexpectedly caused the animation above to be discarded
animationView.setValueProvider(...)
```

| Before | After |
| ----- | ---- |
| ![2022-05-06 15 28 05](https://user-images.githubusercontent.com/1811727/167224470-cd44c810-0955-46d6-a1b2-ababcab8e0ad.gif) | ![2022-05-06 15 25 46](https://user-images.githubusercontent.com/1811727/167224475-cdfbcb4d-6eb1-4ed7-9f8b-694f478f101b.gif) |