### PR TITLE
Add .spi.yml for DocC documentation on Swift Package Index site

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,6 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets:
+      - Lottie


### PR DESCRIPTION
This PR adds a `.spi.yml` file so [Swift Package Index](https://swiftpackageindex.com/airbnb/lottie-ios) will generate DocC documentation