### PR TITLE
Make `animationDidSet` `open`

### DIFF
--- a/Sources/Public/iOS/AnimatedSwitch.swift
+++ b/Sources/Public/iOS/AnimatedSwitch.swift
@@ -67,6 +67,12 @@ open class AnimatedSwitch: AnimatedControl {
     isAccessibilityElement = true
   }
 
+  // MARK: Open
+
+  open override func animationDidSet() {
+    updateOnState(isOn: _isOn, animated: true, shouldFireHaptics: false)
+  }
+
   // MARK: Public
 
   /// Defines what happens when the user taps the switch while an
@@ -123,10 +129,6 @@ open class AnimatedSwitch: AnimatedControl {
     super.endTracking(touch, with: event)
     updateOnState(isOn: !_isOn, animated: true, shouldFireHaptics: true)
     sendActions(for: .valueChanged)
-  }
-
-  public override func animationDidSet() {
-    updateOnState(isOn: _isOn, animated: true, shouldFireHaptics: false)
   }
 
   // MARK: Internal


### PR DESCRIPTION
Hi! Great library but I ran into an issue with `AnimatedSwitch`.

While using `AnimatedSwitch` I noticed that setting the animation triggers it to start but I think that as it is in other places there should be an option to set the animation without starting it.

In `AnimatedSwitch`'s base class `AnimatedControl` this is already defined as `open` so I think keeping it `open` in `AnimatedSwitch` and allowing people to subclass and define their own custom behavior would be very helpful.