### PR TITLE
Use image cached provider to reuse asset when creating RootAnimationLayer

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		19465F52282F998B00BB2C97 /* CachedImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19465F51282F998B00BB2C97 /* CachedImageProvider.swift */; };
+		19465F53282F998B00BB2C97 /* CachedImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19465F51282F998B00BB2C97 /* CachedImageProvider.swift */; };
+		19465F54282F998B00BB2C97 /* CachedImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19465F51282F998B00BB2C97 /* CachedImageProvider.swift */; };
 		2E044E272820536800FA773B /* AutomaticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E044E262820536800FA773B /* AutomaticEngineTests.swift */; };
 		2E09FA0627B6CEB600BA84E5 /* HardcodedFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E09FA0527B6CEB600BA84E5 /* HardcodedFontProvider.swift */; };
 		2E72128327BB329C0027BC56 /* AnimationKeypathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E72128227BB329C0027BC56 /* AnimationKeypathTests.swift */; };
@@ -572,6 +575,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		19465F51282F998B00BB2C97 /* CachedImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedImageProvider.swift; sourceTree = "<group>"; };
 		2E044E262820536800FA773B /* AutomaticEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticEngineTests.swift; sourceTree = "<group>"; };
 		2E09FA0527B6CEB600BA84E5 /* HardcodedFontProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardcodedFontProvider.swift; sourceTree = "<group>"; };
 		2E72128227BB329C0027BC56 /* AnimationKeypathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationKeypathTests.swift; sourceTree = "<group>"; };
@@ -999,6 +1003,7 @@
 				2E9C95602822F43000677516 /* LayerTransformNode.swift */,
 				2E9C95612822F43000677516 /* InvertedMatteLayer.swift */,
 				2E9C95622822F43000677516 /* LayerImageProvider.swift */,
+				19465F51282F998B00BB2C97 /* CachedImageProvider.swift */,
 				2E9C95632822F43000677516 /* LayerTextProvider.swift */,
 				2E9C95642822F43000677516 /* CompositionLayersInitializer.swift */,
 			);
@@ -1720,6 +1725,7 @@
 				2EAF5AAD27A0798700E00531 /* AnimationView.swift in Sources */,
 				2E9C95E82822F43100677516 /* Merge.swift in Sources */,
 				2E9C96032822F43100677516 /* ImageLayerModel.swift in Sources */,
+				19465F52282F998B00BB2C97 /* CachedImageProvider.swift in Sources */,
 				2E9C96BA2822F43100677516 /* KeypathSearchable.swift in Sources */,
 				2E9C963C2822F43100677516 /* AssetLibrary.swift in Sources */,
 				2E9C97022822F43100677516 /* PreCompLayer.swift in Sources */,
@@ -1925,6 +1931,7 @@
 				2EAF5AAE27A0798700E00531 /* AnimationView.swift in Sources */,
 				2E9C95E92822F43100677516 /* Merge.swift in Sources */,
 				2E9C96042822F43100677516 /* ImageLayerModel.swift in Sources */,
+				19465F53282F998B00BB2C97 /* CachedImageProvider.swift in Sources */,
 				2E9C96BB2822F43100677516 /* KeypathSearchable.swift in Sources */,
 				2E9C963D2822F43100677516 /* AssetLibrary.swift in Sources */,
 				2E9C97032822F43100677516 /* PreCompLayer.swift in Sources */,
@@ -2110,6 +2117,7 @@
 				2EAF5AAF27A0798700E00531 /* AnimationView.swift in Sources */,
 				2E9C95EA2822F43100677516 /* Merge.swift in Sources */,
 				2E9C96052822F43100677516 /* ImageLayerModel.swift in Sources */,
+				19465F54282F998B00BB2C97 /* CachedImageProvider.swift in Sources */,
 				2E9C96BC2822F43100677516 /* KeypathSearchable.swift in Sources */,
 				2E9C963E2822F43100677516 /* AssetLibrary.swift in Sources */,
 				2E9C97042822F43100677516 /* PreCompLayer.swift in Sources */,

--- a/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
@@ -45,4 +45,3 @@ extension AnimationImageProvider {
     CachedImageProvider(imageProvider: self)
   }
 }
