### PR TITLE
Add a LottieLogger param to AnimationView

### DIFF
--- a/Sources/Private/CoreAnimation/Animations/CALayer+addAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CALayer+addAnimation.swift
@@ -140,7 +140,7 @@ extension CALayer {
     if property.caLayerKeypath == LayerProperty<CGPoint>.position.caLayerKeypath {
       animation.path = try path(keyframes: keyframes, value: { value in
         guard let point = try keyframeValueMapping(value) as? CGPoint else {
-          LottieLogger.shared.assertionFailure("Cannot create point from keyframe with value \(value)")
+          context.logger.assertionFailure("Cannot create point from keyframe with value \(value)")
           return .zero
         }
 
@@ -154,7 +154,13 @@ extension CALayer {
         try keyframeValueMapping(keyframeModel.value)
       }
 
-      validate(values: &values, keyTimes: &keyTimes, timingFunctions: &timingFunctions, for: calculationMode)
+      validate(
+        values: &values,
+        keyTimes: &keyTimes,
+        timingFunctions: &timingFunctions,
+        for: calculationMode,
+        context: context)
+
       animation.values = values
     }
 
@@ -265,7 +271,8 @@ extension CALayer {
     values: inout [ValueRepresentation],
     keyTimes: inout [NSNumber],
     timingFunctions: inout [CAMediaTimingFunction],
-    for calculationMode: CAAnimationCalculationMode)
+    for calculationMode: CAAnimationCalculationMode,
+    context: LayerAnimationContext)
   {
     // Validate that we have correct start (0.0) and end (1.0) keyframes.
     // From the documentation of `CAKeyframeAnimation.keyTimes`:
@@ -287,11 +294,11 @@ extension CALayer {
       // From the documentation of `CAKeyframeAnimation.keyTimes`:
       //  - The number of elements in the keyTimes array
       //    should match the number of elements in the values property
-      LottieLogger.shared.assert(
+      context.logger.assert(
         values.count == keyTimes.count,
         "`values.count` must exactly equal `keyTimes.count`")
 
-      LottieLogger.shared.assert(
+      context.logger.assert(
         timingFunctions.count == (values.count - 1),
         "`timingFunctions.count` must exactly equal `values.count - 1`")
 
@@ -301,12 +308,12 @@ extension CALayer {
       //    should have one more entry than appears in the values array.
       values.removeLast()
 
-      LottieLogger.shared.assert(
+      context.logger.assert(
         keyTimes.count == values.count + 1,
         "`keyTimes.count` must exactly equal `values.count + 1`")
 
     default:
-      LottieLogger.shared.assertionFailure("""
+      context.logger.assertionFailure("""
         Unexpected keyframe calculation mode \(calculationMode)
         """)
     }

--- a/Sources/Private/CoreAnimation/Animations/TransformAnimations.swift
+++ b/Sources/Private/CoreAnimation/Animations/TransformAnimations.swift
@@ -109,7 +109,7 @@ extension CALayer {
       keyframes: transformModel.anchorPoint.keyframes,
       value: { absoluteAnchorPoint in
         guard bounds.width > 0, bounds.height > 0 else {
-          LottieLogger.shared.assertionFailure("Size must be non-zero before an animation can be played")
+          context.logger.assertionFailure("Size must be non-zero before an animation can be played")
           return .zero
         }
 
@@ -152,7 +152,7 @@ extension CALayer {
     //    in surprising ways that don't happen at runtime. Definitely not ideal.
     if TestHelpers.snapshotTestsAreRunning {
       if transformModel.scale.keyframes.contains(where: { $0.value.x < 0 }) {
-        LottieLogger.shared.warn("""
+        context.logger.warn("""
           Negative `scale.x` values are not displayed correctly in snapshot tests
           """)
       }

--- a/Sources/Private/CoreAnimation/CompatibilityTracker.swift
+++ b/Sources/Private/CoreAnimation/CompatibilityTracker.swift
@@ -20,8 +20,9 @@ final class CompatibilityTracker {
 
   // MARK: Lifecycle
 
-  init(mode: Mode) {
+  init(mode: Mode, logger: LottieLogger) {
     self.mode = mode
+    self.logger = logger
   }
 
   // MARK: Internal
@@ -42,7 +43,7 @@ final class CompatibilityTracker {
 
   /// Records a compatibility issue that will be reported according to `CompatibilityTracker.Mode`
   func logIssue(message: String, context: String) throws {
-    LottieLogger.shared.assert(!context.isEmpty, "Compatibility issue context is unexpectedly empty")
+    logger.assert(!context.isEmpty, "Compatibility issue context is unexpectedly empty")
 
     let issue = CompatibilityIssue(
       // Compatibility messages are usually written in source files using multi-line strings,
@@ -81,6 +82,7 @@ final class CompatibilityTracker {
   // MARK: Private
 
   private let mode: Mode
+  private let logger: LottieLogger
 
   /// Compatibility issues encountered while setting up the animation
   private var issues = [CompatibilityIssue]()

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -18,13 +18,16 @@ final class CoreAnimationLayer: BaseAnimationLayer {
     animation: Animation,
     imageProvider: AnimationImageProvider,
     fontProvider: AnimationFontProvider,
-    compatibilityTrackerMode: CompatibilityTracker.Mode)
+    compatibilityTrackerMode: CompatibilityTracker.Mode,
+    logger: LottieLogger)
     throws
   {
     self.animation = animation
     self.imageProvider = imageProvider
     self.fontProvider = fontProvider
-    compatibilityTracker = CompatibilityTracker(mode: compatibilityTrackerMode)
+    self.logger = logger
+    compatibilityTracker = CompatibilityTracker(mode: compatibilityTrackerMode, logger: logger)
+    valueProviderStore = ValueProviderStore(logger: logger)
     super.init()
 
     setup()
@@ -44,6 +47,8 @@ final class CoreAnimationLayer: BaseAnimationLayer {
     fontProvider = typedLayer.fontProvider
     didSetUpAnimation = typedLayer.didSetUpAnimation
     compatibilityTracker = typedLayer.compatibilityTracker
+    logger = typedLayer.logger
+    valueProviderStore = typedLayer.valueProviderStore
     super.init(layer: typedLayer)
   }
 
@@ -170,8 +175,9 @@ final class CoreAnimationLayer: BaseAnimationLayer {
   @objc private var animationProgress: CGFloat = 0
 
   private let animation: Animation
-  private let valueProviderStore = ValueProviderStore()
+  private let valueProviderStore: ValueProviderStore
   private let compatibilityTracker: CompatibilityTracker
+  private let logger: LottieLogger
 
   /// The current playback state of the animation that is displayed in this layer
   private var currentPlaybackState: PlaybackState? {
@@ -226,6 +232,7 @@ final class CoreAnimationLayer: BaseAnimationLayer {
       endFrame: configuration.animationContext.playTo,
       valueProviderStore: valueProviderStore,
       compatibilityTracker: compatibilityTracker,
+      logger: logger,
       currentKeypath: AnimationKeypath(keys: []))
 
     // Perform a layout pass if necessary so all of the sublayers
@@ -354,7 +361,7 @@ extension CoreAnimationLayer: RootAnimationLayer {
 
   var respectAnimationFrameRate: Bool {
     get { false }
-    set { LottieLogger.shared.assertionFailure("`respectAnimationFrameRate` is currently unsupported") }
+    set { logger.assertionFailure("`respectAnimationFrameRate` is currently unsupported") }
   }
 
   var _animationLayers: [CALayer] {
@@ -363,7 +370,7 @@ extension CoreAnimationLayer: RootAnimationLayer {
 
   var textProvider: AnimationTextProvider {
     get { DictionaryTextProvider([:]) }
-    set { LottieLogger.shared.assertionFailure("`textProvider` is currently unsupported") }
+    set { logger.assertionFailure("`textProvider` is currently unsupported") }
   }
 
   func reloadImages() {
@@ -403,26 +410,26 @@ extension CoreAnimationLayer: RootAnimationLayer {
   }
 
   func getValue(for _: AnimationKeypath, atFrame _: AnimationFrameTime?) -> Any? {
-    LottieLogger.shared.assertionFailure("""
+    logger.assertionFailure("""
       The Core Animation rendering engine doesn't support querying values for individual frames
       """)
     return nil
   }
 
   func getOriginalValue(for _: AnimationKeypath, atFrame _: AnimationFrameTime?) -> Any? {
-    LottieLogger.shared.assertionFailure("""
+    logger.assertionFailure("""
       The Core Animation rendering engine doesn't support querying values for individual frames
       """)
     return nil
   }
 
   func layer(for _: AnimationKeypath) -> CALayer? {
-    LottieLogger.shared.assertionFailure("`AnimationKeypath`s are currently unsupported")
+    logger.assertionFailure("`AnimationKeypath`s are currently unsupported")
     return nil
   }
 
   func animatorNodes(for _: AnimationKeypath) -> [AnimatorNode]? {
-    LottieLogger.shared.assertionFailure("`AnimatorNode`s are not used in this rendering implementation")
+    logger.assertionFailure("`AnimatorNode`s are not used in this rendering implementation")
     return nil
   }
 

--- a/Sources/Private/CoreAnimation/Layers/AnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/AnimationLayer.swift
@@ -35,6 +35,9 @@ struct LayerAnimationContext {
   /// Information about whether or not an animation is compatible with the Core Animation engine
   let compatibilityTracker: CompatibilityTracker
 
+  /// The logger that should be used for assertions and warnings
+  let logger: LottieLogger
+
   /// The AnimationKeypath represented by the current layer
   var currentKeypath: AnimationKeypath
 

--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -9,11 +9,17 @@ import QuartzCore
 /// provide custom values for `AnimationKeypath`s within an `Animation`.
 final class ValueProviderStore {
 
+  // MARK: Lifecycle
+
+  init(logger: LottieLogger) {
+    self.logger = logger
+  }
+
   // MARK: Internal
 
   /// Registers an `AnyValueProvider` for the given `AnimationKeypath`
   func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath) {
-    LottieLogger.shared.assert(
+    logger.assert(
       valueProvider.typeErasedStorage.isSupportedByCoreAnimationRenderingEngine,
       """
       The Core Animation rendering engine doesn't support Value Providers that vend a closure,
@@ -21,7 +27,7 @@ final class ValueProviderStore {
       """)
 
     // TODO: Support more value types
-    LottieLogger.shared.assert(
+    logger.assert(
       keypath.keys.last == PropertyName.color.rawValue,
       "The Core Animation rendering engine currently only supports customizing color values")
 
@@ -61,7 +67,7 @@ final class ValueProviderStore {
     // Convert the type-erased keyframe values using this `CustomizableProperty`'s conversion closure
     let typedKeyframes = typeErasedKeyframes.compactMap { typeErasedKeyframe -> Keyframe<Value>? in
       guard let convertedValue = customizableProperty.conversion(typeErasedKeyframe.value) else {
-        LottieLogger.shared.assertionFailure("""
+        logger.assertionFailure("""
           Could not convert value of type \(type(of: typeErasedKeyframe.value)) to expected type \(Value.self)
           """)
         return nil
@@ -79,6 +85,8 @@ final class ValueProviderStore {
   }
 
   // MARK: Private
+
+  private let logger: LottieLogger
 
   private var valueProviders = [(keypath: AnimationKeypath, valueProvider: AnyValueProvider)]()
 

--- a/Tests/AutomaticEngineTests.swift
+++ b/Tests/AutomaticEngineTests.swift
@@ -20,7 +20,8 @@ final class AutomaticEngineTests: XCTestCase {
         animation: animation,
         imageProvider: BundleImageProvider(bundle: Bundle.main, searchPath: nil),
         fontProvider: DefaultFontProvider(),
-        compatibilityTrackerMode: .track))
+        compatibilityTrackerMode: .track,
+        logger: .shared))
 
       animationLayer.didSetUpAnimation = { issues in
         compatibilityIssues = issues


### PR DESCRIPTION
This PR adds a `logger: LottieLogger = .shared` param to `AnimationView`, so consumers can customize the logger both globally (via `LottieLogger.shared`) and on a per-instance basis (like you can already do with `LottieConfiguration`).

As an example, this is useful for cases where using `renderingEngine: .coreAnimation` emits an assertion but you want to use the Core Animation engine anyway. An option there is to pass in `logger: .printToConsole`, which suppresses any animation validation assertions.