### PR TITLE
`NSImage.CGImage` ⇒ `.lottie_CGImage` to avoid category warning.

### DIFF
--- a/Sources/Public/macOS/BundleImageProvider.macOS.swift
+++ b/Sources/Public/macOS/BundleImageProvider.macOS.swift
@@ -34,7 +34,7 @@ public class BundleImageProvider: AnimationImageProvider {
       let data = Data(imageAsset: asset),
       let image = NSImage(data: data)
     {
-      return image.CGImage
+      return image.lottie_CGImage
     }
 
     let imagePath: String?
@@ -68,7 +68,7 @@ public class BundleImageProvider: AnimationImageProvider {
       LottieLogger.shared.assertionFailure("Could not find image \"\(asset.name)\" in bundle")
       return nil
     }
-    return image.CGImage
+    return image.lottie_CGImage
   }
 
   // MARK: Internal

--- a/Sources/Public/macOS/FilepathImageProvider.macOS.swift
+++ b/Sources/Public/macOS/FilepathImageProvider.macOS.swift
@@ -35,18 +35,18 @@ public class FilepathImageProvider: AnimationImageProvider {
       let data = try? Data(contentsOf: url),
       let image = NSImage(data: data)
     {
-      return image.CGImage
+      return image.lottie_CGImage
     }
 
     let directPath = filepath.appendingPathComponent(asset.name).path
     if FileManager.default.fileExists(atPath: directPath) {
 
-      return NSImage(contentsOfFile: directPath)?.CGImage
+      return NSImage(contentsOfFile: directPath)?.lottie_CGImage
     }
 
     let pathWithDirectory = filepath.appendingPathComponent(asset.directory).appendingPathComponent(asset.name).path
     if FileManager.default.fileExists(atPath: pathWithDirectory) {
-      return NSImage(contentsOfFile: pathWithDirectory)?.CGImage
+      return NSImage(contentsOfFile: pathWithDirectory)?.lottie_CGImage
     }
 
     LottieLogger.shared.assertionFailure("Could not find image \"\(asset.name)\" in bundle")
@@ -60,7 +60,7 @@ public class FilepathImageProvider: AnimationImageProvider {
 
 extension NSImage {
   @nonobjc
-  var CGImage: CGImage? {
+  var lottie_CGImage: CGImage? {
     guard let imageData = tiffRepresentation else { return nil }
     guard let sourceData = CGImageSourceCreateWithData(imageData as CFData, nil) else { return nil }
     return CGImageSourceCreateImageAtIndex(sourceData, 0, nil)


### PR DESCRIPTION
Unfortunately https://github.com/airbnb/lottie-ios/pull/1501 doesn’t fix the category warning when using Lottie on macOS. Would y’all be open to namespacing the extension?

<img width="760" alt="Screen Shot 2022-06-27 at 5 11 19 PM" src="https://user-images.githubusercontent.com/1276296/176038970-b0fe8fec-ef85-46ab-9cf3-2bdacf456afd.png">