### PR TITLE
Change default behaviour when bundle image is not found from `assertionFailure` to `warn`

### DIFF
--- a/Sources/Public/iOS/BundleImageProvider.swift
+++ b/Sources/Public/iOS/BundleImageProvider.swift
@@ -67,7 +67,7 @@ public class BundleImageProvider: AnimationImageProvider {
 
     if imagePath == nil {
       guard let image = UIImage(named: asset.name, in: bundle, compatibleWith: nil) else {
-        LottieLogger.shared.assertionFailure("Could not find image \"\(asset.name)\" in bundle")
+        LottieLogger.shared.warn("Could not find image \"\(asset.name)\" in bundle")
         return nil
       }
       return image.cgImage
@@ -75,7 +75,7 @@ public class BundleImageProvider: AnimationImageProvider {
 
     guard let foundPath = imagePath, let image = UIImage(contentsOfFile: foundPath) else {
       /// No image found.
-      LottieLogger.shared.assertionFailure("Could not find image \"\(asset.name)\" in bundle")
+      LottieLogger.shared.warn("Could not find image \"\(asset.name)\" in bundle")
       return nil
     }
     return image.cgImage

--- a/Sources/Public/iOS/FilepathImageProvider.swift
+++ b/Sources/Public/iOS/FilepathImageProvider.swift
@@ -48,7 +48,7 @@ public class FilepathImageProvider: AnimationImageProvider {
       return UIImage(contentsOfFile: pathWithDirectory)?.cgImage
     }
 
-    LottieLogger.shared.assertionFailure("Could not find image \"\(asset.name)\" in bundle")
+    LottieLogger.shared.warn("Could not find image \"\(asset.name)\" in bundle")
     return nil
   }
 

--- a/Sources/Public/macOS/BundleImageProvider.macOS.swift
+++ b/Sources/Public/macOS/BundleImageProvider.macOS.swift
@@ -64,7 +64,7 @@ public class BundleImageProvider: AnimationImageProvider {
 
     guard let foundPath = imagePath, let image = NSImage(contentsOfFile: foundPath) else {
       /// No image found.
-      LottieLogger.shared.assertionFailure("Could not find image \"\(asset.name)\" in bundle")
+      LottieLogger.shared.warn("Could not find image \"\(asset.name)\" in bundle")
       return nil
     }
     return image.lottie_CGImage

--- a/Sources/Public/macOS/FilepathImageProvider.macOS.swift
+++ b/Sources/Public/macOS/FilepathImageProvider.macOS.swift
@@ -47,7 +47,7 @@ public class FilepathImageProvider: AnimationImageProvider {
       return NSImage(contentsOfFile: pathWithDirectory)?.lottie_CGImage
     }
 
-    LottieLogger.shared.assertionFailure("Could not find image \"\(asset.name)\" in bundle")
+    LottieLogger.shared.warn("Could not find image \"\(asset.name)\" in bundle")
     return nil
   }
 


### PR DESCRIPTION
MR Discussion #1677