### PR TITLE
Fix searching layer by keypath

### DIFF
--- a/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
+++ b/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
@@ -106,12 +106,10 @@ extension KeypathSearchable {
       return nil
     }
 
-    if nextKeypath.nextKeypath != nil {
-      /// Now check child keypaths.
-      for child in childKeypaths {
-        if let layer = child.layer(for: keyPath) {
-          return layer
-        }
+    /// Now check child keypaths.
+    for child in childKeypaths {
+      if let layer = child.layer(for: nextKeypath) {
+        return layer
       }
     }
     return nil

--- a/Tests/AnimationKeypathTests.swift
+++ b/Tests/AnimationKeypathTests.swift
@@ -25,4 +25,14 @@ final class AnimationKeypathTests: XCTestCase {
     XCTAssertFalse(keypath.matches("Layer.Shape Group.Stroke 1.Color.**"))
   }
 
+  func testLayerForKeypath() {
+    let animationView = AnimationView(
+      animation: Samples.animation(named: "Boat_Loader"),
+      configuration: LottieConfiguration(renderingEngine: .mainThread))
+
+    XCTAssertNotNil(animationView.animationLayer?.layer(for: "Success.FishComplete.Fish1Tail 7"))
+    XCTAssertNotNil(animationView.animationLayer?.layer(for: "Success.FishComplete"))
+    XCTAssertNotNil(animationView.animationLayer?.layer(for: "Success"))
+    XCTAssertNotNil(animationView.animationLayer?.layer(for: "Success.*.Fish1Tail 7"))
+  }
 }


### PR DESCRIPTION
This was previously returning `nil` for valid keypaths. Since this is used when adding a subview for a keypath, that method would silently fail.