### PR TITLE
[Memory] reuse image cache for asset to reduce memory usage, alternative for #1590

### DIFF
--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		197ECB9D282D5D3D00CFA211 /* CachedImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 197ECB9C282D5D3D00CFA211 /* CachedImageProvider.swift */; };
+		197ECB9E282D5D3D00CFA211 /* CachedImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 197ECB9C282D5D3D00CFA211 /* CachedImageProvider.swift */; };
+		197ECB9F282D5D3D00CFA211 /* CachedImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 197ECB9C282D5D3D00CFA211 /* CachedImageProvider.swift */; };
 		2E044E272820536800FA773B /* AutomaticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E044E262820536800FA773B /* AutomaticEngineTests.swift */; };
 		2E09FA0627B6CEB600BA84E5 /* HardcodedFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E09FA0527B6CEB600BA84E5 /* HardcodedFontProvider.swift */; };
 		2E72128327BB329C0027BC56 /* AnimationKeypathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E72128227BB329C0027BC56 /* AnimationKeypathTests.swift */; };
@@ -572,6 +575,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		197ECB9C282D5D3D00CFA211 /* CachedImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedImageProvider.swift; sourceTree = "<group>"; };
 		2E044E262820536800FA773B /* AutomaticEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticEngineTests.swift; sourceTree = "<group>"; };
 		2E09FA0527B6CEB600BA84E5 /* HardcodedFontProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardcodedFontProvider.swift; sourceTree = "<group>"; };
 		2E72128227BB329C0027BC56 /* AnimationKeypathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationKeypathTests.swift; sourceTree = "<group>"; };
@@ -1353,6 +1357,7 @@
 				2EAF59D227A0798700E00531 /* FilepathImageProvider.swift */,
 				2EAF59D327A0798700E00531 /* AnimatedSwitch.swift */,
 				2EAF59D427A0798700E00531 /* BundleImageProvider.swift */,
+				197ECB9C282D5D3D00CFA211 /* CachedImageProvider.swift */,
 				2EAF59D527A0798700E00531 /* UIColorExtension.swift */,
 				2EAF59D627A0798700E00531 /* AnimatedButton.swift */,
 				2EAF59D727A0798700E00531 /* AnimationViewBase.swift */,
@@ -1720,6 +1725,7 @@
 				2EAF5AAD27A0798700E00531 /* AnimationView.swift in Sources */,
 				2E9C95E82822F43100677516 /* Merge.swift in Sources */,
 				2E9C96032822F43100677516 /* ImageLayerModel.swift in Sources */,
+				197ECB9D282D5D3D00CFA211 /* CachedImageProvider.swift in Sources */,
 				2E9C96BA2822F43100677516 /* KeypathSearchable.swift in Sources */,
 				2E9C963C2822F43100677516 /* AssetLibrary.swift in Sources */,
 				2E9C97022822F43100677516 /* PreCompLayer.swift in Sources */,
@@ -1925,6 +1931,7 @@
 				2EAF5AAE27A0798700E00531 /* AnimationView.swift in Sources */,
 				2E9C95E92822F43100677516 /* Merge.swift in Sources */,
 				2E9C96042822F43100677516 /* ImageLayerModel.swift in Sources */,
+				197ECB9E282D5D3D00CFA211 /* CachedImageProvider.swift in Sources */,
 				2E9C96BB2822F43100677516 /* KeypathSearchable.swift in Sources */,
 				2E9C963D2822F43100677516 /* AssetLibrary.swift in Sources */,
 				2E9C97032822F43100677516 /* PreCompLayer.swift in Sources */,
@@ -2110,6 +2117,7 @@
 				2EAF5AAF27A0798700E00531 /* AnimationView.swift in Sources */,
 				2E9C95EA2822F43100677516 /* Merge.swift in Sources */,
 				2E9C96052822F43100677516 /* ImageLayerModel.swift in Sources */,
