### PR TITLE
Update Core Animation engine to explicitly not support time remapping keyframes with `isHold = true`

### DIFF
--- a/Sources/Private/CoreAnimation/Layers/PreCompLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/PreCompLayer.swift
@@ -97,14 +97,13 @@ extension KeyframeInterpolator where ValueType == AnimationFrameTime {
     keyframes timeRemappingKeyframes: KeyframeGroup<Vector1D>,
     context: LayerContext)
     throws
-    -> KeyframeInterpolator<AnimationFrameTime>?
+    -> KeyframeInterpolator<AnimationFrameTime>
   {
     // The Core Animation engine doesn't support time remapping keyframes that use `isHold = true`
     //  - We may be able to add support for this in the future
-    guard !timeRemappingKeyframes.keyframes.contains(where: { $0.isHold }) else {
+    if timeRemappingKeyframes.keyframes.contains(where: { $0.isHold }) {
       try context.logCompatibilityIssue(
         "The Core Animation rendering engine doesn't support time remapping keyframes with `isHold = true`")
-      return nil
     }
 
     // `timeRemapping` is a mapping from the animation's global time to the layer's local time.

--- a/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.timeremap.txt
+++ b/Tests/__Snapshots__/AutomaticEngineTests/testAutomaticEngineDetection.timeremap.txt
@@ -1,1 +1,2 @@
-Supports Core Animation engine
+Does not support Core Animation engine. Encountered compatibility issues:
+[Freeze] The Core Animation rendering engine doesn't support time remapping keyframes with `isHold = true`


### PR DESCRIPTION
This PR updates the Core Animation engine to explicitly not support time remapping keyframes with `isHold = true`. This is not supported right now, but previously failed silently. We may be able to support this in the future, but for now we should fall back to using the main thread engine in this case.

| Before | After |
| ----- | ----- |
| ![2022-05-18 10 37 19](https://user-images.githubusercontent.com/1811727/169108284-e1b5434e-eb12-42a2-9252-94b5994ae68a.gif) | ![2022-05-18 10 36 49](https://user-images.githubusercontent.com/1811727/169108299-1b7443ed-01fb-4d84-89bf-c85cf5884737.gif) |