### PR TITLE
Added ability to use a custom URLSession in the Animation Downloader

### DIFF
--- a/Sources/Public/Animation/AnimationPublic.swift
+++ b/Sources/Public/Animation/AnimationPublic.swift
@@ -172,13 +172,14 @@ extension Animation {
   ///
   public static func loadedFrom(
     url: URL,
+    urlSession: URLSession = .shared,
     closure: @escaping Animation.DownloadClosure,
     animationCache: AnimationCacheProvider?)
   {
     if let animationCache = animationCache, let animation = animationCache.animation(forKey: url.absoluteString) {
       closure(animation)
     } else {
-      let task = URLSession.shared.dataTask(with: url) { data, _, error in
+      let task = urlSession.dataTask(with: url) { data, _, error in
         guard error == nil, let jsonData = data else {
           DispatchQueue.main.async {
             closure(nil)

--- a/Sources/Public/Animation/AnimationPublic.swift
+++ b/Sources/Public/Animation/AnimationPublic.swift
@@ -172,14 +172,14 @@ extension Animation {
   ///
   public static func loadedFrom(
     url: URL,
-    urlSession: URLSession = .shared,
+    session: URLSession = .shared,
     closure: @escaping Animation.DownloadClosure,
     animationCache: AnimationCacheProvider?)
   {
     if let animationCache = animationCache, let animation = animationCache.animation(forKey: url.absoluteString) {
       closure(animation)
     } else {
-      let task = urlSession.dataTask(with: url) { data, _, error in
+      let task = session.dataTask(with: url) { data, _, error in
         guard error == nil, let jsonData = data else {
           DispatchQueue.main.async {
             closure(nil)


### PR DESCRIPTION
Simply added a parameter to the `loadedFrom{` function in the public Animation class extension that allow for a custom URLSession to be passed in. This is helpful for setting such things as request timeout and headers if needed. 