### PR TITLE
Replace LRUAnimationCache with a thread-safe NSCache-based cache

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -584,6 +584,10 @@
 		D453D8AB28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */; };
 		D453D8AC28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */; };
 		D453D8AD28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */; };
+		D453D8AF28FF9BC600D3F49C /* AnimationCacheProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AE28FF9BC600D3F49C /* AnimationCacheProviderTests.swift */; };
+		D453D8B228FF9EA900D3F49C /* ThreadSafeAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */; };
+		D453D8B328FF9EAA00D3F49C /* ThreadSafeAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */; };
+		D453D8B428FF9EAA00D3F49C /* ThreadSafeAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -803,6 +807,8 @@
 		A1D5BAAB27C731A500777D06 /* DataURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataURLTests.swift; sourceTree = "<group>"; };
 		A40460582832C52B00ACFEDC /* BlendMode+Filter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BlendMode+Filter.swift"; sourceTree = "<group>"; };
 		D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieAnimationCache.swift; sourceTree = "<group>"; };
+		D453D8AE28FF9BC600D3F49C /* AnimationCacheProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationCacheProviderTests.swift; sourceTree = "<group>"; };
+		D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeAnimationCache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -875,6 +881,7 @@
 				2E8040BD27A07343006E74CB /* Utils */,
 				2E044E262820536800FA773B /* AutomaticEngineTests.swift */,
 				6DB3BDB528243FA5002A276D /* ValueProvidersTests.swift */,
+				D453D8AE28FF9BC600D3F49C /* AnimationCacheProviderTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1438,6 +1445,7 @@
 				2EAF59E227A0798700E00531 /* AnimationCacheProvider.swift */,
 				2EAF59E327A0798700E00531 /* LRUAnimationCache.swift */,
 				D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */,
+				D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */,
 			);
 			path = AnimationCache;
 			sourceTree = "<group>";
@@ -1706,6 +1714,7 @@
 				2EAF5AA427A0798700E00531 /* FilepathImageProvider.macOS.swift in Sources */,
 				2E9C97292822F43100677516 /* EllipseAnimation.swift in Sources */,
 				2E9C96DE2822F43100677516 /* GradientRenderLayer.swift in Sources */,
+				D453D8B428FF9EAA00D3F49C /* ThreadSafeAnimationCache.swift in Sources */,
 				2E9C966C2822F43100677516 /* LayerImageProvider.swift in Sources */,
 				2EAF5ABC27A0798700E00531 /* FilepathImageProvider.swift in Sources */,
 				2EAF5AE927A0798700E00531 /* AnimationTextProvider.swift in Sources */,
@@ -1897,6 +1906,7 @@
 				6DB3BDB628243FA5002A276D /* ValueProvidersTests.swift in Sources */,
 				2E72128327BB329C0027BC56 /* AnimationKeypathTests.swift in Sources */,
 				2E044E272820536800FA773B /* AutomaticEngineTests.swift in Sources */,
+				D453D8AF28FF9BC600D3F49C /* AnimationCacheProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1920,6 +1930,7 @@
 				2EAF5AA527A0798700E00531 /* FilepathImageProvider.macOS.swift in Sources */,
 				2E9C972A2822F43100677516 /* EllipseAnimation.swift in Sources */,
 				2E9C96DF2822F43100677516 /* GradientRenderLayer.swift in Sources */,
+				D453D8B228FF9EA900D3F49C /* ThreadSafeAnimationCache.swift in Sources */,
 				2E9C966D2822F43100677516 /* LayerImageProvider.swift in Sources */,
 				2EAF5ABD27A0798700E00531 /* FilepathImageProvider.swift in Sources */,
 				2EAF5AEA27A0798700E00531 /* AnimationTextProvider.swift in Sources */,
@@ -2113,6 +2124,7 @@
 				2EAF5AA627A0798700E00531 /* FilepathImageProvider.macOS.swift in Sources */,
 				2E9C972B2822F43100677516 /* EllipseAnimation.swift in Sources */,
 				2E9C96E02822F43100677516 /* GradientRenderLayer.swift in Sources */,
