### PR TITLE
Fixed where strokes would not appear under certain conditions

### DIFF
--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientStrokeNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientStrokeNode.swift
@@ -139,7 +139,7 @@ final class GradientStrokeNode: AnimatorNode, RenderNode {
     strokeRender.strokeRender.lineJoin = strokeProperties.lineJoin
 
     /// Get dash lengths
-    let dashLengths = strokeProperties.dashPattern.value.map { $0.cgFloatValue }
+    let dashLengths = strokeProperties.dashPattern.value.map { $0.cgFloatValue }.filter { !$0.isZero }
     if dashLengths.count > 0 {
       strokeRender.strokeRender.dashPhase = strokeProperties.dashPhase.value.cgFloatValue
       strokeRender.strokeRender.dashLengths = dashLengths

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/StrokeNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/StrokeNode.swift
@@ -117,7 +117,7 @@ final class StrokeNode: AnimatorNode, RenderNode {
     strokeRender.lineJoin = strokeProperties.lineJoin
 
     /// Get dash lengths
-    let dashLengths = strokeProperties.dashPattern.value.map { $0.cgFloatValue }
+    let dashLengths = strokeProperties.dashPattern.value.map { $0.cgFloatValue }.filter { !$0.isZero }
     if dashLengths.count > 0 {
       strokeRender.dashPhase = strokeProperties.dashPhase.value.cgFloatValue
       strokeRender.dashLengths = dashLengths


### PR DESCRIPTION
This PR fixes an issue where strokes are not visible.
As in the below the json, strokes are not displayed when the dash key is "k=0".
This issue doesn't seem to occur on lottie-android.

Also Please let us know if you have any other suggestions.
Thanks.

part of json file 

```
                            "bm": 0,
                            "d": [
                                {
                                    "n": "d",
                                    "nm": "dash",
                                    "v": {
                                        "a": 0,
                                        "k": 0, // here
                                        "ix": 1
                                    }
                                },
                                {
                                    "n": "o",
                                    "nm": "offset",
                                    "v": {
                                        "a": 0,
                                        "k": 0,
                                        "ix": 7
                                    }
                                }
                            ],
                            "nm": "Stroke 1",
                            "mn": "ADBE Vector Graphic - Stroke",
                            "hd": false
                        },
```

|before|after|
|---|---|
|<img src="https://user-images.githubusercontent.com/16571394/182263895-4a75614a-d8ca-49b9-9feb-907fc1f185f2.png" width="240">|<img src="https://user-images.githubusercontent.com/16571394/182263712-cbbaeefa-36b5-413a-807e-9fccdeb55f79.gif" width="240">|

original json
```
{
    "v": "5.8.1",
    "fr": 15,
    "ip": 0,
    "op": 12,
    "w": 256,
    "h": 256,
    "nm": "Close",
    "ddd": 0,
    "assets": [],
    "layers": [
        {
            "ddd": 0,
            "ind": 1,
            "ty": 4,
            "nm": "Indicator",
            "sr": 1,
            "ks": {
                "o": {
                    "a": 0,
                    "k": 100,
                    "ix": 11
                },
                "r": {
                    "a": 0,
                    "k": 0,
                    "ix": 10
                },
                "p": {
                    "a": 0,
                    "k": [
                        128,
                        128,
                        0
                    ],
                    "ix": 2,
                    "l": 2
                },
                "a": {
                    "a": 0,
                    "k": [
                        0,
                        0,
                        0
                    ],
                    "ix": 1,
                    "l": 2
                },
                "s": {
                    "a": 0,
                    "k": [
                        100,
                        100,
                        100
                    ],
                    "ix": 6,
                    "l": 2
                }
            },
            "ao": 0,
            "shapes": [
                {
                    "ty": "gr",
                    "it": [
                        {
                            "d": 1,
                            "ty": "el",
                            "s": {
                                "a": 0,
                                "k": [
                                    212,
                                    212
                                ],
                                "ix": 2
                            },
                            "p": {
                                "a": 0,
                                "k": [
                                    0,
                                    0
                                ],
                                "ix": 3
                            },
                            "nm": "Ellipse Path 1",
                            "mn": "ADBE Vector Shape - Ellipse",
                            "hd": false
                        },
                        {
                            "ty": "st",
                            "c": {
                                "a": 0,
                                "k": [
                                    0.49411764705882355,
                                    0.8274509803921568,
                                    0.12941176470588237,
                                    1
                                ],
                                "ix": 3
                            },
                            "o": {
                                "a": 0,
                                "k": 100,
                                "ix": 4
                            },
                            "w": {
                                "a": 0,
                                "k": 8,
                                "ix": 5
                            },
                            "lc": 2,
                            "lj": 2,
                            "bm": 0,
                            "d": [
                                {
                                    "n": "d",
                                    "nm": "dash",
                                    "v": {
                                        "a": 0,
                                        "k": 0,
                                        "ix": 1
                                    }
                                },
                                {
                                    "n": "o",
                                    "nm": "offset",
                                    "v": {
                                        "a": 0,
                                        "k": 0,
                                        "ix": 7
                                    }
                                }
                            ],
                            "nm": "Stroke 1",
                            "mn": "ADBE Vector Graphic - Stroke",
                            "hd": false
                        },
                        {
                            "ty": "tr",
                            "p": {
                                "a": 0,
                                "k": [
                                    0,
                                    0
                                ],
                                "ix": 2
                            },
                            "a": {
                                "a": 0,
                                "k": [
                                    0,
                                    0
                                ],
                                "ix": 1
                            },
                            "s": {
                                "a": 0,
                                "k": [
                                    100,
                                    100
                                ],
                                "ix": 3
                            },
                            "r": {
                                "a": 0,
                                "k": 0,
                                "ix": 6
                            },
                            "o": {
                                "a": 0,
                                "k": 100,
                                "ix": 7
                            },
                            "sk": {
                                "a": 0,
                                "k": 0,
                                "ix": 4
                            },
                            "sa": {
                                "a": 0,
                                "k": 0,
                                "ix": 5
                            },
                            "nm": "Transform"
                        }
                    ],
                    "nm": "Ellipse 1",
                    "np": 2,
                    "cix": 2,
                    "bm": 0,
                    "ix": 1,
                    "mn": "ADBE Vector Group",
                    "hd": false
                },
                {
                    "ty": "tm",
                    "s": {
                        "a": 1,
                        "k": [
                            {
                                "i": {
                                    "x": [
                                        0.833
                                    ],
                                    "y": [
                                        0.833
                                    ]
                                },
                                "o": {
                                    "x": [
                                        0.167
                                    ],
                                    "y": [
                                        0.167
                                    ]
                                },
                                "t": 0,
                                "s": [
                                    0
                                ]
                            },
                            {
                                "t": 12,
                                "s": [
                                    100
                                ]
                            }
                        ],
                        "ix": 1
                    },
                    "e": {
                        "a": 0,
                        "k": 100,
                        "ix": 2
                    },
                    "o": {
                        "a": 0,
                        "k": 0,
                        "ix": 3
                    },
                    "m": 1,
                    "ix": 2,
                    "nm": "Trim Paths 1",
                    "mn": "ADBE Vector Filter - Trim",
                    "hd": false
                }
            ],
            "ip": 0,
            "op": 12,
            "st": 0,
            "bm": 0
        },
        {
            "ddd": 0,
            "ind": 2,
            "ty": 4,
            "nm": "Base",
            "sr": 1,
            "ks": {
                "o": {
                    "a": 0,
                    "k": 100,
                    "ix": 11
                },
                "r": {
                    "a": 0,
                    "k": 0,
                    "ix": 10
                },
                "p": {
                    "a": 0,
                    "k": [
                        129.573,
                        126.745,
                        0
                    ],
                    "ix": 2,
                    "l": 2
                },
                "a": {
                    "a": 0,
                    "k": [
                        0,
                        0,
                        0
                    ],
                    "ix": 1,
                    "l": 2
                },
                "s": {
                    "a": 0,
                    "k": [
                        100,
                        100,
                        100
                    ],
                    "ix": 6,
                    "l": 2
                }
            },
            "ao": 0,
            "ef": [
                {
                    "ty": 26,
                    "nm": "Radial Wipe",
                    "np": 7,
                    "mn": "ADBE Radial Wipe",
                    "ix": 1,
                    "en": 1,
                    "ef": [
                        {
                            "ty": 0,
                            "nm": "Transition Completion",
                            "mn": "ADBE Radial Wipe-0001",
                            "ix": 1,
                            "v": {
                                "a": 0,
                                "k": 0,
                                "ix": 1
                            }
                        },
                        {
                            "ty": 0,
                            "nm": "Start Angle",
                            "mn": "ADBE Radial Wipe-0002",
                            "ix": 2,
                            "v": {
                                "a": 0,
                                "k": 0,
                                "ix": 2
                            }
                        },
                        {
                            "ty": 3,
                            "nm": "Wipe Center",
                            "mn": "ADBE Radial Wipe-0003",
                            "ix": 3,
                            "v": {
                                "a": 0,
                                "k": [
                                    128,
                                    128
                                ],
                                "ix": 3
                            }
                        },
                        {
                            "ty": 7,
                            "nm": "Wipe",
                            "mn": "ADBE Radial Wipe-0004",
                            "ix": 4,
                            "v": {
                                "a": 0,
                                "k": 1,
                                "ix": 4
                            }
                        },
                        {
                            "ty": 0,
                            "nm": "Feather",
                            "mn": "ADBE Radial Wipe-0005",
                            "ix": 5,
                            "v": {
                                "a": 0,
                                "k": 0,
                                "ix": 5
                            }
                        }
                    ]
                }
            ],
            "shapes": [
                {
                    "ty": "gr",
                    "it": [
                        {
                            "d": 1,
                            "ty": "el",
                            "s": {
                                "a": 0,
                                "k": [
                                    212,
                                    212
                                ],
                                "ix": 2
                            },
                            "p": {
                                "a": 0,
                                "k": [
                                    0,
                                    0
                                ],
                                "ix": 3
                            },
                            "nm": "Ellipse Path 1",
                            "mn": "ADBE Vector Shape - Ellipse",
                            "hd": false
                        },
                        {
                            "ty": "st",
                            "c": {
                                "a": 0,
                                "k": [
                                    0.6078431372549019,
                                    0.6078431372549019,
                                    0.6078431372549019,
                                    1
                                ],
                                "ix": 3
                            },
                            "o": {
                                "a": 0,
                                "k": 8,
                                "ix": 4
                            },
                            "w": {
                                "a": 0,
                                "k": 8,
                                "ix": 5
                            },
                            "lc": 2,
                            "lj": 1,
                            "ml": 4,
                            "bm": 0,
                            "d": [
                                {
                                    "n": "d",
                                    "nm": "dash",
                                    "v": {
                                        "a": 0,
                                        "k": 0,
                                        "ix": 1
                                    }
                                },
                                {
                                    "n": "o",
                                    "nm": "offset",
                                    "v": {
                                        "a": 0,
                                        "k": 0,
                                        "ix": 7
                                    }
                                }
                            ],
                            "nm": "Stroke 1",
                            "mn": "ADBE Vector Graphic - Stroke",
                            "hd": false
                        },
                        {
                            "ty": "tr",
                            "p": {
                                "a": 0,
                                "k": [
                                    -1.573,
                                    1.255
                                ],
                                "ix": 2
                            },
                            "a": {
                                "a": 0,
                                "k": [
                                    0,
                                    0
                                ],
                                "ix": 1
                            },
                            "s": {
                                "a": 0,
                                "k": [
                                    100,
                                    100
                                ],
                                "ix": 3
                            },
                            "r": {
                                "a": 0,
                                "k": 0,
                                "ix": 6
                            },
                            "o": {
                                "a": 0,
                                "k": 100,
                                "ix": 7
                            },
                            "sk": {
                                "a": 0,
                                "k": 0,
                                "ix": 4
                            },
                            "sa": {
                                "a": 0,
                                "k": 0,
                                "ix": 5
                            },
                            "nm": "Transform"
                        }
                    ],
                    "nm": "Ellipse 1",
                    "np": 2,
                    "cix": 2,
                    "bm": 0,
                    "ix": 1,
                    "mn": "ADBE Vector Group",
                    "hd": false
                }
            ],
            "ip": 0,
            "op": 14,
            "st": 0,
            "bm": 0
        }
    ],
    "markers": []
}
```