### PR TITLE
Fix performance test flakiness by reducing memory usage

### DIFF
--- a/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,21 +20,12 @@
         }
       },
       {
-        "package": "SourceKitten",
-        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
-        "state": {
-          "branch": null,
-          "revision": "817dfa6f2e09b0476f3a6c9dbc035991f02f0241",
-          "version": "0.32.0"
-        }
-      },
-      {
         "package": "AirbnbSwift",
         "repositoryURL": "https://github.com/airbnb/swift",
         "state": {
-          "branch": "master",
-          "revision": "b844956fd69f05e550038469a5d498462176f87a",
-          "version": null
+          "branch": null,
+          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
+          "version": "1.0.1"
         }
       },
       {
@@ -53,60 +44,6 @@
           "branch": "main",
           "revision": "88f6e2c0afe04221fcfb1601a2ecaad83115a05f",
           "version": null
-        }
-      },
-      {
-        "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax.git",
-        "state": {
-          "branch": null,
-          "revision": "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-          "version": "0.50600.1"
-        }
-      },
-      {
-        "package": "SwiftFormat",
-        "repositoryURL": "https://github.com/calda/SwiftFormat",
-        "state": {
-          "branch": null,
-          "revision": "2a9ed335450d3b3f66b2699d65124b9089195f5d",
-          "version": "0.49.11-beta-2"
-        }
-      },
-      {
-        "package": "SwiftLint",
-        "repositoryURL": "https://github.com/realm/SwiftLint",
-        "state": {
-          "branch": "e497f1f",
-          "revision": "e497f1f5b161af96ba439049d21970c6204d06c6",
-          "version": null
-        }
-      },
-      {
-        "package": "SwiftyTextTable",
-        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
-        "state": {
-          "branch": null,
-          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-          "version": "0.9.0"
-        }
-      },
-      {
-        "package": "SWXMLHash",
-        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-        "state": {
-          "branch": null,
-          "revision": "6469881a3f30417c5bb02404ea4b69207f297592",
-          "version": "6.0.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
         }
       }
     ]


### PR DESCRIPTION
The performance tests have been flaky for the past few days. This is probably because they were using an extremely large amount of memory, because the views / layers weren't being deallocated correctly.

| Before | After |
| ---- | ---- |
| <img width="558" alt="Screen Shot 2022-07-29 at 9 07 02 AM" src="https://user-images.githubusercontent.com/1811727/181803351-0a84edaf-f9af-4c2d-b9cb-643a61275c3a.png"> | <img width="526" alt="Screen Shot 2022-07-29 at 9 19 18 AM" src="https://user-images.githubusercontent.com/1811727/181803376-aea62530-ac73-440c-9210-1a908de95742.png"> |