### PR TITLE
Fix AnimationView.isAnimationPlaying for Core Animation engine

### DIFF
--- a/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
+++ b/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
@@ -86,7 +86,10 @@ class AnimationPreviewViewController: UIViewController {
       slider.value = Float(animationView.realtimeAnimationProgress)
     }
 
-    engineLabel.text = animationView.currentRenderingEngine?.description
+    engineLabel.text = [
+      animationView.currentRenderingEngine?.description,
+      animationView.isAnimationPlaying ? "Playing" : "Paused",
+    ].compactMap { $0 }.joined(separator: " · ")
   }
 
   override func viewDidAppear(_ animated: Bool) {

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -294,6 +294,15 @@ extension CoreAnimationLayer: RootAnimationLayer {
     .specific(#keyPath(animationProgress))
   }
 
+  var isAnimationPlaying: Bool? {
+    switch playbackState {
+    case .playing:
+      return true
+    case nil, .paused:
+      return false
+    }
+  }
+
   var currentFrame: AnimationFrameTime {
     get {
       switch playbackState {

--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -146,6 +146,10 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
     .managed
   }
 
+  var isAnimationPlaying: Bool? {
+    nil // this state is managed by `AnimationView`
+  }
+
   var _animationLayers: [CALayer] {
     Array(animationLayers)
   }

--- a/Sources/Private/RootAnimationLayer.swift
+++ b/Sources/Private/RootAnimationLayer.swift
@@ -20,6 +20,11 @@ protocol RootAnimationLayer: CALayer {
   ///  - `AnimationView` uses this key to check if the animation is still active
   var primaryAnimationKey: AnimationKey { get }
 
+  /// Whether or not this layer is currently playing an animation
+  ///  - If the layer returns `nil`, `AnimationView` determines if an animation
+  ///    is playing by checking if there is an active animation for `primaryAnimationKey`
+  var isAnimationPlaying: Bool? { get }
+
   /// Instructs this layer to remove all `CAAnimation`s,
   /// other than the `CAAnimation` managed by `AnimationView` (if applicable)
   func removeAnimations()

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -222,7 +222,15 @@ final public class AnimationView: AnimationViewBase {
 
   /// Returns `true` if the animation is currently playing.
   public var isAnimationPlaying: Bool {
-    animationLayer?.animation(forKey: activeAnimationName) != nil
+    guard let animationLayer = animationLayer else {
+      return false
+    }
+
+    if let valueFromLayer = animationLayer.isAnimationPlaying {
+      return valueFromLayer
+    } else {
+      return animationLayer.animation(forKey: activeAnimationName) != nil
+    }
   }
 
   /// Returns `true` if the animation will start playing when this view is added to a window.


### PR DESCRIPTION
This PR fixes `AnimationView.isAnimationPlaying` for the Core Animation engine. Previously is returned `true` even when the animation was paused on a specific frame.

| Before | After |
| ----- | ---- |
| ![2022-05-25 09 14 58](https://user-images.githubusercontent.com/1811727/170313701-1eef8a3b-90d7-47ba-b687-411e04ce1f6e.gif) | ![2022-05-25 09 22 25](https://user-images.githubusercontent.com/1811727/170313734-db55ab95-f591-4bc2-980a-599d0be96bfa.gif) |