### PR TITLE
Bump version in podspec

### DIFF
--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'lottie-ios'
-  s.version          = '3.3.0'
+  s.version          = '3.4.0'
   s.summary          = 'A library to render native animations from bodymovin json'
 
   s.description = <<-DESC


### PR DESCRIPTION
This PR updates the version number in the podspec from `3.3.0` to `3.4.0`. This is a requirement for `pod trunk push` to succeed.