### PR TITLE
Fix issue where `AnimationView.animationContext` could be put in an inconsistent state

### DIFF
--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -927,7 +927,11 @@ final public class AnimationView: AnimationViewBase {
 
   // MARK: Fileprivate
 
+  /// Context describing the animation that is currently playing in this `AnimationView`
+  ///  - When non-nil, an animation is currently playing in this view. Otherwise,
+  ///    the view is paused on a specific frame.
   fileprivate var animationContext: AnimationContext?
+
   fileprivate var _activeAnimationName: String = AnimationView.animationName
   fileprivate var animationID = 0
 
@@ -1131,12 +1135,18 @@ final public class AnimationView: AnimationViewBase {
   ///  - This is not necessary with the Core Animation engine, and skipping
   ///    this step lets us avoid building the animations twice (once paused
   ///    and once again playing)
+  ///  - This method should only be called immediately before setting up another
+  ///    animation -- otherwise this AnimationView could be put in an inconsistent state.
   fileprivate func removeCurrentAnimationIfNecessary() {
     switch currentRenderingEngine {
     case .mainThread:
       removeCurrentAnimation()
     case .coreAnimation, nil:
-      break
+      // We still need to remove the `animationContext`, since it should only be present
+      // when an animation is actually playing. Without this calling `removeCurrentAnimationIfNecessary()`
+      // and then setting the animation to a specific paused frame would put this
+      // `AnimationView` in an inconsistent state.
+      animationContext = nil
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where `AnimationView.animationContext` could be put in an inconsistent state.

`AnimationView.animationContext` should be present when an animation is actively playing, and `nil` when the animation is paused. Previously the Core Animation engine wasn't clearing out this value when pausing an animation, which meant `animationContext` would be non-nil even though the animation was paused.

This caused `updateAnimationForBackgroundState()` and `updateAnimationForForegroundState()` to unexpectedly run even when the animation was paused. In this issue below the `AnimationView` is using `.forceFinish`, so the animation progress is unexpectedly changed when using the Core Animation engine.

| Core Animation engine (before) | Main thread engine, Core Animaiton engine (after) |
| ----- | ---- |
| ![2022-07-18 15 27 54](https://user-images.githubusercontent.com/1811727/179628906-df082e98-0529-4697-b99d-4fab132a051f.gif) | ![2022-07-18 15 26 33](https://user-images.githubusercontent.com/1811727/179628911-8060259d-c1d9-4775-b760-99f8f1cf8397.gif) |