### PR TITLE
Fixed Animated Control Accessibility Configuration

### DIFF
--- a/Sources/Public/iOS/AnimatedButton.swift
+++ b/Sources/Public/iOS/AnimatedButton.swift
@@ -70,9 +70,15 @@ open class AnimatedButton: AnimatedControl {
     }
   }
 
-  // MARK: Fileprivate
+  open override var accessibilityTraits: UIAccessibilityTraits {
+    set { customAccessibilityTraits = newValue }
+    get { customAccessibilityTraits.union(.button).union(super.accessibilityTraits) }
+  }
 
-  fileprivate var rangesForEvents: [UInt : (from: CGFloat, to: CGFloat)] =
+  // MARK: Private
+
+  private var customAccessibilityTraits: UIAccessibilityTraits = []
+  private var rangesForEvents: [UInt : (from: CGFloat, to: CGFloat)] =
     [UIControl.Event.touchUpInside.rawValue : (from: 0, to: 1)]
 }
 #endif

--- a/Sources/Public/iOS/AnimatedButton.swift
+++ b/Sources/Public/iOS/AnimatedButton.swift
@@ -11,25 +11,6 @@ import UIKit
 /// An interactive button that plays an animation when pressed.
 open class AnimatedButton: AnimatedControl {
 
-  // MARK: Lifecycle
-
-  public override init(
-    animation: Animation,
-    configuration: LottieConfiguration = .shared)
-  {
-    super.init(animation: animation, configuration: configuration)
-    accessibilityTraits = UIAccessibilityTraits.button
-  }
-
-  public override init() {
-    super.init()
-    accessibilityTraits = UIAccessibilityTraits.button
-  }
-
-  required public init?(coder aDecoder: NSCoder) {
-    super.init(coder: aDecoder)
-  }
-
   // MARK: Public
 
   /// Sets the play range for the given UIControlEvent.
@@ -70,14 +51,8 @@ open class AnimatedButton: AnimatedControl {
     }
   }
 
-  open override var accessibilityTraits: UIAccessibilityTraits {
-    set { customAccessibilityTraits = newValue }
-    get { customAccessibilityTraits.union(.button).union(super.accessibilityTraits) }
-  }
-
   // MARK: Private
 
-  private var customAccessibilityTraits: UIAccessibilityTraits = []
   private var rangesForEvents: [UInt : (from: CGFloat, to: CGFloat)] =
     [UIControl.Event.touchUpInside.rawValue : (from: 0, to: 1)]
 }

--- a/Sources/Public/iOS/AnimatedControl.swift
+++ b/Sources/Public/iOS/AnimatedControl.swift
@@ -126,15 +126,15 @@ open class AnimatedControl: UIControl {
     get { animationView.animationSpeed }
   }
 
+  public override var accessibilityTraits: UIAccessibilityTraits {
+    set { super.accessibilityTraits = newValue }
+    get { super.accessibilityTraits.union(.button) }
+  }
+
   /// Sets which Animation Layer should be visible for the given state.
   public func setLayer(named: String, forState: UIControl.State) {
     stateMap[forState.rawValue] = named
     updateForState()
-  }
-
-  public override var accessibilityTraits: UIAccessibilityTraits {
-    set { customAccessibilityTraits = newValue }
-    get { customAccessibilityTraits.union(.button).union(super.accessibilityTraits) }
   }
 
   /// Sets a ValueProvider for the specified keypath
@@ -164,8 +164,6 @@ open class AnimatedControl: UIControl {
   }
 
   // MARK: Private
-
-  private var customAccessibilityTraits: UIAccessibilityTraits = []
 
   private func commonInit() {
     isAccessibilityElement = true

--- a/Sources/Public/iOS/AnimatedControl.swift
+++ b/Sources/Public/iOS/AnimatedControl.swift
@@ -132,6 +132,11 @@ open class AnimatedControl: UIControl {
     updateForState()
   }
 
+  public override var accessibilityTraits: UIAccessibilityTraits {
+    set { customAccessibilityTraits = newValue }
+    get { customAccessibilityTraits.union(.button).union(super.accessibilityTraits) }
+  }
+
   /// Sets a ValueProvider for the specified keypath
   public func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath) {
     animationView.setValueProvider(valueProvider, keypath: keypath)
@@ -158,9 +163,12 @@ open class AnimatedControl: UIControl {
     }
   }
 
-  // MARK: Fileprivate
+  // MARK: Private
 
-  fileprivate func commonInit() {
+  private var customAccessibilityTraits: UIAccessibilityTraits = []
+
+  private func commonInit() {
+    isAccessibilityElement = true
     animationView.clipsToBounds = false
     clipsToBounds = true
     animationView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Public/iOS/AnimatedSwitch.swift
+++ b/Sources/Public/iOS/AnimatedSwitch.swift
@@ -33,7 +33,6 @@ open class AnimatedSwitch: AnimatedControl {
     #endif
     super.init(animation: animation, configuration: configuration)
     updateOnState(isOn: _isOn, animated: false, shouldFireHaptics: false)
-    accessibilityTraits = UIAccessibilityTraits.button
   }
 
   public override init() {
@@ -49,7 +48,6 @@ open class AnimatedSwitch: AnimatedControl {
     #endif
     super.init()
     updateOnState(isOn: _isOn, animated: false, shouldFireHaptics: false)
-    accessibilityTraits = UIAccessibilityTraits.button
   }
 
   required public init?(coder aDecoder: NSCoder) {
@@ -64,7 +62,6 @@ open class AnimatedSwitch: AnimatedControl {
     hapticGenerator = NullHapticGenerator()
     #endif
     super.init(coder: aDecoder)
-    accessibilityTraits = UIAccessibilityTraits.button
   }
 
   // MARK: Public


### PR DESCRIPTION
- Fixes an issue where `AnimatedButton` and `AnimatedSwitch` weren't showing up as accessibly elements
- Fixes an issues where `AnimatedButton` and `AnimatedSwitch` weren't providing the default traits for UIControl provided states like when `isEnabled = false` or `isSelected = true`

<img width="987" alt="Screen Shot 2022-07-07 at 4 20 07 PM" src="https://user-images.githubusercontent.com/1455522/177887598-c68b088b-4c7a-49a4-9a86-c34cb546bd11.png">
