### PR TITLE
Only Set AnimatedButton and AnimatedSwitch as Accessibility Elements

### DIFF
--- a/Sources/Public/iOS/AnimatedButton.swift
+++ b/Sources/Public/iOS/AnimatedButton.swift
@@ -11,7 +11,32 @@ import UIKit
 /// An interactive button that plays an animation when pressed.
 open class AnimatedButton: AnimatedControl {
 
+  // MARK: Lifecycle
+
+  public override init(
+    animation: Animation,
+    configuration: LottieConfiguration = .shared)
+  {
+    super.init(animation: animation, configuration: configuration)
+    isAccessibilityElement = true
+  }
+
+  public override init() {
+    super.init()
+    isAccessibilityElement = true
+  }
+
+  required public init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+    isAccessibilityElement = true
+  }
+
   // MARK: Public
+
+  public override var accessibilityTraits: UIAccessibilityTraits {
+    set { super.accessibilityTraits = newValue }
+    get { super.accessibilityTraits.union(.button) }
+  }
 
   /// Sets the play range for the given UIControlEvent.
   public func setPlayRange(fromProgress: AnimationProgressTime, toProgress: AnimationProgressTime, event: UIControl.Event) {

--- a/Sources/Public/iOS/AnimatedControl.swift
+++ b/Sources/Public/iOS/AnimatedControl.swift
@@ -126,11 +126,6 @@ open class AnimatedControl: UIControl {
     get { animationView.animationSpeed }
   }
 
-  public override var accessibilityTraits: UIAccessibilityTraits {
-    set { super.accessibilityTraits = newValue }
-    get { super.accessibilityTraits.union(.button) }
-  }
-
   /// Sets which Animation Layer should be visible for the given state.
   public func setLayer(named: String, forState: UIControl.State) {
     stateMap[forState.rawValue] = named
@@ -166,7 +161,6 @@ open class AnimatedControl: UIControl {
   // MARK: Private
 
   private func commonInit() {
-    isAccessibilityElement = true
     animationView.clipsToBounds = false
     clipsToBounds = true
     animationView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Public/iOS/AnimatedSwitch.swift
+++ b/Sources/Public/iOS/AnimatedSwitch.swift
@@ -32,6 +32,7 @@ open class AnimatedSwitch: AnimatedControl {
     hapticGenerator = NullHapticGenerator()
     #endif
     super.init(animation: animation, configuration: configuration)
+    isAccessibilityElement = true
     updateOnState(isOn: _isOn, animated: false, shouldFireHaptics: false)
   }
 
@@ -47,6 +48,7 @@ open class AnimatedSwitch: AnimatedControl {
     hapticGenerator = NullHapticGenerator()
     #endif
     super.init()
+    isAccessibilityElement = true
     updateOnState(isOn: _isOn, animated: false, shouldFireHaptics: false)
   }
 
@@ -62,6 +64,7 @@ open class AnimatedSwitch: AnimatedControl {
     hapticGenerator = NullHapticGenerator()
     #endif
     super.init(coder: aDecoder)
+    isAccessibilityElement = true
   }
 
   // MARK: Public
@@ -75,6 +78,11 @@ open class AnimatedSwitch: AnimatedControl {
 
   /// The cancel behavior for the switch. See CancelBehavior for options
   public var cancelBehavior: CancelBehavior = .reverse
+
+  public override var accessibilityTraits: UIAccessibilityTraits {
+    set { super.accessibilityTraits = newValue }
+    get { super.accessibilityTraits.union(.button) }
+  }
 
   /// The current state of the switch.
   public var isOn: Bool {


### PR DESCRIPTION
- Disable setting `AnimatedControl` accessibility element with the button trait by default and instead just set `AnimatedButton` and `AnimatedSwitch` to have this behavior
- Follow-up recommendation from [this PR ](https://github.com/airbnb/lottie-ios/pull/1637)