### PR TITLE
Bump version to 3.4.3

### DIFF
--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'lottie-ios'
-  s.version          = '3.4.3
+  s.version          = '3.4.3'
   s.summary          = 'A library to render native animations from bodymovin json'
 
   s.description = <<-DESC

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'lottie-ios'
-  s.version          = '3.4.2'
+  s.version          = '3.4.3
   s.summary          = 'A library to render native animations from bodymovin json'
 
   s.description = <<-DESC

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-ios",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR bumps the library version to `3.4.3`. I'll release this version today with the past few weeks of fixes: https://github.com/airbnb/lottie-ios/compare/3.4.2...b3dd4d8