### PR TITLE
Bump to 4.0.0, remove backwards compatibility typealiases

### DIFF
--- a/Sources/Private/Utility/Primitives/VectorsExtensions.swift
+++ b/Sources/Private/Utility/Primitives/VectorsExtensions.swift
@@ -66,14 +66,6 @@ extension Double {
   }
 }
 
-// MARK: - Vector2D
-
-@available(*, deprecated, renamed: "LottieVector2D", message: """
-  `Lottie.Vector2D` has been renamed to `LottieVector2D` for consistency with \
-  the new `LottieVector3D` type. This notice will be removed in Lottie 4.0.
-  """)
-public typealias Vector2D = LottieVector2D
-
 // MARK: - LottieVector2D
 
 /// Needed for decoding json {x: y:} to a CGPoint

--- a/Sources/Public/Animation/LottieAnimation.swift
+++ b/Sources/Public/Animation/LottieAnimation.swift
@@ -14,14 +14,6 @@ public enum CoordinateSpace: Int, Codable {
   case type3d
 }
 
-// MARK: - Animation
-
-@available(*, deprecated, renamed: "LottieAnimation", message: """
-  `Lottie.Animation` has been renamed to `LottieAnimation`, to prevent conflicts \
-  with the `SwiftUI.Animation` type. This notice will be removed in Lottie 4.0.
-  """)
-public typealias Animation = LottieAnimation
-
 // MARK: - LottieAnimation
 
 /// The `LottieAnimation` model is the top level model object in Lottie.

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -84,14 +84,6 @@ extension LottieLoopMode: Equatable {
   }
 }
 
-// MARK: - AnimationView
-
-@available(*, deprecated, renamed: "LottieAnimationView", message: """
-  `AnimationView` has been renamed to `LottieAnimationView`, for consistency with \
-  the new `LottieAnimation` type. This notice will be removed in Lottie 4.0.
-  """)
-public typealias AnimationView = LottieAnimationView
-
 // MARK: - LottieAnimationView
 
 @IBDesignable

--- a/Sources/Public/Primitives/LottieColor.swift
+++ b/Sources/Public/Primitives/LottieColor.swift
@@ -26,14 +26,6 @@ public enum ColorFormatDenominator: Hashable {
   }
 }
 