-

--- a/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
@@ -3,8 +3,6 @@
 
 import CoreGraphics
 import Foundation
-#if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
-import UIKit
 
 // MARK: - CachedImageProvider
 
@@ -48,4 +46,3 @@ extension AnimationImageProvider {
   }
 }
 
-#endif

--- a/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
@@ -1,0 +1,51 @@
+// Created by Jianjun Wu on 2022/5/12.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import CoreGraphics
+import Foundation
+#if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
+import UIKit
+
+// MARK: - CachedImageProvider
+
+private final class CachedImageProvider: AnimationImageProvider {
+
+  // MARK: Lifecycle
+
+  /// Initializes an image provider with an image provider
+  ///
+  /// - Parameter imageProvider: The provider to load image from asset
+  ///
+  public init(imageProvider: AnimationImageProvider) {
+    self.imageProvider = imageProvider
+  }
+
+  // MARK: Public
+
+  public func imageForAsset(asset: ImageAsset) -> CGImage? {
+    if let image = imageCache.object(forKey: asset.id as NSString) {
+      return image
+    }
+    if let image = imageProvider.imageForAsset(asset: asset) {
+      imageCache.setObject(image, forKey: asset.id as NSString)
+      return image
+    }
+    return nil
+  }
+
+  // MARK: Internal
+
+  let imageCache: NSCache<NSString, CGImage> = .init()
+  let imageProvider: AnimationImageProvider
+}
+
+extension AnimationImageProvider {
+  /// Create a cache enabled image provider which will reuse the asset image with the same asset id
+  /// It wraps the current provider as image loader, and uses `NSCache` to cache the images for resue.
+  /// The cache will be reset when the `animation` is reset.
+  var cachedImageProvider: AnimationImageProvider {
+    CachedImageProvider(imageProvider: self)
+  }
+}
+
+#endif

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -199,7 +199,7 @@ final public class AnimationView: AnimationViewBase {
   /// Setting this will cause the animation to reload its image contents.
   public var imageProvider: AnimationImageProvider {
     didSet {
-      animationLayer?.imageProvider = imageProvider
+      animationLayer?.imageProvider = imageProvider.cachedImageProvider
       reloadImages()
     }
   }
@@ -968,7 +968,7 @@ final public class AnimationView: AnimationViewBase {
   fileprivate func makeMainThreadAnimationLayer(for animation: Animation) -> MainThreadAnimationLayer {
     MainThreadAnimationLayer(
       animation: animation,
-      imageProvider: imageProvider,
+      imageProvider: imageProvider.cachedImageProvider,
       textProvider: textProvider,
       fontProvider: fontProvider)
   }
@@ -977,7 +977,7 @@ final public class AnimationView: AnimationViewBase {
     do {
       let coreAnimationLayer = try CoreAnimationLayer(
         animation: animation,
-        imageProvider: imageProvider,
+        imageProvider: imageProvider.cachedImageProvider,
         fontProvider: fontProvider,
         compatibilityTrackerMode: .track)
 
@@ -1010,7 +1010,7 @@ final public class AnimationView: AnimationViewBase {
       // or throw an error later in `CALayer.display()` that will be reported in `didSetUpAnimation`.
       let coreAnimationLayer = try CoreAnimationLayer(
         animation: animation,
-        imageProvider: imageProvider,
+        imageProvider: imageProvider.cachedImageProvider,
         fontProvider: fontProvider,
         compatibilityTrackerMode: .abort)
 


### PR DESCRIPTION
## Change summary:

Before this change, the Lottie animation layer creates images for each layer from asset which costs memory.

In this PR, the `BundleImageProvider ` is enhanced with image cache to reduce memory usage when creating layers with same asset.

The lifecycle of `CachedImageProvider` is the same as each `animation` in `AnimationView`.

## Please review:

|| before | after |
|-|-|-|
| Sample Lottie |![before](https://user-images.githubusercontent.com/105257537/168031411-22780506-be9f-48e8-8413-4eab7054c4f9.png) | ![after](https://user-images.githubusercontent.com/105257537/168031377-6a6bec86-e868-4ad6-9daf-e19b4cace63f.png)|  
