### PR TITLE
Update `LottieBackgroundBehavior.default` from `.pause` to `.pauseAndRestore` for Main Thread rendering engine

### DIFF
--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -16,10 +16,11 @@ public enum LottieBackgroundBehavior {
   case stop
 
   /// Pause the animation in its current state. The completion block is called.
-  ///  - This is the default when using the Main Thread rendering engine.
   case pause
 
-  /// Pause the animation and restart it when the application moves to the foreground. The completion block is stored and called when the animation completes.
+  /// Pause the animation and restart it when the application moves to the foreground.
+  /// The completion block is stored and called when the animation completes.
+  ///  - This is the default when using the Main Thread rendering engine.
   case pauseAndRestore
 
   /// Stops the animation and sets it to the end of its current play time. The completion block is called.
@@ -43,7 +44,7 @@ public enum LottieBackgroundBehavior {
   public static func `default`(for renderingEngine: RenderingEngine) -> LottieBackgroundBehavior {
     switch renderingEngine {
     case .mainThread:
-      return .pause
+      return .pauseAndRestore
     case .coreAnimation:
       return .continuePlaying
     }


### PR DESCRIPTION
As discussed in https://github.com/airbnb/lottie-ios/discussions/1649, I've seen some confusion about `AnimationView.backgroundBehavior`. It currently defaults to `.pause` when using the main thread rendering engine, which seems unexpected to many users. For example:
 - https://github.com/airbnb/lottie-ios/issues/1332
 - https://github.com/airbnb/lottie-ios/issues/1565

We have an opportunity to update this in Lottie 4.0, so this PR changes the default from `.pause` to `.pauseAndRestore`. This matches the behavior of the Core Animation engine, which isn't paused when backgrounded.