+				D453D8B328FF9EAA00D3F49C /* ThreadSafeAnimationCache.swift in Sources */,
 				2E9C966E2822F43100677516 /* LayerImageProvider.swift in Sources */,
 				2EAF5ABE27A0798700E00531 /* FilepathImageProvider.swift in Sources */,
 				2EAF5AEB27A0798700E00531 /* AnimationTextProvider.swift in Sources */,

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -585,9 +585,9 @@
 		D453D8AC28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */; };
 		D453D8AD28FE6EE300D3F49C /* LottieAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */; };
 		D453D8AF28FF9BC600D3F49C /* AnimationCacheProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8AE28FF9BC600D3F49C /* AnimationCacheProviderTests.swift */; };
-		D453D8B228FF9EA900D3F49C /* ThreadSafeAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */; };
-		D453D8B328FF9EAA00D3F49C /* ThreadSafeAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */; };
-		D453D8B428FF9EAA00D3F49C /* ThreadSafeAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */; };
+		D453D8B228FF9EA900D3F49C /* DefaultAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8B028FF9E3A00D3F49C /* DefaultAnimationCache.swift */; };
+		D453D8B328FF9EAA00D3F49C /* DefaultAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8B028FF9E3A00D3F49C /* DefaultAnimationCache.swift */; };
+		D453D8B428FF9EAA00D3F49C /* DefaultAnimationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D453D8B028FF9E3A00D3F49C /* DefaultAnimationCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -808,7 +808,7 @@
 		A40460582832C52B00ACFEDC /* BlendMode+Filter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BlendMode+Filter.swift"; sourceTree = "<group>"; };
 		D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieAnimationCache.swift; sourceTree = "<group>"; };
 		D453D8AE28FF9BC600D3F49C /* AnimationCacheProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationCacheProviderTests.swift; sourceTree = "<group>"; };
-		D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeAnimationCache.swift; sourceTree = "<group>"; };
+		D453D8B028FF9E3A00D3F49C /* DefaultAnimationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAnimationCache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1445,7 +1445,7 @@
 				2EAF59E227A0798700E00531 /* AnimationCacheProvider.swift */,
 				2EAF59E327A0798700E00531 /* LRUAnimationCache.swift */,
 				D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */,
-				D453D8B028FF9E3A00D3F49C /* ThreadSafeAnimationCache.swift */,
+				D453D8B028FF9E3A00D3F49C /* DefaultAnimationCache.swift */,
 			);
 			path = AnimationCache;
 			sourceTree = "<group>";
@@ -1714,7 +1714,7 @@
 				2EAF5AA427A0798700E00531 /* FilepathImageProvider.macOS.swift in Sources */,
 				2E9C97292822F43100677516 /* EllipseAnimation.swift in Sources */,
 				2E9C96DE2822F43100677516 /* GradientRenderLayer.swift in Sources */,
-				D453D8B428FF9EAA00D3F49C /* ThreadSafeAnimationCache.swift in Sources */,
+				D453D8B428FF9EAA00D3F49C /* DefaultAnimationCache.swift in Sources */,
 				2E9C966C2822F43100677516 /* LayerImageProvider.swift in Sources */,
 				2EAF5ABC27A0798700E00531 /* FilepathImageProvider.swift in Sources */,
 				2EAF5AE927A0798700E00531 /* AnimationTextProvider.swift in Sources */,
@@ -1930,7 +1930,7 @@
 				2EAF5AA527A0798700E00531 /* FilepathImageProvider.macOS.swift in Sources */,
 				2E9C972A2822F43100677516 /* EllipseAnimation.swift in Sources */,
 				2E9C96DF2822F43100677516 /* GradientRenderLayer.swift in Sources */,
-				D453D8B228FF9EA900D3F49C /* ThreadSafeAnimationCache.swift in Sources */,
+				D453D8B228FF9EA900D3F49C /* DefaultAnimationCache.swift in Sources */,
 				2E9C966D2822F43100677516 /* LayerImageProvider.swift in Sources */,
 				2EAF5ABD27A0798700E00531 /* FilepathImageProvider.swift in Sources */,
 				2EAF5AEA27A0798700E00531 /* AnimationTextProvider.swift in Sources */,
@@ -2124,7 +2124,7 @@
 				2EAF5AA627A0798700E00531 /* FilepathImageProvider.macOS.swift in Sources */,
 				2E9C972B2822F43100677516 /* EllipseAnimation.swift in Sources */,
 				2E9C96E02822F43100677516 /* GradientRenderLayer.swift in Sources */,
