### PR TITLE
Allow customizing default AnimationCacheProvider

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -581,6 +581,9 @@
 		A40460592832C52B00ACFEDC /* BlendMode+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40460582832C52B00ACFEDC /* BlendMode+Filter.swift */; };
 		A404605A2832C52B00ACFEDC /* BlendMode+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40460582832C52B00ACFEDC /* BlendMode+Filter.swift */; };
 		A404605B2832C52B00ACFEDC /* BlendMode+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40460582832C52B00ACFEDC /* BlendMode+Filter.swift */; };
+		D453D8AB28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */; };
+		D453D8AC28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */; };
+		D453D8AD28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -799,6 +802,7 @@
 		7E48BF5F2860D4FA00A39198 /* KeyframeGroup+Extensions.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = "KeyframeGroup+Extensions.swift"; sourceTree = "<group>"; tabWidth = 4; };
 		A1D5BAAB27C731A500777D06 /* DataURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataURLTests.swift; sourceTree = "<group>"; };
 		A40460582832C52B00ACFEDC /* BlendMode+Filter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BlendMode+Filter.swift"; sourceTree = "<group>"; };
+		D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieAnimationCache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1433,6 +1437,7 @@
 			children = (
 				2EAF59E227A0798700E00531 /* AnimationCacheProvider.swift */,
 				2EAF59E327A0798700E00531 /* LRUAnimationCache.swift */,
+				D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */,
 			);
 			path = AnimationCache;
 			sourceTree = "<group>";
@@ -1695,6 +1700,7 @@
 				2E9C973E2822F43100677516 /* LayerDebugging.swift in Sources */,
 				6D99D6432823790700E5205B /* LegacyGradientFillRenderer.swift in Sources */,
 				2EAF5B0427A0798700E00531 /* AnimationFontProvider.swift in Sources */,
+				D453D8AB28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */,
 				2E9C96DB2822F43100677516 /* TextLayer.swift in Sources */,
 				2E9C964B2822F43100677516 /* TextCompositionLayer.swift in Sources */,
 				2EAF5AA427A0798700E00531 /* FilepathImageProvider.macOS.swift in Sources */,
@@ -1908,6 +1914,7 @@
 				2E9C973F2822F43100677516 /* LayerDebugging.swift in Sources */,
 				6D99D6442823790700E5205B /* LegacyGradientFillRenderer.swift in Sources */,
 				2EAF5B0527A0798700E00531 /* AnimationFontProvider.swift in Sources */,
+				D453D8AC28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */,
 				2E9C96DC2822F43100677516 /* TextLayer.swift in Sources */,
 				2E9C964C2822F43100677516 /* TextCompositionLayer.swift in Sources */,
 				2EAF5AA527A0798700E00531 /* FilepathImageProvider.macOS.swift in Sources */,
@@ -2100,6 +2107,7 @@
 				2E9C97402822F43100677516 /* LayerDebugging.swift in Sources */,
 				6D99D6452823790700E5205B /* LegacyGradientFillRenderer.swift in Sources */,
 				2EAF5B0627A0798700E00531 /* AnimationFontProvider.swift in Sources */,
