### PR TITLE
Fix CoreAnimation `playbackState` race condition

### DIFF
--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -329,11 +329,18 @@ extension CoreAnimationLayer: RootAnimationLayer {
   }
 
   var isAnimationPlaying: Bool? {
-    switch playbackState {
+    switch pendingAnimationConfiguration?.playbackState {
     case .playing:
-      return pendingAnimationConfiguration?.playbackState == .playing || animation(forKey: #keyPath(animationProgress)) != nil
-    case nil, .paused:
+      return true
+    case .paused:
       return false
+    case nil:
+      switch playbackState {
+      case .playing:
+        return animation(forKey: #keyPath(animationProgress)) != nil
+      case nil, .paused:
+        return false
+      }
     }
   }
 

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -331,7 +331,7 @@ extension CoreAnimationLayer: RootAnimationLayer {
   var isAnimationPlaying: Bool? {
     switch playbackState {
     case .playing:
-      return animation(forKey: #keyPath(animationProgress)) != nil
+      return pendingAnimationConfiguration?.playbackState == .playing || animation(forKey: #keyPath(animationProgress)) != nil
     case nil, .paused:
       return false
     }


### PR DESCRIPTION
#1682 introduced a bug where infinitely looping animations would sometimes report as not playing. I think this is because the property is read while a new animation is scheduled but haven't yet been applied through the `display` lifecycle method. This PR changes the `playbackState` to take the pending animation configuration into consideration which fixes the bug on our end, but happy to see if you have a better approach at fixing this. 