### PR TITLE
Simplify issue template, link to GitHub discussions page

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,30 +1,15 @@
 <!--
-## Lottie-iOS Issue
 Hello! Sorry you're having an Issue! Please help us make Lottie better by filling everything below out with as much information as you can, so we can try to reproduce and fix the issue!
+
+Issues are for filing bug reports about crashes, regressions, unexpected behavior, etc.
+
+If you have a question or feature request, please start a discussion here:
+https://github.com/airbnb/lottie-ios/discussions
 -->
-
-## Check these before submitting:
-- [] The issue doesn't involve an [Unsupported Feature](https://github.com/airbnb/lottie-ios/blob/master/README.md#supported-after-effects-features)
-- [] This issue isn't related to another open issue
-
-## This issue is a:
-- [] Non-Crashing Bug (Visual or otherwise)
-- [] Crashing Bug
-- [] Feature Request
-- [] Regression (Something that once worked, but doesn't work anymore)
 
 ## Which Version of Lottie are you using?
 
-Lottie 3.0
-
-## What Platform are you on? 
-<!-- (Specify Platform Version) -->
-- [] MacOS
-- [] iOS
-
-## What Language are you in?
-- [] Swift
-- [] Objective-C
+Lottie 3.x.x
 
 ## Expected Behavior 
 <!-- Screenshots encouraged -->
@@ -32,7 +17,5 @@ Lottie 3.0
 ## Actual Behavior
 <!-- Screenshots encouraged -->
 
-## Code Example
-
 ## Animation JSON
-<!-- Adding the animation JSON helps us debug the issue faster!  If you don't want to publicly share the Animation, please email me brandon@withrow.io -->
+<!-- Adding the animation JSON helps us debug the issue faster! -->


### PR DESCRIPTION
This PR simplifies the repo's issue template, and adds a link to the GitHub discussions page.

I enabled the GitHub discussions site, because it seems like a good place to host user questions and announcements.