### PR TITLE
Fix deprecation warnings in iOS example app

### DIFF
--- a/Example/iOS/ViewControllers/ControlsDemoViewController.swift
+++ b/Example/iOS/ViewControllers/ControlsDemoViewController.swift
@@ -46,9 +46,9 @@ final class ControlsDemoViewController: CollectionViewController {
           "Checkmark Outlines 2.Group 1.Stroke 1.Color": [Keyframe(.black)],
           "X Outlines.Group 1.Stroke 1.Color": [Keyframe(.black)],
           "Switch Outline Outlines.Fill 1.Color": [
-            Keyframe(value: Color.black, time: 0),
-            Keyframe(value: Color(r: 0.76, g: 0.76, b: 0.76, a: 1), time: 75),
-            Keyframe(value: Color.black, time: 150),
+            Keyframe(value: LottieColor.black, time: 0),
+            Keyframe(value: LottieColor(r: 0.76, g: 0.76, b: 0.76, a: 1), time: 75),
+            Keyframe(value: LottieColor.black, time: 150),
           ],
         ]))
 
@@ -66,8 +66,8 @@ final class ControlsDemoViewController: CollectionViewController {
 
 }
 
-extension Color {
-  static var black: Color {
+extension LottieColor {
+  static var black: LottieColor {
     .init(r: 0, g: 0, b: 0, a: 1)
   }
 }

--- a/Example/iOS/Views/AnimatedSwitchRow.swift
+++ b/Example/iOS/Views/AnimatedSwitchRow.swift
@@ -31,7 +31,7 @@ final class AnimatedSwitchRow: UIView, EpoxyableView {
     var title: String
     var onTimeRange: ClosedRange<CGFloat>
     var offTimeRange: ClosedRange<CGFloat>
-    var colorValueProviders: [String: [Keyframe<Color>]] = [:]
+    var colorValueProviders: [String: [Keyframe<LottieColor>]] = [:]
   }
 
   func setContent(_ content: Content, animated _: Bool) {


### PR DESCRIPTION
This PR fixes a few deprecation warnings in the iOS example app, which I must have missed in #1761.