### PR TITLE
Update Gemfile.lock PLATFORMS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
-  x86_64-darwin-19
+  ruby
 
 DEPENDENCIES
   cocoapods (~> 1.11.0)!


### PR DESCRIPTION
This PR updates `PLATFORMS` in `Gemfile.lock`

I got a new M1 laptop this week, and noticed that ruby keeps adding `universal-darwin-21` to the list of platforms in `Gemfile.lock`:

```diff
 PLATFORMS
+  universal-darwin-21
   x86_64-darwin-19
```

I noticed that Epoxy just [lists `ruby`](https://github.com/airbnb/epoxy-ios/blob/master/Gemfile.lock#L92) under its platforms. Not totally sure what this means but it seems to make ruby happy without having to list multiple different platforms here.