### PR TITLE
Fix issue where some animations would unexpectedly allocate a very large amounts of memory

### DIFF
--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -118,7 +118,12 @@ final class CoreAnimationLayer: BaseAnimationLayer {
   }
 
   override func display() {
-    super.display()
+    // We intentionally don't call `super.display()`, since this layer
+    // doesn't directly render any content.
+    //  - This fixes an issue where certain animations would unexpectedly
+    //    allocate a very large amount of memory (400mb+).
+    //  - Alternatively this layer could subclass `CATransformLayer`,
+    //    but this causes Core Animation to emit unnecessary logs.
 
     if let pendingAnimationConfiguration = pendingAnimationConfiguration {
       self.pendingAnimationConfiguration = nil


### PR DESCRIPTION
This PR fixes an issue where some animations would unexpectedly allocate a very large amount of memory (400mb+). I'm not exactly sure what was causing this, but the Allocations instrument says the memory is being allocated by the `super.display()` call in `CoreAnimationLayer.display`. 

Since that layer doesn't render any content directly, we can just remove the `super.display()` call without experiencing any behavior changes. Alternatively we could have `CoreAnimationLayer` subclass `CATransformLayer`, which also works but causes some unwanted log output:

> <Lottie.CoreAnimationLayer: 0x7fce30d14c10> - changing property contentsScale in transform-only layer, will have no effect