### PR TITLE
Add support set negative speed to do reverse transition on Core Animation

### DIFF
--- a/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
+++ b/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
@@ -147,27 +147,31 @@ class AnimationPreviewViewController: UIViewController {
           title: "Speed",
           children: [
             UIAction(
-              title: "-1",
+              title: "-100%",
               state: speed == -1 ? .on : .off,
               handler: { [unowned self] _ in
                 speed = -1
-                animationView.animationSpeed = speed
                 updateAnimation()
               }),
             UIAction(
-              title: "0",
-              state: speed == 0 ? .on : .off,
+              title: "-50%",
+              state: speed == -0.5 ? .on : .off,
               handler: { [unowned self] _ in
-                speed = 0
-                animationView.animationSpeed = speed
+                speed = -0.5
                 updateAnimation()
               }),
             UIAction(
-              title: "1",
+              title: "50%",
+              state: speed == 0.5 ? .on : .off,
+              handler: { [unowned self] _ in
+                speed = 0.5
+                updateAnimation()
+              }),
+            UIAction(
+              title: "100%",
               state: speed == 1 ? .on : .off,
               handler: { [unowned self] _ in
                 speed = 1
-                animationView.animationSpeed = speed
                 updateAnimation()
               }),
           ]),
@@ -235,6 +239,7 @@ class AnimationPreviewViewController: UIViewController {
 
   private func updateAnimation() {
     animationView.play(fromProgress: fromProgress, toProgress: toProgress, loopMode: loopMode)
+    animationView.animationSpeed = speed
     configureSettingsMenu()
   }
 

--- a/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
+++ b/Example/iOS/ViewControllers/AnimationPreviewViewController.swift
@@ -107,6 +107,7 @@ class AnimationPreviewViewController: UIViewController {
   private var displayLink: CADisplayLink?
 
   private var loopMode = LottieLoopMode.autoReverse
+  private var speed: CGFloat = 1
   private var fromProgress: AnimationProgressTime = 0
   private var toProgress: AnimationProgressTime = 1
 
@@ -138,6 +139,35 @@ class AnimationPreviewViewController: UIViewController {
               state: loopMode == .playOnce ? .on : .off,
               handler: { [unowned self] _ in
                 loopMode = .playOnce
+                updateAnimation()
+              }),
+          ]),
+
+        UIMenu(
+          title: "Speed",
+          children: [
+            UIAction(
+              title: "-1",
+              state: speed == -1 ? .on : .off,
+              handler: { [unowned self] _ in
+                speed = -1
+                animationView.animationSpeed = speed
+                updateAnimation()
+              }),
+            UIAction(
+              title: "0",
+              state: speed == 0 ? .on : .off,
+              handler: { [unowned self] _ in
+                speed = 0
+                animationView.animationSpeed = speed
+                updateAnimation()
+              }),
+            UIAction(
+              title: "1",
+              state: speed == 1 ? .on : .off,
+              handler: { [unowned self] _ in
+                speed = 1
+                animationView.animationSpeed = speed
                 updateAnimation()
               }),
           ]),

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -1213,7 +1213,15 @@ final public class AnimationView: AnimationViewBase {
       var timingConfiguration = CoreAnimationLayer.CAMediaTimingConfiguration(
         autoreverses: loopMode.caAnimationConfiguration.autoreverses,
         repeatCount: loopMode.caAnimationConfiguration.repeatCount,
-        speed: Float(animationSpeed))
+        speed: abs(Float(animationSpeed)))
+
+      // Core Animation not supported negative speed to do reverse animation.
+      if animationSpeed < 0 {
+        // Switch startFrame and endFrame in context
+        let temp = animationContext.playFrom
+        animationContext.playFrom = animationContext.playTo
+        animationContext.playTo = temp
+      }
 
       // The animation should start playing from the `currentFrame`,
       // if `currentFrame` is included in the time range being played.
@@ -1234,7 +1242,11 @@ final public class AnimationView: AnimationViewBase {
         // the duration of the _first_ loop. Instead of setting `playFrom`, we just add a `timeOffset`
         // so the first loop begins at `currentTime` but all subsequent loops are the standard duration.
         default:
-          timingConfiguration.timeOffset = currentTime - animation.time(forFrame: animationContext.playFrom)
+          if animationSpeed < 0 {
+            timingConfiguration.timeOffset = animation.time(forFrame: animationContext.playFrom) - currentTime
+          } else {
+            timingConfiguration.timeOffset = currentTime - animation.time(forFrame: animationContext.playFrom)
+          }
         }
       }
 

--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -1210,18 +1210,19 @@ final public class AnimationView: AnimationViewBase {
 
     if let coreAnimationLayer = animationlayer as? CoreAnimationLayer {
       var animationContext = animationContext
-      var timingConfiguration = CoreAnimationLayer.CAMediaTimingConfiguration(
-        autoreverses: loopMode.caAnimationConfiguration.autoreverses,
-        repeatCount: loopMode.caAnimationConfiguration.repeatCount,
-        speed: abs(Float(animationSpeed)))
 
-      // Core Animation not supported negative speed to do reverse animation.
+      // Core Animation doesn't natively support negative speed values,
+      // so instead we can swap `playFrom` / `playTo`
       if animationSpeed < 0 {
-        // Switch startFrame and endFrame in context
         let temp = animationContext.playFrom
         animationContext.playFrom = animationContext.playTo
         animationContext.playTo = temp
       }
+
+      var timingConfiguration = CoreAnimationLayer.CAMediaTimingConfiguration(
+        autoreverses: loopMode.caAnimationConfiguration.autoreverses,
+        repeatCount: loopMode.caAnimationConfiguration.repeatCount,
+        speed: abs(Float(animationSpeed)))
 
       // The animation should start playing from the `currentFrame`,
       // if `currentFrame` is included in the time range being played.


### PR DESCRIPTION
It looks like the Core Animation rendering engine is not supported to set `animationSpeed` less than 0 for doing reverse animation, which the main thread engine does.

My solution is switch `playFrom` and `playTo` if `animationSpeed` less than 0, not sure if this is best way. I also add speed menu into example.