+				D453D8AD28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */,
 				2E9C96DD2822F43100677516 /* TextLayer.swift in Sources */,
 				2E9C964D2822F43100677516 /* TextCompositionLayer.swift in Sources */,
 				2EAF5AA627A0798700E00531 /* FilepathImageProvider.macOS.swift in Sources */,

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -35,14 +35,14 @@ extension LottieAnimation {
   /// - Parameter name: The name of the json file without the json extension. EG "StarAnimation"
   /// - Parameter bundle: The bundle in which the animation is located. Defaults to `Bundle.main`
   /// - Parameter subdirectory: A subdirectory in the bundle in which the animation is located. Optional.
-  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieConfiguration.shared.animationCache`. Optional.
+  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieAnimationCache.shared`. Optional.
   ///
   /// - Returns: Deserialized `LottieAnimation`. Optional.
   public static func named(
     _ name: String,
     bundle: Bundle = Bundle.main,
     subdirectory: String? = nil,
-    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache)
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared)
     -> LottieAnimation?
   {
     /// Create a cache key for the animation.
@@ -74,12 +74,12 @@ extension LottieAnimation {
 
   /// Loads an animation from a specific filepath.
   /// - Parameter filepath: The absolute filepath of the animation to load. EG "/User/Me/starAnimation.json"
-  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieConfiguration.shared.animationCache`. Optional.
+  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieAnimationCache.shared`. Optional.
   ///
   /// - Returns: Deserialized `LottieAnimation`. Optional.
   public static func filepath(
     _ filepath: String,
-    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache)
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared)
     -> LottieAnimation?
   {
     /// Check cache for animation
@@ -105,12 +105,12 @@ extension LottieAnimation {
   ///    Loads an animation model from the asset catalog by its name. Returns `nil` if an animation is not found.
   ///    - Parameter name: The name of the json file in the asset catalog. EG "StarAnimation"
   ///    - Parameter bundle: The bundle in which the animation is located. Defaults to `Bundle.main`
-  ///    - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieConfiguration.shared.animationCache` Optional.
+  ///    - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieAnimationCache.shared` Optional.
   ///    - Returns: Deserialized `LottieAnimation`. Optional.
   public static func asset(
     _ name: String,
     bundle: Bundle = Bundle.main,
-    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache)
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared)
     -> LottieAnimation?
   {
     /// Create a cache key for the animation.
@@ -168,13 +168,13 @@ extension LottieAnimation {
   ///
   /// - Parameter url: The url to load the animation from.
   /// - Parameter closure: A closure to be called when the animation has loaded.
-  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieConfiguration.shared.animationCache`. Optional.
+  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieAnimationCache.shared`. Optional.
   ///
   public static func loadedFrom(
     url: URL,
     session: URLSession = .shared,
     closure: @escaping LottieAnimation.DownloadClosure,
-    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache)
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared)
   {
     if let animationCache = animationCache, let animation = animationCache.animation(forKey: url.absoluteString) {
       closure(animation)

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -35,14 +35,14 @@ extension LottieAnimation {
   /// - Parameter name: The name of the json file without the json extension. EG "StarAnimation"
   /// - Parameter bundle: The bundle in which the animation is located. Defaults to `Bundle.main`
   /// - Parameter subdirectory: A subdirectory in the bundle in which the animation is located. Optional.
-  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LRUAnimationCache.sharedCache`. Optional.
+  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieConfiguration.shared.animationCache`. Optional.
   ///
   /// - Returns: Deserialized `LottieAnimation`. Optional.
   public static func named(
     _ name: String,
     bundle: Bundle = Bundle.main,
     subdirectory: String? = nil,
-    animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache)
+    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache)
     -> LottieAnimation?
   {
     /// Create a cache key for the animation.
@@ -74,12 +74,12 @@ extension LottieAnimation {
 
   /// Loads an animation from a specific filepath.
   /// - Parameter filepath: The absolute filepath of the animation to load. EG "/User/Me/starAnimation.json"
-  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LRUAnimationCache.sharedCache`. Optional.
+  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieConfiguration.shared.animationCache`. Optional.
   ///
   /// - Returns: Deserialized `LottieAnimation`. Optional.
   public static func filepath(
     _ filepath: String,
-    animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache)
+    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache)
     -> LottieAnimation?
   {
     /// Check cache for animation
@@ -105,12 +105,12 @@ extension LottieAnimation {
   ///    Loads an animation model from the asset catalog by its name. Returns `nil` if an animation is not found.
   ///    - Parameter name: The name of the json file in the asset catalog. EG "StarAnimation"
   ///    - Parameter bundle: The bundle in which the animation is located. Defaults to `Bundle.main`
-  ///    - Parameter animationCache: A cache for holding loaded animations. Defaults to `LRUAnimationCache.sharedCache` Optional.
+  ///    - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieConfiguration.shared.animationCache` Optional.
   ///    - Returns: Deserialized `LottieAnimation`. Optional.
   public static func asset(
     _ name: String,
     bundle: Bundle = Bundle.main,
-    animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache)
+    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache)
     -> LottieAnimation?
   {
     /// Create a cache key for the animation.
@@ -168,13 +168,13 @@ extension LottieAnimation {
   ///
   /// - Parameter url: The url to load the animation from.
   /// - Parameter closure: A closure to be called when the animation has loaded.
-  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LRUAnimationCache.sharedCache`. Optional.
+  /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieConfiguration.shared.animationCache`. Optional.
   ///
   public static func loadedFrom(
     url: URL,
     session: URLSession = .shared,
     closure: @escaping LottieAnimation.DownloadClosure,
-    animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache)
+    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache)
   {
     if let animationCache = animationCache, let animation = animationCache.animation(forKey: url.absoluteString) {
       closure(animation)

--- a/Sources/Public/Animation/LottieAnimationViewInitializers.swift
+++ b/Sources/Public/Animation/LottieAnimationViewInitializers.swift
@@ -23,7 +23,7 @@ extension LottieAnimationView {
     name: String,
     bundle: Bundle = Bundle.main,
     imageProvider: AnimationImageProvider? = nil,
-    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache,
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared,
     configuration: LottieConfiguration = .shared)
   {
     let animation = LottieAnimation.named(name, bundle: bundle, subdirectory: nil, animationCache: animationCache)
@@ -39,7 +39,7 @@ extension LottieAnimationView {
   public convenience init(
     filePath: String,
     imageProvider: AnimationImageProvider? = nil,
-    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache,
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared,
     configuration: LottieConfiguration = .shared)
   {
     let animation = LottieAnimation.filepath(filePath, animationCache: animationCache)
@@ -58,7 +58,7 @@ extension LottieAnimationView {
     url: URL,
     imageProvider: AnimationImageProvider? = nil,
     closure: @escaping LottieAnimationView.DownloadClosure,
-    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache,
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared,
     configuration: LottieConfiguration = .shared)
   {
     if let animationCache = animationCache, let animation = animationCache.animation(forKey: url.absoluteString) {
@@ -88,7 +88,7 @@ extension LottieAnimationView {
     asset name: String,
     bundle: Bundle = Bundle.main,
     imageProvider: AnimationImageProvider? = nil,
-    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache,
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared,
     configuration: LottieConfiguration = .shared)
   {
     let animation = LottieAnimation.asset(name, bundle: bundle, animationCache: animationCache)

--- a/Sources/Public/Animation/LottieAnimationViewInitializers.swift
+++ b/Sources/Public/Animation/LottieAnimationViewInitializers.swift
@@ -23,7 +23,7 @@ extension LottieAnimationView {
     name: String,
     bundle: Bundle = Bundle.main,
     imageProvider: AnimationImageProvider? = nil,
-    animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache,
+    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache,
     configuration: LottieConfiguration = .shared)
   {
     let animation = LottieAnimation.named(name, bundle: bundle, subdirectory: nil, animationCache: animationCache)
@@ -39,7 +39,7 @@ extension LottieAnimationView {
   public convenience init(
     filePath: String,
     imageProvider: AnimationImageProvider? = nil,
-    animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache,
+    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache,
     configuration: LottieConfiguration = .shared)
   {
     let animation = LottieAnimation.filepath(filePath, animationCache: animationCache)
@@ -58,7 +58,7 @@ extension LottieAnimationView {
     url: URL,
     imageProvider: AnimationImageProvider? = nil,
     closure: @escaping LottieAnimationView.DownloadClosure,
-    animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache,
+    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache,
     configuration: LottieConfiguration = .shared)
   {
     if let animationCache = animationCache, let animation = animationCache.animation(forKey: url.absoluteString) {
@@ -88,7 +88,7 @@ extension LottieAnimationView {
     asset name: String,
     bundle: Bundle = Bundle.main,
     imageProvider: AnimationImageProvider? = nil,
-    animationCache: AnimationCacheProvider? = LRUAnimationCache.sharedCache,
+    animationCache: AnimationCacheProvider? = LottieConfiguration.shared.animationCache,
     configuration: LottieConfiguration = .shared)
   {
     let animation = LottieAnimation.asset(name, bundle: bundle, animationCache: animationCache)

--- a/Sources/Public/AnimationCache/AnimationCacheProvider.swift
+++ b/Sources/Public/AnimationCache/AnimationCacheProvider.swift
@@ -11,7 +11,7 @@ import Foundation
 /// can increase performance when loading an animation multiple times.
 ///
 /// Lottie comes with a prebuilt LRU Animation Cache.
-public protocol AnimationCacheProvider {
+public protocol AnimationCacheProvider: AnyObject {
 
   func animation(forKey: String) -> LottieAnimation?
 

--- a/Sources/Public/AnimationCache/LottieAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LottieAnimationCache.swift
@@ -5,6 +5,7 @@
 //  Created by Marcelo Fabri on 10/17/22.
 //
 
+/// A customization point to configure which `AnimationCacheProvider` will be used.
 public enum LottieAnimationCache {
 
   /// The animation cache that will be used when loading `LottieAnimation` models.

--- a/Sources/Public/AnimationCache/LottieAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LottieAnimationCache.swift
@@ -1,0 +1,14 @@
+//
+//  LottieAnimationCache.swift
+//  Lottie
+//
+//  Created by Marcelo Fabri on 10/17/22.
+//
+
+public enum LottieAnimationCache {
+
+  /// The animation cache that will be used when loading `LottieAnimation` models.
+  /// Using an Animation Cache can increase performance when loading an animation multiple times.
+  /// Defaults to LRUAnimationCache.sharedCache.
+  public static var shared: AnimationCacheProvider? = LRUAnimationCache.sharedCache
+}


### PR DESCRIPTION
Motivated by https://github.com/airbnb/lottie-ios/issues/1774, I think it's important that we have a single customization point for which animation cache should be used, instead of using `LRUAnimationCache.sharedCache` everywhere.