### PR TITLE
Fix bug in `AnimationView.play(fromFrame:toFrame:)` with `fromFrame: nil`

### DIFF
--- a/Sources/Public/Animation/AnimationView.swift
+++ b/Sources/Public/Animation/AnimationView.swift
@@ -465,7 +465,7 @@ final public class AnimationView: AnimationViewBase {
     }
 
     let context = AnimationContext(
-      playFrom: fromFrame ?? currentProgress,
+      playFrom: fromFrame ?? currentFrame,
       playTo: toFrame,
       closure: completion)
     addNewAnimationForContext(context)


### PR DESCRIPTION
This PR fixes an issue in `AnimationView.play(fromFrame:toFrame:)` where if you pass in `fromFrame: nil` it would fall back to using `fromFrame: currentProgress`. Based on the docs, this is supposed to be `fromFrame: currentFrame` (_"Parameter fromFrame: The start frame of the animation. If `nil` the animation will start at the current frame."_)

Fixes #1233.