### PR TITLE
Bump version number in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-ios",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I am going to try and upload 3.4.0 to npm (https://github.com/airbnb/lottie-ios/issues/1631) but first we need to bump the version number here