### PR TITLE
Tweak threshold for parsing performance test

### DIFF
--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -72,7 +72,7 @@ final class PerformanceTests: XCTestCase {
   func testParsing_complexAnimation() throws {
     let data = try XCTUnwrap(Bundle.module.getAnimationData("LottieLogo2", subdirectory: "Samples"))
     let ratio = try compareDeserializationPerformance(data: data, iterations: 500)
-    XCTAssertEqual(ratio, 2, accuracy: 0.5)
+    XCTAssertEqual(ratio, 1.7, accuracy: 0.5)
   }
 
   override func setUp() {


### PR DESCRIPTION
This PR tweaks the threshold for the `testParsing_complexAnimation()` performance test. I've seen this get as low as `1.3` in CI, which has caused a few spurious failures.