### PR TITLE
Add `logHierarchyKeypaths()` support to Core Animation rendering engine

### DIFF
--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -400,9 +400,7 @@ extension CoreAnimationLayer: RootAnimationLayer {
   }
 
   func forceDisplayUpdate() {
-    rebuildCurrentAnimation()
-    setNeedsDisplay()
-    displayIfNeeded()
+    // Unimplemented / unused
   }
 
   func logHierarchyKeypaths() {
@@ -417,7 +415,7 @@ extension CoreAnimationLayer: RootAnimationLayer {
     // This allows the consumer to know what keypaths can be customized in their animation.
     configuration.logHierarchyKeypaths = true
     rebuildCurrentAnimation(with: configuration)
-    forceDisplayUpdate()
+    displayIfNeeded()
   }
 
   func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath) {

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -74,6 +74,13 @@ final class CoreAnimationLayer: BaseAnimationLayer {
     case paused(frame: AnimationFrameTime)
   }
 
+  /// Configuration used by the `playAnimation` method
+  struct AnimationConfiguration: Equatable {
+    var animationContext: AnimationContext
+    var timingConfiguration: CAMediaTimingConfiguration
+    var logHierarchyKeypaths = false
+  }
+
   /// A closure that is called after this layer sets up its animation.
   /// If the animation setup was unsuccessful and encountered compatibility issues,
   /// those issues are included in this call.
@@ -97,12 +104,11 @@ final class CoreAnimationLayer: BaseAnimationLayer {
   ///     is called multiple times in the same run loop cycle, the animation
   ///     will only be set up a single time.
   func playAnimation(
-    context: AnimationContext,
-    timingConfiguration: CAMediaTimingConfiguration,
+    configuration: AnimationConfiguration,
     playbackState: PlaybackState = .playing)
   {
     pendingAnimationConfiguration = (
-      animationConfiguration: .init(animationContext: context, timingConfiguration: timingConfiguration),
+      animationConfiguration: configuration,
       playbackState: playbackState)
 
     setNeedsDisplay()
@@ -129,7 +135,6 @@ final class CoreAnimationLayer: BaseAnimationLayer {
     //    allocate a very large amount of memory (400mb+).
     //  - Alternatively this layer could subclass `CATransformLayer`,
     //    but this causes Core Animation to emit unnecessary logs.
-
     if let pendingAnimationConfiguration = pendingAnimationConfiguration {
       self.pendingAnimationConfiguration = nil
 
@@ -155,11 +160,6 @@ final class CoreAnimationLayer: BaseAnimationLayer {
   }
 
   // MARK: Private
-
-  private struct AnimationConfiguration: Equatable {
-    let animationContext: AnimationContext
-    let timingConfiguration: CAMediaTimingConfiguration
-  }
 
   /// The configuration for the most recent animation which has been
   /// queued by calling `playAnimation` but not yet actually set up
@@ -233,7 +233,8 @@ final class CoreAnimationLayer: BaseAnimationLayer {
       valueProviderStore: valueProviderStore,
       compatibilityTracker: compatibilityTracker,
       logger: logger,
-      currentKeypath: AnimationKeypath(keys: []))
+      currentKeypath: AnimationKeypath(keys: []),
+      logHierarchyKeypaths: configuration.logHierarchyKeypaths)
 
     // Perform a layout pass if necessary so all of the sublayers
     // have the most up-to-date sizing information
@@ -268,7 +269,7 @@ final class CoreAnimationLayer: BaseAnimationLayer {
 
   // Removes the current `CAAnimation`s, and rebuilds new animations
   // using the same configuration as the previous animations.
-  private func rebuildCurrentAnimation() {
+  private func rebuildCurrentAnimation(with newConfiguration: AnimationConfiguration? = nil) {
     guard
       let currentConfiguration = currentAnimationConfiguration,
       let playbackState = playbackState,
@@ -276,7 +277,15 @@ final class CoreAnimationLayer: BaseAnimationLayer {
       // on the next run loop cycle, since an existing pending animation
       // will cause the animation to be rebuilt anyway.
       pendingAnimationConfiguration == nil
-    else { return }
+    else {
+      // If we already have a pending animation setup pass, but a new configuration was provided,
+      // replace the pending configuration with the new configuration
+      if let newConfiguration = newConfiguration {
+        pendingAnimationConfiguration?.animationConfiguration = newConfiguration
+      }
+
+      return
+    }
 
     removeAnimations()
 
@@ -285,9 +294,7 @@ final class CoreAnimationLayer: BaseAnimationLayer {
       currentFrame = frame
 
     case .playing:
-      playAnimation(
-        context: currentConfiguration.animationContext,
-        timingConfiguration: currentConfiguration.timingConfiguration)
+      playAnimation(configuration: newConfiguration ?? currentConfiguration)
     }
   }
 
@@ -341,8 +348,7 @@ extension CoreAnimationLayer: RootAnimationLayer {
 
       else {
         playAnimation(
-          context: requiredAnimationConfiguration.animationContext,
-          timingConfiguration: requiredAnimationConfiguration.timingConfiguration,
+          configuration: requiredAnimationConfiguration,
           playbackState: .paused(frame: newValue))
       }
     }
@@ -394,11 +400,24 @@ extension CoreAnimationLayer: RootAnimationLayer {
   }
 
   func forceDisplayUpdate() {
-    // Unimplemented / unused
+    rebuildCurrentAnimation()
+    setNeedsDisplay()
+    displayIfNeeded()
   }
 
   func logHierarchyKeypaths() {
-    // Unimplemented / unused
+    guard var configuration = pendingAnimationConfiguration?.animationConfiguration ?? currentAnimationConfiguration else {
+      logger.print("Cannot log hierarchy keypaths until animation has been set up at least once")
+      return
+    }
+
+    logger.print("Lottie: Rebuilding animation with hierarchy keypath logging enabled")
+
+    // Rebuild the animation with `logHierarchyKeypaths = true` so the `ValueProviderStore` will log any keypath lookups that occur.
+    // This allows the consumer to know what keypaths can be customized in their animation.
+    configuration.logHierarchyKeypaths = true
+    rebuildCurrentAnimation(with: configuration)
+    forceDisplayUpdate()
   }
 
   func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath) {

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -367,7 +367,11 @@ extension CoreAnimationLayer: RootAnimationLayer {
 
   var respectAnimationFrameRate: Bool {
     get { false }
-    set { logger.assertionFailure("`respectAnimationFrameRate` is currently unsupported") }
+    set {
+      logger.assertionFailure("""
+        The Core Animation rendering engine currently doesn't support `respectAnimationFrameRate`)
+        """)
+    }
   }
 
   var _animationLayers: [CALayer] {
@@ -376,7 +380,11 @@ extension CoreAnimationLayer: RootAnimationLayer {
 
   var textProvider: AnimationTextProvider {
     get { DictionaryTextProvider([:]) }
-    set { logger.assertionFailure("`textProvider` is currently unsupported") }
+    set {
+      logger.assertionFailure("""
+        The Core Animation rendering engine currently doesn't support `textProvider`s")
+        """)
+    }
   }
 
   func reloadImages() {
@@ -441,12 +449,16 @@ extension CoreAnimationLayer: RootAnimationLayer {
   }
 
   func layer(for _: AnimationKeypath) -> CALayer? {
-    logger.assertionFailure("`AnimationKeypath`s are currently unsupported")
+    logger.assertionFailure("""
+      The Core Animation rendering engine doesn't support retrieving `CALayer`s by keypath
+      """)
     return nil
   }
 
   func animatorNodes(for _: AnimationKeypath) -> [AnimatorNode]? {
-    logger.assertionFailure("`AnimatorNode`s are not used in this rendering implementation")
+    logger.assertionFailure("""
+      The Core Animation rendering engine does not use `AnimatorNode`s
+      """)
     return nil
   }
 

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -413,11 +413,11 @@ extension CoreAnimationLayer: RootAnimationLayer {
 
   func logHierarchyKeypaths() {
     guard var configuration = pendingAnimationConfiguration?.animationConfiguration ?? currentAnimationConfiguration else {
-      logger.print("Cannot log hierarchy keypaths until animation has been set up at least once")
+      logger.info("Cannot log hierarchy keypaths until animation has been set up at least once")
       return
     }
 
-    logger.print("Lottie: Rebuilding animation with hierarchy keypath logging enabled")
+    logger.info("Lottie: Rebuilding animation with hierarchy keypath logging enabled")
 
     // Rebuild the animation with `logHierarchyKeypaths = true` so the `ValueProviderStore` will log any keypath lookups that occur.
     // This allows the consumer to know what keypaths can be customized in their animation.

--- a/Sources/Private/CoreAnimation/Layers/AnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/AnimationLayer.swift
@@ -41,6 +41,10 @@ struct LayerAnimationContext {
   /// The AnimationKeypath represented by the current layer
   var currentKeypath: AnimationKeypath
 
+  /// Whether or not to log `AnimationKeypath`s for all of the animation's layers
+  ///  - Used for `CoreAnimationLayer.logHierarchyKeypaths()`
+  var logHierarchyKeypaths: Bool
+
   /// A closure that remaps the given frame in the child layer's local time to a frame
   /// in the animation's overall global time
   private(set) var timeRemapping: ((AnimationFrameTime) -> AnimationFrameTime) = { $0 }

--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -44,7 +44,7 @@ final class ValueProviderStore {
     -> KeyframeGroup<Value>?
   {
     if context.logHierarchyKeypaths {
-      context.logger.print(keypath.fullPath)
+      context.logger.info(keypath.fullPath)
     }
 
     guard let anyValueProvider = valueProvider(for: keypath) else {

--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -43,6 +43,10 @@ final class ValueProviderStore {
     throws
     -> KeyframeGroup<Value>?
   {
+    if context.logHierarchyKeypaths {
+      context.logger.print(keypath.fullPath)
+    }
+
     guard let anyValueProvider = valueProvider(for: keypath) else {
       return nil
     }

--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -22,12 +22,14 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
     animation: Animation,
     imageProvider: AnimationImageProvider,
     textProvider: AnimationTextProvider,
-    fontProvider: AnimationFontProvider)
+    fontProvider: AnimationFontProvider,
+    logger: LottieLogger)
   {
     layerImageProvider = LayerImageProvider(imageProvider: imageProvider, assets: animation.assetLibrary?.imageAssets)
     layerTextProvider = LayerTextProvider(textProvider: textProvider)
     layerFontProvider = LayerFontProvider(fontProvider: fontProvider)
     animationLayers = []
+    self.logger = logger
     super.init()
     bounds = animation.bounds
     let layers = animation.layers.initializeCompositionLayers(
@@ -76,17 +78,21 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
     setNeedsDisplay()
   }
 
-  /// For CAAnimation Use
-  public override init(layer: Any) {
+  /// Called by CoreAnimation to create a shadow copy of this layer
+  /// More details: https://developer.apple.com/documentation/quartzcore/calayer/1410842-init
+  override init(layer: Any) {
+    guard let typedLayer = layer as? Self else {
+      fatalError("\(Self.self).init(layer:) incorrectly called with \(type(of: layer))")
+    }
+
     animationLayers = []
     layerImageProvider = LayerImageProvider(imageProvider: BlankImageProvider(), assets: nil)
     layerTextProvider = LayerTextProvider(textProvider: DefaultTextProvider())
     layerFontProvider = LayerFontProvider(fontProvider: DefaultFontProvider())
+    logger = typedLayer.logger
     super.init(layer: layer)
 
-    guard let animationLayer = layer as? MainThreadAnimationLayer else { return }
-
-    currentFrame = animationLayer.currentFrame
+    currentFrame = typedLayer.currentFrame
 
   }
 
@@ -193,8 +199,8 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
   }
 
   func logHierarchyKeypaths() {
-    print("Lottie: Logging Animation Keypaths")
-    animationLayers.forEach({ $0.logKeypaths(for: nil) })
+    logger.print("Lottie: Logging Animation Keypaths")
+    animationLayers.forEach({ $0.logKeypaths(for: nil, logger: self.logger) })
   }
 
   func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath) {
@@ -259,6 +265,7 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
   fileprivate let layerImageProvider: LayerImageProvider
   fileprivate let layerTextProvider: LayerTextProvider
   fileprivate let layerFontProvider: LayerFontProvider
+  fileprivate let logger: LottieLogger
 }
 
 // MARK: - BlankImageProvider

--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -199,7 +199,7 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
   }
 
   func logHierarchyKeypaths() {
-    logger.print("Lottie: Logging Animation Keypaths")
+    logger.info("Lottie: Logging Animation Keypaths")
     animationLayers.forEach({ $0.logKeypaths(for: nil, logger: self.logger) })
   }
 

--- a/Sources/Private/Utility/Debugging/AnimatorNodeDebugging.swift
+++ b/Sources/Private/Utility/Debugging/AnimatorNodeDebugging.swift
@@ -11,14 +11,14 @@ extension AnimatorNode {
 
   func printNodeTree() {
     parentNode?.printNodeTree()
-    LottieLogger.shared.print(String(describing: type(of: self)))
+    LottieLogger.shared.info(String(describing: type(of: self)))
 
     if let group = self as? GroupNode {
-      LottieLogger.shared.print("* |Children")
+      LottieLogger.shared.info("* |Children")
       group.rootNode?.printNodeTree()
-      LottieLogger.shared.print("*")
+      LottieLogger.shared.info("*")
     } else {
-      LottieLogger.shared.print("|")
+      LottieLogger.shared.info("|")
     }
   }
 

--- a/Sources/Private/Utility/Debugging/AnimatorNodeDebugging.swift
+++ b/Sources/Private/Utility/Debugging/AnimatorNodeDebugging.swift
@@ -11,14 +11,14 @@ extension AnimatorNode {
 
   func printNodeTree() {
     parentNode?.printNodeTree()
-    print(String(describing: type(of: self)))
+    LottieLogger.shared.print(String(describing: type(of: self)))
 
     if let group = self as? GroupNode {
-      print("* |Children")
+      LottieLogger.shared.print("* |Children")
       group.rootNode?.printNodeTree()
-      print("*")
+      LottieLogger.shared.print("*")
     } else {
-      print("|")
+      LottieLogger.shared.print("|")
     }
   }
 

--- a/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
+++ b/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
@@ -115,19 +115,19 @@ extension KeypathSearchable {
     return nil
   }
 
-  func logKeypaths(for keyPath: AnimationKeypath?) {
+  func logKeypaths(for keyPath: AnimationKeypath?, logger: LottieLogger) {
     let newKeypath: AnimationKeypath
     if let previousKeypath = keyPath {
       newKeypath = previousKeypath.appendingKey(keypathName)
     } else {
       newKeypath = AnimationKeypath(keys: [keypathName])
     }
-    print(newKeypath.fullPath)
+    logger.print(newKeypath.fullPath)
     for key in keypathProperties.keys {
-      print(newKeypath.appendingKey(key).fullPath)
+      logger.print(newKeypath.appendingKey(key).fullPath)
     }
     for child in childKeypaths {
-      child.logKeypaths(for: newKeypath)
+      child.logKeypaths(for: newKeypath, logger: logger)
     }
   }
 }

--- a/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
+++ b/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
@@ -122,9 +122,9 @@ extension KeypathSearchable {
     } else {
       newKeypath = AnimationKeypath(keys: [keypathName])
     }
-    logger.print(newKeypath.fullPath)
+    logger.info(newKeypath.fullPath)
     for key in keypathProperties.keys {
-      logger.print(newKeypath.appendingKey(key).fullPath)
+      logger.info(newKeypath.appendingKey(key).fullPath)
     }
     for child in childKeypaths {
       child.logKeypaths(for: newKeypath, logger: logger)

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -986,7 +986,8 @@ final public class AnimationView: AnimationViewBase {
       animation: animation,
       imageProvider: imageProvider.cachedImageProvider,
       textProvider: textProvider,
-      fontProvider: fontProvider)
+      fontProvider: fontProvider,
+      logger: logger)
   }
 
   fileprivate func makeCoreAnimationLayer(for animation: Animation) -> CoreAnimationLayer? {
@@ -1230,9 +1231,9 @@ final public class AnimationView: AnimationViewBase {
         }
       }
 
-      coreAnimationLayer.playAnimation(
-        context: animationContext,
-        timingConfiguration: timingConfiguration)
+      coreAnimationLayer.playAnimation(configuration: .init(
+        animationContext: animationContext,
+        timingConfiguration: timingConfiguration))
 
       return
     }

--- a/Sources/Public/Logging/LottieLogger.swift
+++ b/Sources/Public/Logging/LottieLogger.swift
@@ -15,13 +15,20 @@ public final class LottieLogger {
     warn: @escaping Warn = { message, _, _ in
       #if DEBUG
       // swiftlint:disable:next no_direct_standard_out_logs
-      print(message())
+      Swift.print(message())
+      #endif
+    },
+    print: @escaping Print = { message in
+      #if DEBUG
+      // swiftlint:disable:next no_direct_standard_out_logs
+      Swift.print(message())
       #endif
     })
   {
     _assert = assert
     _assertionFailure = assertionFailure
     _warn = warn
+    _print = print
   }
 
   // MARK: Public
@@ -47,6 +54,9 @@ public final class LottieLogger {
     _ fileID: StaticString,
     _ line: UInt)
     -> Void
+
+  /// Prints a purely informational message.
+  public typealias Print = (_ message: @autoclosure () -> String) -> Void
 
   /// The shared instance used to log Lottie assertions and warnings.
   ///
@@ -81,11 +91,17 @@ public final class LottieLogger {
     _warn(message(), fileID, line)
   }
 
+  /// Logs a purely informational message.
+  public func print(_ message: @autoclosure () -> String = String()) {
+    _print(message())
+  }
+
   // MARK: Private
 
   private let _assert: Assert
   private let _assertionFailure: AssertionFailure
   private let _warn: Warn
+  private let _print: Print
 
 }
 
@@ -98,11 +114,11 @@ extension LottieLogger {
     LottieLogger(
       assert: { condition, message, _, _ in
         if !condition() {
-          print(message())
+          Swift.print(message())
         }
       },
       assertionFailure: { message, _, _ in
-        print(message())
+        Swift.print(message())
       })
   }
 }

--- a/Sources/Public/Logging/LottieLogger.swift
+++ b/Sources/Public/Logging/LottieLogger.swift
@@ -15,20 +15,20 @@ public final class LottieLogger {
     warn: @escaping Warn = { message, _, _ in
       #if DEBUG
       // swiftlint:disable:next no_direct_standard_out_logs
-      Swift.print(message())
+      print(message())
       #endif
     },
-    print: @escaping Print = { message in
+    info: @escaping Info = { message in
       #if DEBUG
       // swiftlint:disable:next no_direct_standard_out_logs
-      Swift.print(message())
+      print(message())
       #endif
     })
   {
     _assert = assert
     _assertionFailure = assertionFailure
     _warn = warn
-    _print = print
+    _info = info
   }
 
   // MARK: Public
@@ -56,7 +56,7 @@ public final class LottieLogger {
     -> Void
 
   /// Prints a purely informational message.
-  public typealias Print = (_ message: @autoclosure () -> String) -> Void
+  public typealias Info = (_ message: @autoclosure () -> String) -> Void
 
   /// The shared instance used to log Lottie assertions and warnings.
   ///
@@ -92,8 +92,8 @@ public final class LottieLogger {
   }
 
   /// Logs a purely informational message.
-  public func print(_ message: @autoclosure () -> String = String()) {
-    _print(message())
+  public func info(_ message: @autoclosure () -> String = String()) {
+    _info(message())
   }
 
   // MARK: Private
@@ -101,7 +101,7 @@ public final class LottieLogger {
   private let _assert: Assert
   private let _assertionFailure: AssertionFailure
   private let _warn: Warn
-  private let _print: Print
+  private let _info: Info
 
 }
 
@@ -114,11 +114,11 @@ extension LottieLogger {
     LottieLogger(
       assert: { condition, message, _, _ in
         if !condition() {
-          Swift.print(message())
+          print(message())
         }
       },
       assertionFailure: { message, _, _ in
-        Swift.print(message())
+        print(message())
       })
   }
 }

--- a/Tests/AnimationKeypathTests.swift
+++ b/Tests/AnimationKeypathTests.swift
@@ -1,11 +1,14 @@
 // Created by Cal Stephens on 1/24/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+import SnapshotTesting
 import XCTest
 
 @testable import Lottie
 
 final class AnimationKeypathTests: XCTestCase {
+
+  // MARK: Internal
 
   func testKeypathMatches() {
     let keypath = AnimationKeypath(keypath: "Layer.Shape Group.Stroke 1.Color")
@@ -35,4 +38,57 @@ final class AnimationKeypathTests: XCTestCase {
     XCTAssertNotNil(animationView.animationLayer?.layer(for: "Success"))
     XCTAssertNotNil(animationView.animationLayer?.layer(for: "Success.*.Fish1Tail 7"))
   }
+
+  func testMainThreadEngineKeypathLogging() {
+    snapshotHierarchyKeypaths(
+      animationName: "Switch",
+      configuration: LottieConfiguration(renderingEngine: .mainThread))
+  }
+
+  func testCoreAnimationEngineKeypathLogging() {
+    snapshotHierarchyKeypaths(
+      animationName: "Switch",
+      configuration: LottieConfiguration(renderingEngine: .coreAnimation))
+  }
+
+  /// The Core Animation engine supports a subset of the keypaths supported by the Main Thread engine.
+  /// All keypaths that are supported in the Core Animation engine should also be supported by the Main Thread engine.
+  func testCoreAnimationEngineKeypathCompatibility() {
+    let mainThreadKeypaths = Set(hierarchyKeypaths(animationName: "Switch", configuration: .init(renderingEngine: .mainThread)))
+    let coreAnimationKeypaths = hierarchyKeypaths(animationName: "Switch", configuration: .init(renderingEngine: .coreAnimation))
+
+    for coreAnimationKeypath in coreAnimationKeypaths {
+      XCTAssert(mainThreadKeypaths.contains(coreAnimationKeypath))
+    }
+  }
+
+  // MARK: Private
+
+  private func snapshotHierarchyKeypaths(
+    animationName: String,
+    configuration: LottieConfiguration,
+    function: String = #function,
+    line: UInt = #line)
+  {
+    let hierarchyKeypaths = hierarchyKeypaths(animationName: animationName, configuration: configuration)
+
+    assertSnapshot(
+      matching: hierarchyKeypaths.sorted().joined(separator: "\n"),
+      as: .description,
+      named: animationName,
+      testName: function,
+      line: line)
+  }
+
+  private func hierarchyKeypaths(animationName: String, configuration: LottieConfiguration) -> [String] {
+    var printedMessages = [String]()
+    let logger = LottieLogger(print: { message in
+      printedMessages.append(message())
+    })
+
+    let animationView = SnapshotConfiguration.makeAnimationView(for: animationName, configuration: configuration, logger: logger)
+    animationView?.logHierarchyKeypaths()
+    return Array(printedMessages[1...])
+  }
+
 }

--- a/Tests/AnimationKeypathTests.swift
+++ b/Tests/AnimationKeypathTests.swift
@@ -82,7 +82,7 @@ final class AnimationKeypathTests: XCTestCase {
 
   private func hierarchyKeypaths(animationName: String, configuration: LottieConfiguration) -> [String] {
     var printedMessages = [String]()
-    let logger = LottieLogger(print: { message in
+    let logger = LottieLogger(info: { message in
       printedMessages.append(message())
     })
 

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -228,7 +228,8 @@ extension SnapshotConfiguration {
   /// Creates an `AnimationView` for the sample snapshot with the given name
   static func makeAnimationView(
     for sampleAnimationName: String,
-    configuration: LottieConfiguration)
+    configuration: LottieConfiguration,
+    logger: LottieLogger = LottieLogger.shared)
     -> AnimationView?
   {
     let snapshotConfiguration = SnapshotConfiguration.forSample(named: sampleAnimationName)
@@ -240,7 +241,8 @@ extension SnapshotConfiguration {
 
     let animationView = AnimationView(
       animation: animation,
-      configuration: configuration)
+      configuration: configuration,
+      logger: logger)
 
     // Set up the animation view with a valid frame
     // so the geometry is correct when setting up the `CAAnimation`s

--- a/Tests/__Snapshots__/AnimationKeypathTests/testCoreAnimationEngineKeypathLogging.Switch.txt
+++ b/Tests/__Snapshots__/AnimationKeypathTests/testCoreAnimationEngineKeypathLogging.Switch.txt
@@ -1,0 +1,5 @@
+Checkmark Outlines 2.Group 1.Stroke 1.Color
+Checkmark Outlines.Group 1.Stroke 1.Color
+Switch Outline Outlines.Fill 1.Color
+White BG Outlines.Group 1.Fill 1.Color
+X Outlines.Group 1.Stroke 1.Color

--- a/Tests/__Snapshots__/AnimationKeypathTests/testMainThreadEngineKeypathLogging.Switch.txt
+++ b/Tests/__Snapshots__/AnimationKeypathTests/testMainThreadEngineKeypathLogging.Switch.txt
@@ -1,0 +1,161 @@
+Checkmark Outlines
+Checkmark Outlines 2
+Checkmark Outlines 2.Group 1
+Checkmark Outlines 2.Group 1.Anchor Point
+Checkmark Outlines 2.Group 1.Opacity
+Checkmark Outlines 2.Group 1.Path 1
+Checkmark Outlines 2.Group 1.Path 1.Path
+Checkmark Outlines 2.Group 1.Position
+Checkmark Outlines 2.Group 1.Rotation
+Checkmark Outlines 2.Group 1.Scale
+Checkmark Outlines 2.Group 1.Skew
+Checkmark Outlines 2.Group 1.Skew Axis
+Checkmark Outlines 2.Group 1.Stroke 1
+Checkmark Outlines 2.Group 1.Stroke 1.Color
+Checkmark Outlines 2.Group 1.Stroke 1.Dash Phase
+Checkmark Outlines 2.Group 1.Stroke 1.Dashes
+Checkmark Outlines 2.Group 1.Stroke 1.Opacity
+Checkmark Outlines 2.Group 1.Stroke 1.Stroke Width
+Checkmark Outlines 2.Group 1.Transform
+Checkmark Outlines 2.Group 1.Transform.Anchor Point
+Checkmark Outlines 2.Group 1.Transform.Opacity
+Checkmark Outlines 2.Group 1.Transform.Position
+Checkmark Outlines 2.Group 1.Transform.Rotation
+Checkmark Outlines 2.Group 1.Transform.Scale
+Checkmark Outlines 2.Group 1.Transform.Skew
+Checkmark Outlines 2.Group 1.Transform.Skew Axis
+Checkmark Outlines 2.Group 1.Trim Paths 1
+Checkmark Outlines 2.Group 1.Trim Paths 1.End
+Checkmark Outlines 2.Group 1.Trim Paths 1.Offset
+Checkmark Outlines 2.Group 1.Trim Paths 1.Start
+Checkmark Outlines 2.Transform
+Checkmark Outlines 2.Transform.Anchor Point
+Checkmark Outlines 2.Transform.Opacity
+Checkmark Outlines 2.Transform.Position
+Checkmark Outlines 2.Transform.Rotation
+Checkmark Outlines 2.Transform.Scale
+Checkmark Outlines.Group 1
+Checkmark Outlines.Group 1.Anchor Point
+Checkmark Outlines.Group 1.Opacity
+Checkmark Outlines.Group 1.Path 1
+Checkmark Outlines.Group 1.Path 1.Path
+Checkmark Outlines.Group 1.Position
+Checkmark Outlines.Group 1.Rotation
+Checkmark Outlines.Group 1.Scale
+Checkmark Outlines.Group 1.Skew
+Checkmark Outlines.Group 1.Skew Axis
+Checkmark Outlines.Group 1.Stroke 1
+Checkmark Outlines.Group 1.Stroke 1.Color
+Checkmark Outlines.Group 1.Stroke 1.Dash Phase
+Checkmark Outlines.Group 1.Stroke 1.Dashes
+Checkmark Outlines.Group 1.Stroke 1.Opacity
+Checkmark Outlines.Group 1.Stroke 1.Stroke Width
+Checkmark Outlines.Group 1.Transform
+Checkmark Outlines.Group 1.Transform.Anchor Point
+Checkmark Outlines.Group 1.Transform.Opacity
+Checkmark Outlines.Group 1.Transform.Position
+Checkmark Outlines.Group 1.Transform.Rotation
+Checkmark Outlines.Group 1.Transform.Scale
+Checkmark Outlines.Group 1.Transform.Skew
+Checkmark Outlines.Group 1.Transform.Skew Axis
+Checkmark Outlines.Group 1.Trim Paths 1
+Checkmark Outlines.Group 1.Trim Paths 1.End
+Checkmark Outlines.Group 1.Trim Paths 1.Offset
+Checkmark Outlines.Group 1.Trim Paths 1.Start
+Checkmark Outlines.Transform
+Checkmark Outlines.Transform.Anchor Point
+Checkmark Outlines.Transform.Opacity
+Checkmark Outlines.Transform.Position
+Checkmark Outlines.Transform.Rotation
+Checkmark Outlines.Transform.Scale
+Switch Outline Outlines
+Switch Outline Outlines.Fill 1
+Switch Outline Outlines.Fill 1.Color
+Switch Outline Outlines.Fill 1.Opacity
+Switch Outline Outlines.Group 1
+Switch Outline Outlines.Group 1.Anchor Point
+Switch Outline Outlines.Group 1.Opacity
+Switch Outline Outlines.Group 1.Path 1
+Switch Outline Outlines.Group 1.Path 1.Path
+Switch Outline Outlines.Group 1.Position
+Switch Outline Outlines.Group 1.Rotation
+Switch Outline Outlines.Group 1.Scale
+Switch Outline Outlines.Group 1.Skew
+Switch Outline Outlines.Group 1.Skew Axis
+Switch Outline Outlines.Group 1.Transform
+Switch Outline Outlines.Group 1.Transform.Anchor Point
+Switch Outline Outlines.Group 1.Transform.Opacity
+Switch Outline Outlines.Group 1.Transform.Position
+Switch Outline Outlines.Group 1.Transform.Rotation
+Switch Outline Outlines.Group 1.Transform.Scale
+Switch Outline Outlines.Group 1.Transform.Skew
+Switch Outline Outlines.Group 1.Transform.Skew Axis
+Switch Outline Outlines.Transform
+Switch Outline Outlines.Transform.Anchor Point
+Switch Outline Outlines.Transform.Opacity
+Switch Outline Outlines.Transform.Position
+Switch Outline Outlines.Transform.Rotation
+Switch Outline Outlines.Transform.Scale
+White BG Outlines
+White BG Outlines.Group 1
+White BG Outlines.Group 1.Anchor Point
+White BG Outlines.Group 1.Fill 1
+White BG Outlines.Group 1.Fill 1.Color
+White BG Outlines.Group 1.Fill 1.Opacity
+White BG Outlines.Group 1.Opacity
+White BG Outlines.Group 1.Path 1
+White BG Outlines.Group 1.Path 1.Path
+White BG Outlines.Group 1.Position
+White BG Outlines.Group 1.Rotation
+White BG Outlines.Group 1.Scale
+White BG Outlines.Group 1.Skew
+White BG Outlines.Group 1.Skew Axis
+White BG Outlines.Group 1.Transform
+White BG Outlines.Group 1.Transform.Anchor Point
+White BG Outlines.Group 1.Transform.Opacity
+White BG Outlines.Group 1.Transform.Position
+White BG Outlines.Group 1.Transform.Rotation
+White BG Outlines.Group 1.Transform.Scale
+White BG Outlines.Group 1.Transform.Skew
+White BG Outlines.Group 1.Transform.Skew Axis
+White BG Outlines.Transform
+White BG Outlines.Transform.Anchor Point
+White BG Outlines.Transform.Opacity
+White BG Outlines.Transform.Position
+White BG Outlines.Transform.Rotation
+White BG Outlines.Transform.Scale
+X Outlines
+X Outlines.Group 1
+X Outlines.Group 1.Anchor Point
+X Outlines.Group 1.Opacity
+X Outlines.Group 1.Path 1
+X Outlines.Group 1.Path 1.Path
+X Outlines.Group 1.Position
+X Outlines.Group 1.Rotation
+X Outlines.Group 1.Scale
+X Outlines.Group 1.Skew
+X Outlines.Group 1.Skew Axis
+X Outlines.Group 1.Stroke 1
+X Outlines.Group 1.Stroke 1.Color
+X Outlines.Group 1.Stroke 1.Dash Phase
+X Outlines.Group 1.Stroke 1.Dashes
+X Outlines.Group 1.Stroke 1.Opacity
+X Outlines.Group 1.Stroke 1.Stroke Width
+X Outlines.Group 1.Transform
+X Outlines.Group 1.Transform.Anchor Point
+X Outlines.Group 1.Transform.Opacity
+X Outlines.Group 1.Transform.Position
+X Outlines.Group 1.Transform.Rotation
+X Outlines.Group 1.Transform.Scale
+X Outlines.Group 1.Transform.Skew
+X Outlines.Group 1.Transform.Skew Axis
+X Outlines.Transform
+X Outlines.Transform.Anchor Point
+X Outlines.Transform.Opacity
+X Outlines.Transform.Position
+X Outlines.Transform.Rotation
+X Outlines.Transform.Scale
+X Outlines.Trim Paths 1
+X Outlines.Trim Paths 1.End
+X Outlines.Trim Paths 1.Offset
+X Outlines.Trim Paths 1.Start


### PR DESCRIPTION
This PR implements `logHierarchyKeypaths()` on `CoreAnimationLayer`. Previously it was unimplementation and calling it was a no-op. Fixes #1623.

I also added some snapshot tests for the output of this method, on both the Main Thread and Core Animation rendering engines.