### PR TITLE
Allow overrides of begin/end tracking in subclasses of AnimatedSwitch and AnimatedButton

### DIFF
--- a/Sources/Public/iOS/AnimatedButton.swift
+++ b/Sources/Public/iOS/AnimatedButton.swift
@@ -31,6 +31,31 @@ open class AnimatedButton: AnimatedControl {
     isAccessibilityElement = true
   }
 
+  // MARK: Open
+
+  open override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
+    let _ = super.beginTracking(touch, with: event)
+    let touchEvent = UIControl.Event.touchDown
+    if let playrange = rangesForEvents[touchEvent.rawValue] {
+      animationView.play(fromProgress: playrange.from, toProgress: playrange.to, loopMode: LottieLoopMode.playOnce)
+    }
+    return true
+  }
+
+  open override func endTracking(_ touch: UITouch?, with event: UIEvent?) {
+    super.endTracking(touch, with: event)
+    let touchEvent: UIControl.Event
+    if let touch = touch, bounds.contains(touch.location(in: self)) {
+      touchEvent = UIControl.Event.touchUpInside
+    } else {
+      touchEvent = UIControl.Event.touchUpOutside
+    }
+
+    if let playrange = rangesForEvents[touchEvent.rawValue] {
+      animationView.play(fromProgress: playrange.from, toProgress: playrange.to, loopMode: LottieLoopMode.playOnce)
+    }
+  }
+
   // MARK: Public
 
   public override var accessibilityTraits: UIAccessibilityTraits {
@@ -50,29 +75,6 @@ open class AnimatedButton: AnimatedControl {
       let end = animationView.progressTime(forMarker: toName)
     {
       rangesForEvents[event.rawValue] = (from: start, to: end)
-    }
-  }
-
-  public override func beginTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
-    let _ = super.beginTracking(touch, with: event)
-    let touchEvent = UIControl.Event.touchDown
-    if let playrange = rangesForEvents[touchEvent.rawValue] {
-      animationView.play(fromProgress: playrange.from, toProgress: playrange.to, loopMode: LottieLoopMode.playOnce)
-    }
-    return true
-  }
-
-  public override func endTracking(_ touch: UITouch?, with event: UIEvent?) {
-    super.endTracking(touch, with: event)
-    let touchEvent: UIControl.Event
-    if let touch = touch, bounds.contains(touch.location(in: self)) {
-      touchEvent = UIControl.Event.touchUpInside
-    } else {
-      touchEvent = UIControl.Event.touchUpOutside
-    }
-
-    if let playrange = rangesForEvents[touchEvent.rawValue] {
-      animationView.play(fromProgress: playrange.from, toProgress: playrange.to, loopMode: LottieLoopMode.playOnce)
     }
   }
 

--- a/Sources/Public/iOS/AnimatedSwitch.swift
+++ b/Sources/Public/iOS/AnimatedSwitch.swift
@@ -73,6 +73,12 @@ open class AnimatedSwitch: AnimatedControl {
     updateOnState(isOn: _isOn, animated: true, shouldFireHaptics: false)
   }
 
+  open override func endTracking(_ touch: UITouch?, with event: UIEvent?) {
+    super.endTracking(touch, with: event)
+    updateOnState(isOn: !_isOn, animated: true, shouldFireHaptics: true)
+    sendActions(for: .valueChanged)
+  }
+
   // MARK: Public
 
   /// Defines what happens when the user taps the switch while an
@@ -123,12 +129,6 @@ open class AnimatedSwitch: AnimatedControl {
     }
 
     updateOnState(isOn: _isOn, animated: false, shouldFireHaptics: false)
-  }
-
-  public override func endTracking(_ touch: UITouch?, with event: UIEvent?) {
-    super.endTracking(touch, with: event)
-    updateOnState(isOn: !_isOn, animated: true, shouldFireHaptics: true)
-    sendActions(for: .valueChanged)
   }
 
   // MARK: Internal


### PR DESCRIPTION
Subclasses of `AnimatedSwitch` and `AnimatedButton` would benefit from having the ability to override tracking methods I feel. What do you think?