### PR TITLE
Fix issue where `isAnimationPlaying` would be incorrect when using `LottieLoopMode.playOnce`

### DIFF
--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -264,6 +264,11 @@ final class CoreAnimationLayer: BaseAnimationLayer {
 
     let timedProgressAnimation = animationProgressTracker.timed(with: context, for: self)
     timedProgressAnimation.delegate = currentAnimationConfiguration?.animationContext.closure
+    
+    // Remove the progress animation once complete so we know when the animation
+    // has finished playing (if it doesn't loop infinitely)
+    timedProgressAnimation.isRemovedOnCompletion = true
+    
     add(timedProgressAnimation, forKey: #keyPath(animationProgress))
   }
 
@@ -311,7 +316,7 @@ extension CoreAnimationLayer: RootAnimationLayer {
   var isAnimationPlaying: Bool? {
     switch playbackState {
     case .playing:
-      return true
+      return animation(forKey: #keyPath(animationProgress)) != nil
     case nil, .paused:
       return false
     }

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -264,11 +264,11 @@ final class CoreAnimationLayer: BaseAnimationLayer {
 
     let timedProgressAnimation = animationProgressTracker.timed(with: context, for: self)
     timedProgressAnimation.delegate = currentAnimationConfiguration?.animationContext.closure
-    
+
     // Remove the progress animation once complete so we know when the animation
     // has finished playing (if it doesn't loop infinitely)
     timedProgressAnimation.isRemovedOnCompletion = true
-    
+
     add(timedProgressAnimation, forKey: #keyPath(animationProgress))
   }
 


### PR DESCRIPTION
This PR fixes an issue where the Core Animation engine would incorrectly return `true` for `isAnimationPlaying` when using a finite `LottieLoopMode` (e.g. `playOnce` or `loop(Int)`), even after the animation finished playing. It incorrectly assumed that the animation was either looping indefinitely or paused on a specific frame. Fixes #1681.