### PR TITLE
Fix mysterious crash due to reentrant PreCompLayer.init call

### DIFF
--- a/Sources/Private/CoreAnimation/Layers/LayerModel+makeAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/LayerModel+makeAnimationLayer.swift
@@ -29,7 +29,9 @@ extension LayerModel {
 
     switch (type, self) {
     case (.precomp, let preCompLayerModel as PreCompLayerModel):
-      return try PreCompLayer(preCompLayer: preCompLayerModel, context: context)
+      let preCompLayer = PreCompLayer(preCompLayer: preCompLayerModel)
+      try preCompLayer.setup(context: context)
+      return preCompLayer
 
     case (.solid, let solidLayerModel as SolidLayerModel):
       return SolidLayer(solidLayerModel)


### PR DESCRIPTION
As far as I can tell, this PR fixes a mysterious crash that appears to have been caused by reentrant calls to `PreCompLayer.init`.

I haven't been able to reproduce this crash a single time locally. @thedrick was able to repro this crash 100% of the time on a certain page, and he confirmed that this change fixed the issue for him.