+				197ECB9F282D5D3D00CFA211 /* CachedImageProvider.swift in Sources */,
 				2E9C96BC2822F43100677516 /* KeypathSearchable.swift in Sources */,
 				2E9C963E2822F43100677516 /* AssetLibrary.swift in Sources */,
 				2E9C97042822F43100677516 /* PreCompLayer.swift in Sources */,

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -102,7 +102,7 @@ final public class AnimationView: AnimationViewBase {
     configuration: LottieConfiguration = .shared)
   {
     self.animation = animation
-    self.imageProvider = imageProvider ?? BundleImageProvider(bundle: Bundle.main, searchPath: nil)
+    self.imageProvider = imageProvider ?? BundleImageProvider(bundle: Bundle.main, searchPath: nil).cachedImageProvider
     self.textProvider = textProvider
     self.fontProvider = fontProvider
     self.configuration = configuration
@@ -116,7 +116,7 @@ final public class AnimationView: AnimationViewBase {
 
   public init(configuration: LottieConfiguration = .shared) {
     animation = nil
-    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
+    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil).cachedImageProvider
     textProvider = DefaultTextProvider()
     fontProvider = DefaultFontProvider()
     self.configuration = configuration
@@ -126,7 +126,7 @@ final public class AnimationView: AnimationViewBase {
 
   public override init(frame: CGRect) {
     animation = nil
-    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
+    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil).cachedImageProvider
     textProvider = DefaultTextProvider()
     fontProvider = DefaultFontProvider()
     configuration = .shared
@@ -135,7 +135,7 @@ final public class AnimationView: AnimationViewBase {
   }
 
   required public init?(coder aDecoder: NSCoder) {
-    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
+    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil).cachedImageProvider
     textProvider = DefaultTextProvider()
     fontProvider = DefaultFontProvider()
     configuration = .shared

--- a/Sources/Public/Animation/AnimationViewInitializers.swift
+++ b/Sources/Public/Animation/AnimationViewInitializers.swift
@@ -26,7 +26,7 @@ extension AnimationView {
     animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache)
   {
     let animation = Animation.named(name, bundle: bundle, subdirectory: nil, animationCache: animationCache)
-    let provider = imageProvider ?? BundleImageProvider(bundle: bundle, searchPath: nil)
+    let provider = imageProvider ?? BundleImageProvider(bundle: bundle, searchPath: nil).cachedImageProvider
     self.init(animation: animation, imageProvider: provider)
   }
 
@@ -90,7 +90,7 @@ extension AnimationView {
     animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache)
   {
     let animation = Animation.asset(name, bundle: bundle, animationCache: animationCache)
-    let provider = imageProvider ?? BundleImageProvider(bundle: bundle, searchPath: nil)
+    let provider = imageProvider ?? BundleImageProvider(bundle: bundle, searchPath: nil).cachedImageProvider
     self.init(animation: animation, imageProvider: provider)
   }
 

--- a/Sources/Public/iOS/CachedImageProvider.swift
+++ b/Sources/Public/iOS/CachedImageProvider.swift
@@ -40,6 +40,8 @@ private final class CachedImageProvider: AnimationImageProvider {
 }
 
 extension AnimationImageProvider {
+  /// Create a cache enabled image provider which will reuse the asset image with the same asset id
+  /// It wraps the current provider as image loader, and uses `NSCache` to cache the images for resue.
   public var cachedImageProvider: AnimationImageProvider {
     CachedImageProvider(imageProvider: self)
   }

--- a/Sources/Public/iOS/CachedImageProvider.swift
+++ b/Sources/Public/iOS/CachedImageProvider.swift
@@ -1,0 +1,48 @@
+// Created by Jianjun Wu on 2022/5/12.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import CoreGraphics
+import Foundation
+#if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
+import UIKit
+
+// MARK: - CachedImageProvider
+
+private final class CachedImageProvider: AnimationImageProvider {
+
+  // MARK: Lifecycle
+
+  /// Initializes an image provider with an image provider
+  ///
+  /// - Parameter imageProvider: The provider to load image from asset
+  ///
+  public init(imageProvider: AnimationImageProvider) {
+    self.imageProvider = imageProvider
+  }
+
+  // MARK: Public
+
+  public func imageForAsset(asset: ImageAsset) -> CGImage? {
+    if let image = imageCache.object(forKey: asset.id as NSString) {
+      return image
+    }
+    if let image = imageProvider.imageForAsset(asset: asset) {
+      imageCache.setObject(image, forKey: asset.id as NSString)
+      return image
+    }
+    return nil
+  }
+
+  // MARK: Internal
+
+  let imageCache: NSCache<NSString, CGImage> = .init()
+  let imageProvider: AnimationImageProvider
+}
+
+extension AnimationImageProvider {
+  public var cachedImageProvider: AnimationImageProvider {
+    CachedImageProvider(imageProvider: self)
+  }
+}
+
+#endif

--- a/Tests/AutomaticEngineTests.swift
+++ b/Tests/AutomaticEngineTests.swift
@@ -18,7 +18,7 @@ final class AutomaticEngineTests: XCTestCase {
 
       let animationLayer = try XCTUnwrap(CoreAnimationLayer(
         animation: animation,
-        imageProvider: BundleImageProvider(bundle: Bundle.main, searchPath: nil),
+        imageProvider: BundleImageProvider(bundle: Bundle.main, searchPath: nil).cachedImageProvider,
         fontProvider: DefaultFontProvider(),
         compatibilityTrackerMode: .track))
 


### PR DESCRIPTION
As there are several image provider implementation classes, I create extension func to enable cache.
There is another way to implement the cache mechanism compared to PR https://github.com/airbnb/lottie-ios/pull/1590

## Change summary:
Before, the lottie animation create an image for each layer from asset. 
In this PR, the `BundleImageProvider ` is enhanced with image cache to reduce memory usage when creating layers with same asset.

## Please review:

|| before | after |
|-|-|-|
| Sample Lottie |![before](https://user-images.githubusercontent.com/105257537/168031411-22780506-be9f-48e8-8413-4eab7054c4f9.png) | ![after](https://user-images.githubusercontent.com/105257537/168031377-6a6bec86-e868-4ad6-9daf-e19b4cace63f.png)|  
