### PR TITLE
Tweak threshold for parsing performance test again

### DIFF
--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -72,7 +72,7 @@ final class PerformanceTests: XCTestCase {
   func testParsing_complexAnimation() throws {
     let data = try XCTUnwrap(Bundle.module.getAnimationData("LottieLogo2", subdirectory: "Samples"))
     let ratio = try compareDeserializationPerformance(data: data, iterations: 500)
-    XCTAssertEqual(ratio, 1.7, accuracy: 0.5)
+    XCTAssertEqual(ratio, 1.7, accuracy: 0.6)
   }
 
   override func setUp() {


### PR DESCRIPTION
I noticed another spurious CI failure where this performance test got `2.2014`, which is just outside of the current range (`1.2`-`2.2`). This PR expands the threshold a bit more.