-// MARK: - Color
-
-@available(*, deprecated, renamed: "LottieColor", message: """
-  `Lottie.Color` has been renamed to `LottieColor`, to prevent conflicts with \
-  the `SwiftUI.Color` type. This notice will be removed in Lottie 4.0.
-  """)
-public typealias Color = LottieColor
-
 // MARK: - LottieColor
 
 public struct LottieColor: Hashable {

--- a/Sources/Public/Primitives/Vectors.swift
+++ b/Sources/Public/Primitives/Vectors.swift
@@ -7,14 +7,6 @@
 
 import Foundation
 
-// MARK: - Vector1D
-
-@available(*, deprecated, renamed: "LottieVector1D", message: """
-  `Lottie.Vector1D` has been renamed to `LottieVector1D` for consistency with \
-  the new `LottieVector3D` type. This notice will be removed in Lottie 4.0.
-  """)
-public typealias Vector1D = LottieVector1D
-
 // MARK: - LottieVector1D
 
 public struct LottieVector1D: Hashable {
@@ -26,14 +18,6 @@ public struct LottieVector1D: Hashable {
   public let value: Double
 
 }
-
-// MARK: - Vector3D
-
-@available(*, deprecated, renamed: "LottieVector3D", message: """
-  `Lottie.Vector3D` has been renamed to `LottieVector3D`, to prevent conflicts with \
-  the Apple SDK `Spatial.Vector3D` type. This notice will be removed in Lottie 4.0.
-  """)
-public typealias Vector3D = LottieVector3D
 
 // MARK: - LottieVector3D
 

--- a/Tests/SnapshotConfiguration.swift
+++ b/Tests/SnapshotConfiguration.swift
@@ -60,7 +60,7 @@ extension SnapshotConfiguration {
       AnimationKeypath(keypath: "X Outlines.Group 1.Stroke 1.Color"): ColorValueProvider(.black),
       AnimationKeypath(keypath: "Switch Outline Outlines.Fill 1.Color"): ColorValueProvider([
         Keyframe(value: LottieColor.black, time: 0),
-        Keyframe(value: Color(r: 0.76, g: 0.76, b: 0.76, a: 1), time: 75),
+        Keyframe(value: LottieColor(r: 0.76, g: 0.76, b: 0.76, a: 1), time: 75),
         Keyframe(value: LottieColor.black, time: 150),
       ]),
     ]),
@@ -166,7 +166,7 @@ extension SnapshotConfiguration {
 // MARK: - LottieColor helpers
 
 extension LottieColor {
-  static let black = Color(r: 0, g: 0, b: 0, a: 1)
-  static let red = Color(r: 1, g: 0, b: 0, a: 1)
+  static let black = LottieColor(r: 0, g: 0, b: 0, a: 1)
+  static let red = LottieColor(r: 1, g: 0, b: 0, a: 1)
 }
 #endif

--- a/Tests/ValueProvidersTests.swift
+++ b/Tests/ValueProvidersTests.swift
@@ -17,11 +17,11 @@ final class ValueProvidersTests: XCTestCase {
 
     let keypath = AnimationKeypath(keypath: "A1.Shape 1.Stroke 1.Color")
     animationView.setValueProvider(ColorValueProvider(.red), keypath: keypath)
-    let updatedColor = try XCTUnwrap(animationView.getValue(for: keypath, atFrame: 0) as? Color)
+    let updatedColor = try XCTUnwrap(animationView.getValue(for: keypath, atFrame: 0) as? LottieColor)
     XCTAssertEqual(updatedColor, .red)
 
-    let originalColor = try XCTUnwrap(animationView.getOriginalValue(for: keypath, atFrame: 0) as? Color)
-    XCTAssertEqual(originalColor, Color(r: 0.4, g: 0.16, b: 0.7, a: 1))
+    let originalColor = try XCTUnwrap(animationView.getOriginalValue(for: keypath, atFrame: 0) as? LottieColor)
+    XCTAssertEqual(originalColor, LottieColor(r: 0.4, g: 0.16, b: 0.7, a: 1))
   }
 
 }

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'lottie-ios'
-  s.version          = '3.5.0'
+  s.version          = '4.0.0'
   s.summary          = 'A library to render native animations from bodymovin json'
 
   s.description = <<-DESC
@@ -19,7 +19,7 @@ Lottie enables designers to create and ship beautiful animations without an engi
 
   s.homepage         = 'https://github.com/airbnb/lottie-ios'
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
-  s.author           = { 'Brandon Withrow' => 'buba447@gmail.com' }
+  s.author           = { 'Brandon Withrow' => 'buba447@gmail.com', 'Cal Stephens' => 'cal.stephens@airbnb.com' }
   s.source           = { :git => 'https://github.com/airbnb/lottie-ios.git', :tag => s.version.to_s }
 
   s.swift_version = '5.3'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-ios",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/airbnb/lottie-ios.git"
   },
-  "author": "Brandon Withrow <buba447@gmail.com>",
+  "author": "Brandon Withrow <buba447@gmail.com>, Cal Stephens <cal.stephens@airbnb.com>",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/airbnb/lottie-ios/issues"

--- a/script/test-carthage/CarthageTest-macOS/ViewController.swift
+++ b/script/test-carthage/CarthageTest-macOS/ViewController.swift
@@ -8,7 +8,7 @@ class ViewController: NSViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    let animationView = AnimationView()
+    let animationView = LottieAnimationView()
     view.addSubview(animationView)
   }
 

--- a/script/test-carthage/CarthageTest/ViewController.swift
+++ b/script/test-carthage/CarthageTest/ViewController.swift
@@ -8,7 +8,7 @@ class ViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    let animationView = AnimationView()
+    let animationView = LottieAnimationView()
     view.addSubview(animationView)
   }
 


### PR DESCRIPTION
This PR bumps the repo version number to 4.0.0, and removes the backwards compatibility typealiases that were added in #1761 (a source-breaking change). Fixes #1420.