-				D453D8B328FF9EAA00D3F49C /* ThreadSafeAnimationCache.swift in Sources */,
+				D453D8B328FF9EAA00D3F49C /* DefaultAnimationCache.swift in Sources */,
 				2E9C966E2822F43100677516 /* LayerImageProvider.swift in Sources */,
 				2EAF5ABE27A0798700E00531 /* FilepathImageProvider.swift in Sources */,
 				2EAF5AEB27A0798700E00531 /* AnimationTextProvider.swift in Sources */,

--- a/Sources/Public/AnimationCache/DefaultAnimationCache.swift
+++ b/Sources/Public/AnimationCache/DefaultAnimationCache.swift
@@ -1,5 +1,5 @@
 //
-//  ThreadSafeAnimationCache.swift
+//  DefaultAnimationCache.swift
 //  Lottie
 //
 //  Created by Marcelo Fabri on 10/18/22.
@@ -13,7 +13,7 @@ import Foundation
 /// The default size of the cache is 100.
 ///
 /// This cache implementation also responds to memory pressure, as it's backed by `NSCache`.
-public class ThreadSafeAnimationCache: AnimationCacheProvider {
+public class DefaultAnimationCache: AnimationCacheProvider {
 
   // MARK: Lifecycle
 
@@ -24,7 +24,7 @@ public class ThreadSafeAnimationCache: AnimationCacheProvider {
   // MARK: Public
 
   /// The global shared Cache.
-  public static let sharedCache = ThreadSafeAnimationCache()
+  public static let sharedCache = DefaultAnimationCache()
 
   /// The size of the cache.
   public var cacheSize = defaultCacheCountLimit {

--- a/Sources/Public/AnimationCache/LRUAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LRUAnimationCache.swift
@@ -7,5 +7,5 @@
 
 import Foundation
 
-@available(*, deprecated, message: "Use DefaultAnimationCache instead, which is thread-safe and automatically responds to memory pressure")
+@available(*, deprecated, message: "Use DefaultAnimationCache instead, which is thread-safe and automatically responds to memory pressure.")
 public typealias LRUAnimationCache = DefaultAnimationCache

--- a/Sources/Public/AnimationCache/LRUAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LRUAnimationCache.swift
@@ -11,6 +11,8 @@ import Foundation
 ///
 /// Once `cacheSize` is reached, the least recently used animation will be ejected.
 /// The default size of the cache is 100.
+///
+/// Note: this cache doesn't evict entries under memory pressury, nor is thread-safe.
 public class LRUAnimationCache: AnimationCacheProvider {
 
   // MARK: Lifecycle

--- a/Sources/Public/AnimationCache/LRUAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LRUAnimationCache.swift
@@ -7,5 +7,5 @@
 
 import Foundation
 
-@available(*, deprecated, message: "Use DefaultAnimationCache instead")
+@available(*, deprecated, message: "Use DefaultAnimationCache instead, which is thread-safe and automatically responds to memory pressure")
 public typealias LRUAnimationCache = DefaultAnimationCache

--- a/Sources/Public/AnimationCache/LRUAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LRUAnimationCache.swift
@@ -7,57 +7,5 @@
 
 import Foundation
 
-/// An Animation Cache that will store animations up to `cacheSize`.
-///
-/// Once `cacheSize` is reached, the least recently used animation will be ejected.
-/// The default size of the cache is 100.
-///
-/// Note: this cache doesn't evict entries under memory pressury, nor is thread-safe.
-public class LRUAnimationCache: AnimationCacheProvider {
-
-  // MARK: Lifecycle
-
-  public init() { }
-
-  // MARK: Public
-
-  /// The global shared Cache.
-  public static let sharedCache = LRUAnimationCache()
-
-  /// The size of the cache.
-  public var cacheSize = 100
-
-  /// Clears the Cache.
-  public func clearCache() {
-    cacheMap.removeAll()
-    lruList.removeAll()
-  }
-
-  public func animation(forKey: String) -> LottieAnimation? {
-    guard let animation = cacheMap[forKey] else {
-      return nil
-    }
-    if let index = lruList.firstIndex(of: forKey) {
-      lruList.remove(at: index)
-      lruList.append(forKey)
-    }
-    return animation
-  }
-
-  public func setAnimation(_ animation: LottieAnimation, forKey: String) {
-    cacheMap[forKey] = animation
-    lruList.append(forKey)
-    if lruList.count > cacheSize {
-      let removed = lruList.remove(at: 0)
-      if removed != forKey {
-        cacheMap[removed] = nil
-      }
-    }
-  }
-
-  // MARK: Fileprivate
-
-  fileprivate var cacheMap: [String: LottieAnimation] = [:]
-  fileprivate var lruList: [String] = []
-
-}
+@available(*, deprecated, message: "Use DefaultAnimationCache instead")
+public typealias LRUAnimationCache = DefaultAnimationCache

--- a/Sources/Public/AnimationCache/LRUAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LRUAnimationCache.swift
@@ -7,5 +7,7 @@
 
 import Foundation
 
-@available(*, deprecated, message: "Use DefaultAnimationCache instead, which is thread-safe and automatically responds to memory pressure.")
+@available(*, deprecated, message: """
+  Use DefaultAnimationCache instead, which is thread-safe and automatically responds to memory pressure.
+  """)
 public typealias LRUAnimationCache = DefaultAnimationCache

--- a/Sources/Public/AnimationCache/LottieAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LottieAnimationCache.swift
@@ -10,6 +10,6 @@ public enum LottieAnimationCache {
 
   /// The animation cache that will be used when loading `LottieAnimation` models.
   /// Using an Animation Cache can increase performance when loading an animation multiple times.
-  /// Defaults to LRUAnimationCache.sharedCache.
-  public static var shared: AnimationCacheProvider? = LRUAnimationCache.sharedCache
+  /// Defaults to DefaultAnimationCache.sharedCache.
+  public static var shared: AnimationCacheProvider? = DefaultAnimationCache.sharedCache
 }

--- a/Sources/Public/AnimationCache/ThreadSafeAnimationCache.swift
+++ b/Sources/Public/AnimationCache/ThreadSafeAnimationCache.swift
@@ -1,0 +1,54 @@
+//
+//  ThreadSafeAnimationCache.swift
+//  Lottie
+//
+//  Created by Marcelo Fabri on 10/18/22.
+//
+
+import Foundation
+
+/// A thread-safe Animation Cache that will store animations up to `cacheSize`.
+///
+/// Once `cacheSize` is reached, animations can be ejected.
+/// The default size of the cache is 100.
+///
+/// This cache implementation also responds to memory pressure, as it's backed by `NSCache`.
+public class ThreadSafeAnimationCache: AnimationCacheProvider {
+
+  // MARK: Lifecycle
+
+  public init() {
+    cache.countLimit = Self.defaultCacheCountLimit
+  }
+
+  // MARK: Public
+
+  /// The global shared Cache.
+  public static let sharedCache = ThreadSafeAnimationCache()
+
+  /// The size of the cache.
+  public var cacheSize = defaultCacheCountLimit {
+    didSet {
+      cache.countLimit = cacheSize
+    }
+  }
+
+  /// Clears the Cache.
+  public func clearCache() {
+    cache.removeAllObjects()
+  }
+
+  public func animation(forKey key: String) -> LottieAnimation? {
+    cache.object(forKey: key as NSString)
+  }
+
+  public func setAnimation(_ animation: LottieAnimation, forKey key: String) {
+    cache.setObject(animation, forKey: key as NSString)
+  }
+
+  // MARK: Private
+
+  private static let defaultCacheCountLimit = 100
+
+  private var cache = NSCache<NSString, LottieAnimation>()
+}

--- a/Tests/AnimationCacheProviderTests.swift
+++ b/Tests/AnimationCacheProviderTests.swift
@@ -11,48 +11,30 @@ import XCTest
 
 final class AnimationCacheProviderTests: XCTestCase {
 
-  // MARK: Internal
-
-  override func setUp() {
-    super.setUp()
-    lruCache = LRUAnimationCache()
-    threadSafeCache = ThreadSafeAnimationCache()
-    caches = [lruCache, threadSafeCache]
-  }
-
   func testCaches() throws {
+    let cache = DefaultAnimationCache()
     let animation1 = try XCTUnwrap(Samples.animation(named: "Boat_Loader"))
     let animation2 = try XCTUnwrap(Samples.animation(named: "TwitterHeart"))
 
-    for cache in caches {
-      XCTAssertNil(cache.animation(forKey: "animation1"))
-      cache.setAnimation(animation1, forKey: "animation1")
-      XCTAssertNoDiff(cache.animation(forKey: "animation1"), animation1)
+    XCTAssertNil(cache.animation(forKey: "animation1"))
+    cache.setAnimation(animation1, forKey: "animation1")
+    XCTAssertNoDiff(cache.animation(forKey: "animation1"), animation1)
 
-      XCTAssertNil(cache.animation(forKey: "animation2"))
-      cache.setAnimation(animation2, forKey: "animation2")
-      XCTAssertNoDiff(cache.animation(forKey: "animation2"), animation2)
-      XCTAssertNoDiff(cache.animation(forKey: "animation1"), animation1)
-    }
+    XCTAssertNil(cache.animation(forKey: "animation2"))
+    cache.setAnimation(animation2, forKey: "animation2")
+    XCTAssertNoDiff(cache.animation(forKey: "animation2"), animation2)
+    XCTAssertNoDiff(cache.animation(forKey: "animation1"), animation1)
   }
 
   func testClearCache() throws {
+    let cache = DefaultAnimationCache()
     let animation = try XCTUnwrap(Samples.animation(named: "Boat_Loader"))
 
-    for cache in caches {
-      XCTAssertNil(cache.animation(forKey: "animation"))
-      cache.setAnimation(animation, forKey: "animation")
-      XCTAssertNotNil(cache.animation(forKey: "animation"))
+    XCTAssertNil(cache.animation(forKey: "animation"))
+    cache.setAnimation(animation, forKey: "animation")
+    XCTAssertNotNil(cache.animation(forKey: "animation"))
 
-      cache.clearCache()
-      XCTAssertNil(cache.animation(forKey: "animation"))
-    }
+    cache.clearCache()
+    XCTAssertNil(cache.animation(forKey: "animation"))
   }
-
-  // MARK: Private
-
-  private var lruCache: LRUAnimationCache!
-  private var threadSafeCache: ThreadSafeAnimationCache!
-  private var caches: [AnimationCacheProvider]!
-
 }

--- a/Tests/AnimationCacheProviderTests.swift
+++ b/Tests/AnimationCacheProviderTests.swift
@@ -1,0 +1,58 @@
+//
+//  AnimationCacheProviderTests.swift
+//  LottieTests
+//
+//  Created by Marcelo Fabri on 10/18/22.
+//
+
+import XCTest
+
+@testable import Lottie
+
+final class AnimationCacheProviderTests: XCTestCase {
+
+  // MARK: Internal
+
+  override func setUp() {
+    super.setUp()
+    lruCache = LRUAnimationCache()
+    threadSafeCache = ThreadSafeAnimationCache()
+    caches = [lruCache, threadSafeCache]
+  }
+
+  func testCaches() throws {
+    let animation1 = try XCTUnwrap(Samples.animation(named: "Boat_Loader"))
+    let animation2 = try XCTUnwrap(Samples.animation(named: "TwitterHeart"))
+
+    for cache in caches {
+      XCTAssertNil(cache.animation(forKey: "animation1"))
+      cache.setAnimation(animation1, forKey: "animation1")
+      XCTAssertNoDiff(cache.animation(forKey: "animation1"), animation1)
+
+      XCTAssertNil(cache.animation(forKey: "animation2"))
+      cache.setAnimation(animation2, forKey: "animation2")
+      XCTAssertNoDiff(cache.animation(forKey: "animation2"), animation2)
+      XCTAssertNoDiff(cache.animation(forKey: "animation1"), animation1)
+    }
+  }
+
+  func testClearCache() throws {
+    let animation = try XCTUnwrap(Samples.animation(named: "Boat_Loader"))
+
+    for cache in caches {
+      XCTAssertNil(cache.animation(forKey: "animation"))
+      cache.setAnimation(animation, forKey: "animation")
+      XCTAssertNotNil(cache.animation(forKey: "animation"))
+
+      cache.clearCache()
+      XCTAssertNil(cache.animation(forKey: "animation"))
+    }
+  }
+
+  // MARK: Private
+
+  private var lruCache: LRUAnimationCache!
+  private var threadSafeCache: ThreadSafeAnimationCache!
+  private var caches: [AnimationCacheProvider]!
+
+}


### PR DESCRIPTION
Fixes https://github.com/airbnb/lottie-ios/issues/1774. Fixes https://github.com/airbnb/lottie-ios/issues/1410.

I think we should also change the default to use this new implementation as it can be surprising if the default implementation is not thread-safe.