### PR TITLE
Use warn instead of assertionFailure when detecting repeater use

### DIFF
--- a/Sources/Private/MainThread/NodeRenderSystem/Extensions/ItemsExtension.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Extensions/ItemsExtension.swift
@@ -80,7 +80,7 @@ extension Array where Element == ShapeItem {
         nodeTree.paths.append(contentsOf: tree.paths)
         nodeTree.renderContainers.append(node.container)
       } else if item is Repeater {
-        LottieLogger.shared.assertionFailure("""
+        LottieLogger.shared.warn("""
           The Main Thread rendering engine doesn't currently support repeaters.
           To play an animation with repeaters, you can use the Core Animation rendering engine instead.
           """)


### PR DESCRIPTION
This is based on a fix discussed in https://github.com/airbnb/lottie-ios/issues/1739
