### PR TITLE
Add completion callbacks to LottieAnimationView DotLottie initializers

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0887347B28F0CCDD00458627 /* LottieAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0887347428F0CCDD00458627 /* LottieAnimationView.swift */; };
 		0887347C28F0CCDD00458627 /* LottieAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0887347428F0CCDD00458627 /* LottieAnimationView.swift */; };
 		0887347D28F0CCDD00458627 /* LottieAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0887347428F0CCDD00458627 /* LottieAnimationView.swift */; };
+		08CB2681291ED2B700B4F071 /* AnimationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB2680291ED2B700B4F071 /* AnimationViewTests.swift */; };
 		08EED05028F0D2D10057D958 /* LottieColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EED04F28F0D2D10057D958 /* LottieColor.swift */; };
 		08EED05128F0D2D10057D958 /* LottieColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EED04F28F0D2D10057D958 /* LottieColor.swift */; };
 		08EED05228F0D2D10057D958 /* LottieColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EED04F28F0D2D10057D958 /* LottieColor.swift */; };
@@ -662,6 +663,7 @@
 		0887347228F0CCDD00458627 /* LottieAnimationHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LottieAnimationHelpers.swift; sourceTree = "<group>"; };
 		0887347328F0CCDD00458627 /* LottieAnimationViewInitializers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LottieAnimationViewInitializers.swift; sourceTree = "<group>"; };
 		0887347428F0CCDD00458627 /* LottieAnimationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LottieAnimationView.swift; sourceTree = "<group>"; };
+		08CB2680291ED2B700B4F071 /* AnimationViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationViewTests.swift; sourceTree = "<group>"; };
 		08EED04F28F0D2D10057D958 /* LottieColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LottieColor.swift; sourceTree = "<group>"; };
 		08EF21DB289C643B0097EA47 /* KeyframeInterpolator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyframeInterpolator.swift; sourceTree = "<group>"; };
 		08F8B20C2898A7B100CB5323 /* RepeaterLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeaterLayer.swift; sourceTree = "<group>"; };
@@ -958,6 +960,7 @@
 				2E044E262820536800FA773B /* AutomaticEngineTests.swift */,
 				6DB3BDB528243FA5002A276D /* ValueProvidersTests.swift */,
 				D453D8AE28FF9BC600D3F49C /* AnimationCacheProviderTests.swift */,
+				08CB2680291ED2B700B4F071 /* AnimationViewTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -2041,6 +2044,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08F8B213289990CB00CB5323 /* SnapshotTests.swift in Sources */,
+				08CB2681291ED2B700B4F071 /* AnimationViewTests.swift in Sources */,
 				A1D5BAAC27C731A500777D06 /* DataURLTests.swift in Sources */,
 				2E8044AD27A07347006E74CB /* HardcodedImageProvider.swift in Sources */,
 				2E09FA0627B6CEB600BA84E5 /* HardcodedFontProvider.swift in Sources */,

--- a/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,24 @@
         }
       },
       {
+        "package": "AirbnbSwift",
+        "repositoryURL": "https://github.com/airbnb/swift",
+        "state": {
+          "branch": null,
+          "revision": "7884f265499752cc5eccaa9eba08b4a2f8b73357",
+          "version": null
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "fddd1c00396eed152c45a46bea9f47b98e59301d",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "swift-snapshot-testing",
         "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
         "state": {

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -303,3 +303,15 @@ extension LottieAnimation {
     CGFloat(time * framerate) + startFrame
   }
 }
+
+// MARK: - Foundation.Bundle + Sendable
+
+/// Necessary to suppress warnings like:
+/// ```
+/// Non-sendable type 'Bundle' exiting main actor-isolated context in call to non-isolated
+/// static method 'named(_:bundle:subdirectory:dotLottieCache:)' cannot cross actor boundary
+/// ```
+/// This retroactive conformance is safe because Sendable is a marker protocol that doesn't
+/// include any runtime component. Multiple modules in the same package graph can provide this
+/// conformance without causing any conflicts.
+extension Foundation.Bundle: @unchecked Sendable { }

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -225,6 +225,45 @@ final public class LottieAnimationView: LottieAnimationViewBase {
   public var animation: LottieAnimation? {
     didSet {
       makeAnimationLayer(usingEngine: configuration.renderingEngine)
+
+      if let animation = animation {
+        animationLoaded?(self, animation)
+      }
+    }
+  }
+
+  /// A closure that is called when `self.animation` is loaded. When setting this closure,
+  /// it is called immediately if `self.animation` is non-nil.
+  ///
+  /// When initializing a `LottieAnimationView`, the animation will either be loaded
+  /// synchronously (when loading a `LottieAnimation` from a .json file on disk)
+  /// or asynchronously (when loading a `DotLottieFile` from disk, or downloading
+  /// an animation from a URL). This closure is called in both cases once the
+  /// animation is loaded and applied, so can be a useful way to configure this
+  /// `LottieAnimationView` regardless of which initializer was used. For example:
+  ///
+  /// ```
+  /// let animationView: LottieAnimationView
+  ///
+  /// if loadDotLottieFile {
+  ///   // Loads the .lottie file asynchronously
+  ///   animationView = LottieAnimationView(dotLottieName: "animation")
+  /// } else {
+  ///   // Loads the .json file synchronously
+  ///   animationView = LottieAnimationView(name: "animation")
+  /// }
+  ///
+  /// animationView.animationLoaded = { animationView, animation in
+  ///   // If using a .lottie file, this is called once the file finishes loading.
+  ///   // If using a .json file, this is called immediately (since the animation is loaded synchronously).
+  ///   animationView.play()
+  /// }
+  /// ```
+  public var animationLoaded: ((_ animationView: LottieAnimationView, _ animation: LottieAnimation) -> Void)? {
+    didSet {
+      if let animation = animation {
+        animationLoaded?(self, animation)
+      }
     }
   }
 

--- a/Sources/Public/Animation/LottieAnimationViewInitializers.swift
+++ b/Sources/Public/Animation/LottieAnimationViewInitializers.swift
@@ -165,16 +165,16 @@ extension LottieAnimationView {
     animationId: String? = nil,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
     configuration: LottieConfiguration = .shared,
-    completion: @escaping (LottieAnimationView, Error?) -> Void)
+    completion: ((LottieAnimationView, Error?) -> Void)? = nil)
   {
     self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
     DotLottieFile.named(name, bundle: bundle, dotLottieCache: dotLottieCache) { result in
       switch result {
       case .success(let dotLottieFile):
         self.loadAnimation(animationId, from: dotLottieFile)
-        completion(self, nil)
+        completion?(self, nil)
       case .failure(let error):
-        completion(self, error)
+        completion?(self, error)
       }
     }
   }
@@ -208,16 +208,16 @@ extension LottieAnimationView {
     animationId: String? = nil,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
     configuration: LottieConfiguration = .shared,
-    completion: @escaping (LottieAnimationView, Error?) -> Void)
+    completion: ((LottieAnimationView, Error?) -> Void)? = nil)
   {
     self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
     DotLottieFile.loadedFrom(filepath: filePath, dotLottieCache: dotLottieCache) { result in
       switch result {
       case .success(let dotLottieFile):
         self.loadAnimation(animationId, from: dotLottieFile)
-        completion(self, nil)
+        completion?(self, nil)
       case .failure(let error):
-        completion(self, error)
+        completion?(self, error)
       }
     }
   }
@@ -253,20 +253,20 @@ extension LottieAnimationView {
     animationId: String? = nil,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
     configuration: LottieConfiguration = .shared,
-    completion: @escaping (LottieAnimationView, Error?) -> Void)
+    completion: ((LottieAnimationView, Error?) -> Void)? = nil)
   {
     if let dotLottieCache = dotLottieCache, let lottie = dotLottieCache.file(forKey: url.absoluteString) {
       self.init(dotLottie: lottie, animationId: animationId, configuration: configuration)
-      completion(self, nil)
+      completion?(self, nil)
     } else {
       self.init(dotLottie: nil, configuration: configuration)
       DotLottieFile.loadedFrom(url: url, dotLottieCache: dotLottieCache) { result in
         switch result {
         case .success(let lottie):
           self.loadAnimation(animationId, from: lottie)
-          completion(self, nil)
+          completion?(self, nil)
         case .failure(let error):
-          completion(self, error)
+          completion?(self, error)
         }
       }
     }
@@ -303,16 +303,16 @@ extension LottieAnimationView {
     animationId: String? = nil,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
     configuration: LottieConfiguration = .shared,
-    completion: @escaping (LottieAnimationView, Error?) -> Void)
+    completion: ((LottieAnimationView, Error?) -> Void)? = nil)
   {
     self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
     DotLottieFile.asset(named: name, bundle: bundle, dotLottieCache: dotLottieCache) { result in
       switch result {
       case .success(let dotLottieFile):
         self.loadAnimation(animationId, from: dotLottieFile)
-        completion(self, nil)
+        completion?(self, nil)
       case .failure(let error):
-        completion(self, error)
+        completion?(self, error)
       }
     }
   }

--- a/Sources/Public/Animation/LottieAnimationViewInitializers.swift
+++ b/Sources/Public/Animation/LottieAnimationViewInitializers.swift
@@ -110,14 +110,14 @@ extension LottieAnimationView {
   public convenience init(
     dotLottieName name: String,
     bundle: Bundle = Bundle.main,
-    subdirectory _: String? = nil,
+    subdirectory: String? = nil,
     animationId: String? = nil,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
     configuration: LottieConfiguration = .shared,
     completion: ((LottieAnimationView, Error?) -> Void)? = nil)
   {
     self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
-    DotLottieFile.named(name, bundle: bundle, dotLottieCache: dotLottieCache) { result in
+    DotLottieFile.named(name, bundle: bundle, subdirectory: subdirectory, dotLottieCache: dotLottieCache) { result in
       switch result {
       case .success(let dotLottieFile):
         self.loadAnimation(animationId, from: dotLottieFile)

--- a/Sources/Public/Animation/LottieAnimationViewInitializers.swift
+++ b/Sources/Public/Animation/LottieAnimationViewInitializers.swift
@@ -13,20 +13,20 @@ extension LottieAnimationView {
 
   /// Loads a Lottie animation from a JSON file in the supplied bundle.
   ///
-  /// - Parameter name: The string name of the lottie animation with no file
-  /// extension provided.
-  /// - Parameter bundle: The bundle in which the animation is located.
-  /// Defaults to the Main bundle.
+  /// - Parameter name: The string name of the lottie animation with no file extension provided.
+  /// - Parameter bundle: The bundle in which the animation is located. Defaults to the Main bundle.
+  /// - Parameter subdirectory: A subdirectory in the bundle in which the animation is located. Optional.
   /// - Parameter imageProvider: An image provider for the animation's image data.
   /// If none is supplied Lottie will search in the supplied bundle for images.
   public convenience init(
     name: String,
     bundle: Bundle = Bundle.main,
+    subdirectory: String? = nil,
     imageProvider: AnimationImageProvider? = nil,
     animationCache: AnimationCacheProvider? = LottieAnimationCache.shared,
     configuration: LottieConfiguration = .shared)
   {
-    let animation = LottieAnimation.named(name, bundle: bundle, subdirectory: nil, animationCache: animationCache)
+    let animation = LottieAnimation.named(name, bundle: bundle, subdirectory: subdirectory, animationCache: animationCache)
     let provider = imageProvider ?? BundleImageProvider(bundle: bundle, searchPath: nil)
     self.init(animation: animation, imageProvider: provider, configuration: configuration)
   }
@@ -78,6 +78,31 @@ extension LottieAnimationView {
     }
   }
 
+  /// Loads a Lottie animation asynchronously from the URL
+  ///
+  /// - Parameter url: The url to load the animation from.
+  /// - Parameter imageProvider: An image provider for the animation's image data.
+  /// If none is supplied Lottie will search in the main bundle for images.
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  public convenience init(
+    url: URL,
+    imageProvider: AnimationImageProvider? = nil,
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared,
+    configuration: LottieConfiguration = .shared) async throws
+  {
+    if let animationCache = animationCache, let animation = animationCache.animation(forKey: url.absoluteString) {
+      self.init(animation: animation, imageProvider: imageProvider, configuration: configuration)
+    } else {
+      self.init(animation: nil, imageProvider: imageProvider, configuration: configuration)
+
+      guard let animation = await LottieAnimation.loadedFrom(url: url, animationCache: animationCache) else {
+        throw LottieDownloadError.downloadFailed
+      }
+
+      self.animation = animation
+    }
+  }
+
   /// Loads a Lottie animation from a JSON file located in the Asset catalog of the supplied bundle.
   /// - Parameter name: The string name of the lottie animation in the asset catalog.
   /// - Parameter bundle: The bundle in which the animation is located.
@@ -100,68 +125,148 @@ extension LottieAnimationView {
 
   /// Loads a Lottie animation from a .lottie file in the supplied bundle.
   ///
-  /// - Parameter filePath: The string name of the lottie file with no file
-  /// extension provided.
-  /// - Parameter bundle: The bundle in which the file is located.
-  /// Defaults to the Main bundle.
+  /// - Parameter filePath: The name of the lottie file without the lottie extension. EG "StarAnimation"
+  /// - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
+  /// - Parameter subdirectory: A subdirectory in the bundle in which the lottie is located. Optional.
   /// - Parameter animationId: Animation id to play. Optional
+  /// Defaults to first animation in file
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  public convenience init(
+    dotLottieName name: String,
+    bundle: Bundle = Bundle.main,
+    subdirectory: String? = nil,
+    animationId: String? = nil,
+    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
+    configuration: LottieConfiguration = .shared) async throws
+  {
+    self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
+
+    let dotLottieFile = try await DotLottieFile.named(
+      name,
+      bundle: bundle,
+      subdirectory: subdirectory,
+      dotLottieCache: dotLottieCache)
+
+    loadAnimation(animationId, from: dotLottieFile)
+  }
+
+  /// Loads a Lottie animation from a .lottie file in the supplied bundle.
+  ///
+  /// - Parameter dotLottieName: The name of the lottie file without the lottie extension. EG "StarAnimation"
+  /// - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
+  /// - Parameter subdirectory: A subdirectory in the bundle in which the lottie is located. Optional.
+  /// - Parameter animationId: Animation id to play. Optional
+  /// - Parameter completion: A closure that is called when the .lottie file is finished loading
   /// Defaults to first animation in file
   public convenience init(
     dotLottieName name: String,
     bundle: Bundle = Bundle.main,
+    subdirectory _: String? = nil,
     animationId: String? = nil,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
-    configuration: LottieConfiguration = .shared)
+    configuration: LottieConfiguration = .shared,
+    completion: @escaping (LottieAnimationView, Error?) -> Void)
   {
     self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
     DotLottieFile.named(name, bundle: bundle, dotLottieCache: dotLottieCache) { result in
-      guard case Result.success(let lottie) = result else { return }
-      self.loadAnimation(animationId, from: lottie)
+      switch result {
+      case .success(let dotLottieFile):
+        self.loadAnimation(animationId, from: dotLottieFile)
+        completion(self, nil)
+      case .failure(let error):
+        completion(self, error)
+      }
     }
   }
 
   /// Loads a Lottie from a .lottie file in a specific path on disk.
   ///
-  /// - Parameter filePath: The absolute path of the Lottie file.
+  /// - Parameter dotLottieFilePath: The absolute path of the Lottie file.
   /// - Parameter animationId: Animation id to play. Optional
+  /// Defaults to first animation in file
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  public convenience init(
+    dotLottieFilePath filePath: String,
+    animationId: String? = nil,
+    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
+    configuration: LottieConfiguration = .shared) async throws
+  {
+    self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
+
+    let dotLottieFile = try await DotLottieFile.loadedFrom(filepath: filePath, dotLottieCache: dotLottieCache)
+    loadAnimation(animationId, from: dotLottieFile)
+  }
+
+  /// Loads a Lottie from a .lottie file in a specific path on disk.
+  ///
+  /// - Parameter dotLottieFilePath: The absolute path of the Lottie file.
+  /// - Parameter animationId: Animation id to play. Optional
+  /// - Parameter completion: A closure that is called when the .lottie file is finished loading
   /// Defaults to first animation in file
   public convenience init(
     dotLottieFilePath filePath: String,
     animationId: String? = nil,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
-    configuration: LottieConfiguration = .shared)
+    configuration: LottieConfiguration = .shared,
+    completion: @escaping (LottieAnimationView, Error?) -> Void)
   {
     self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
     DotLottieFile.loadedFrom(filepath: filePath, dotLottieCache: dotLottieCache) { result in
-      guard case Result.success(let lottie) = result else { return }
-      self.loadAnimation(animationId, from: lottie)
+      switch result {
+      case .success(let dotLottieFile):
+        self.loadAnimation(animationId, from: dotLottieFile)
+        completion(self, nil)
+      case .failure(let error):
+        completion(self, error)
+      }
     }
   }
 
   /// Loads a Lottie file asynchronously from the URL
   ///
   /// - Parameter dotLottieUrl: The url to load the lottie file from.
-  /// - Parameter animationId: Animation id to play. Optional
-  /// Defaults to first animation in file
-  /// - Parameter closure: A closure to be called when the animation has loaded.
+  /// - Parameter animationId: Animation id to play. Optional. Defaults to first animation in file.
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   public convenience init(
     dotLottieUrl url: URL,
     animationId: String? = nil,
-    closure: @escaping LottieAnimationView.DownloadClosure,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
-    configuration: LottieConfiguration = .shared)
+    configuration: LottieConfiguration = .shared) async throws
   {
     if let dotLottieCache = dotLottieCache, let lottie = dotLottieCache.file(forKey: url.absoluteString) {
       self.init(dotLottie: lottie, animationId: animationId, configuration: configuration)
-      closure(nil)
+    } else {
+      self.init(dotLottie: nil, configuration: configuration)
+
+      let dotLottieFile = try await DotLottieFile.loadedFrom(url: url, dotLottieCache: dotLottieCache)
+      loadAnimation(animationId, from: dotLottieFile)
+    }
+  }
+
+  /// Loads a Lottie file asynchronously from the URL
+  ///
+  /// - Parameter dotLottieUrl: The url to load the lottie file from.
+  /// - Parameter animationId: Animation id to play. Optional. Defaults to first animation in file.
+  /// - Parameter completion: A closure to be called when the animation has loaded.
+  public convenience init(
+    dotLottieUrl url: URL,
+    animationId: String? = nil,
+    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
+    configuration: LottieConfiguration = .shared,
+    completion: @escaping (LottieAnimationView, Error?) -> Void)
+  {
+    if let dotLottieCache = dotLottieCache, let lottie = dotLottieCache.file(forKey: url.absoluteString) {
+      self.init(dotLottie: lottie, animationId: animationId, configuration: configuration)
+      completion(self, nil)
     } else {
       self.init(dotLottie: nil, configuration: configuration)
       DotLottieFile.loadedFrom(url: url, dotLottieCache: dotLottieCache) { result in
         switch result {
         case .success(let lottie):
           self.loadAnimation(animationId, from: lottie)
+          completion(self, nil)
         case .failure(let error):
-          closure(error)
+          completion(self, error)
         }
       }
     }
@@ -169,21 +274,46 @@ extension LottieAnimationView {
 
   /// Loads a Lottie from a .lottie file located in the Asset catalog of the supplied bundle.
   /// - Parameter name: The string name of the lottie file in the asset catalog.
-  /// - Parameter bundle: The bundle in which the file is located.
-  /// Defaults to the Main bundle.
+  /// - Parameter bundle: The bundle in which the file is located. Defaults to the Main bundle.
   /// - Parameter animationId: Animation id to play. Optional
+  /// Defaults to first animation in file
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  public convenience init(
+    dotLottieAsset name: String,
+    bundle: Bundle = Bundle.main,
+    animationId: String? = nil,
+    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
+    configuration: LottieConfiguration = .shared) async throws
+  {
+    self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
+
+    let dotLottieFile = try await DotLottieFile.asset(named: name, bundle: bundle, dotLottieCache: dotLottieCache)
+    loadAnimation(animationId, from: dotLottieFile)
+  }
+
+  /// Loads a Lottie from a .lottie file located in the Asset catalog of the supplied bundle.
+  /// - Parameter name: The string name of the lottie file in the asset catalog.
+  /// - Parameter bundle: The bundle in which the file is located. Defaults to the Main bundle.
+  /// - Parameter animationId: Animation id to play. Optional
+  /// - Parameter completion: A closure that is called when the .lottie file is finished loading
   /// Defaults to first animation in file
   public convenience init(
     dotLottieAsset name: String,
     bundle: Bundle = Bundle.main,
     animationId: String? = nil,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
-    configuration: LottieConfiguration = .shared)
+    configuration: LottieConfiguration = .shared,
+    completion: @escaping (LottieAnimationView, Error?) -> Void)
   {
     self.init(dotLottie: nil, animationId: animationId, configuration: configuration)
     DotLottieFile.asset(named: name, bundle: bundle, dotLottieCache: dotLottieCache) { result in
-      guard case Result.success(let lottie) = result else { return }
-      self.loadAnimation(animationId, from: lottie)
+      switch result {
+      case .success(let dotLottieFile):
+        self.loadAnimation(animationId, from: dotLottieFile)
+        completion(self, nil)
+      case .failure(let error):
+        completion(self, error)
+      }
     }
   }
 
@@ -198,3 +328,12 @@ extension LottieAnimationView {
 enum LottieDownloadError: Error {
   case downloadFailed
 }
+
+// MARK: - Foundation.Bundle + Sendable
+
+/// Necessary to suppress warnings like:
+/// ```
+/// Non-sendable type 'Bundle' exiting main actor-isolated context in call to non-isolated
+/// static method 'named(_:bundle:subdirectory:dotLottieCache:)' cannot cross actor boundary
+/// ```
+extension Foundation.Bundle: @unchecked Sendable { }

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -138,10 +138,10 @@ extension DotLottieFile {
     }
   }
 
-  ///    Loads a DotLottie model from the asset catalog by its name. Returns `nil` if a lottie is not found.
-  ///    - Parameter name: The name of the lottie file in the asset catalog. EG "StarAnimation"
-  ///    - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
-  ///    - Parameter dotLottieCache: A cache for holding loaded lottie files. Defaults to `LRUDotLottieCache.sharedCache` Optional.
+  /// Loads a DotLottie model from the asset catalog by its name. Returns `nil` if a lottie is not found.
+  /// - Parameter name: The name of the lottie file in the asset catalog. EG "StarAnimation"
+  /// - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
+  /// - Parameter dotLottieCache: A cache for holding loaded lottie files. Defaults to `LRUDotLottieCache.sharedCache` Optional.
   @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   public static func asset(
     named name: String,

--- a/Tests/AnimationViewTests.swift
+++ b/Tests/AnimationViewTests.swift
@@ -7,7 +7,7 @@ import XCTest
 @MainActor
 final class AnimationViewTests: XCTestCase {
 
-  func loadJsonFile() {
+  func testLoadJsonFile() {
     let animationView = LottieAnimationView(
       name: "LottieLogo1",
       bundle: .module,
@@ -26,16 +26,7 @@ final class AnimationViewTests: XCTestCase {
     wait(for: [expectation], timeout: 0.25)
   }
 
-  func loadDotLottieFileAsync() async throws {
-    let animationView = try await LottieAnimationView(
-      dotLottieName: "DotLottie/animation",
-      bundle: .module,
-      subdirectory: Samples.directoryName)
-
-    XCTAssertNotNil(animationView.animation)
-  }
-
-  func loadDotLottieFileAsyncWithCompletionClosure() {
+  func testLoadDotLottieFileAsyncWithCompletionClosure() {
     let expectation = XCTestExpectation(description: "completion closure is called")
 
     _ = LottieAnimationView(
@@ -52,7 +43,7 @@ final class AnimationViewTests: XCTestCase {
     wait(for: [expectation], timeout: 1.0)
   }
 
-  func loadDotLottieFileAsyncWithDidLoadClosure() {
+  func testLoadDotLottieFileAsyncWithDidLoadClosure() {
     let expectation = XCTestExpectation(description: "animationLoaded closure is called")
 
     let animationView = LottieAnimationView(

--- a/Tests/AnimationViewTests.swift
+++ b/Tests/AnimationViewTests.swift
@@ -14,6 +14,16 @@ final class AnimationViewTests: XCTestCase {
       subdirectory: Samples.directoryName)
 
     XCTAssertNotNil(animationView.animation)
+
+    let expectation = XCTestExpectation(description: "animationLoaded is called")
+    animationView.animationLoaded = { [weak animationView] view, animation in
+      XCTAssert(animation === view.animation)
+      XCTAssertEqual(view, animationView)
+      XCTAssert(Thread.isMainThread)
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 0.25)
   }
 
   func loadDotLottieFileAsync() async throws {
@@ -25,20 +35,38 @@ final class AnimationViewTests: XCTestCase {
     XCTAssertNotNil(animationView.animation)
   }
 
-  func loadDotLottieFileAsyncWithClosure() {
-    let expectation = XCTestExpectation(description: "DotLottie file is loaded asynchronously")
+  func loadDotLottieFileAsyncWithCompletionClosure() {
+    let expectation = XCTestExpectation(description: "completion closure is called")
 
-    let animationView = LottieAnimationView(
+    _ = LottieAnimationView(
       dotLottieName: "DotLottie/animation",
       bundle: .module,
       subdirectory: Samples.directoryName,
       completion: { animationView, error in
         XCTAssertNil(error)
         XCTAssertNotNil(animationView.animation)
+        XCTAssert(Thread.isMainThread)
         expectation.fulfill()
       })
 
-    XCTAssertNil(animationView.animation)
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  func loadDotLottieFileAsyncWithDidLoadClosure() {
+    let expectation = XCTestExpectation(description: "animationLoaded closure is called")
+
+    let animationView = LottieAnimationView(
+      dotLottieName: "DotLottie/animation",
+      bundle: .module,
+      subdirectory: Samples.directoryName)
+
+    animationView.animationLoaded = { [weak animationView] view, animation in
+      XCTAssert(view.animation === animation)
+      XCTAssertEqual(view, animationView)
+      XCTAssert(Thread.isMainThread)
+      expectation.fulfill()
+    }
+
     wait(for: [expectation], timeout: 1.0)
   }
 

--- a/Tests/AnimationViewTests.swift
+++ b/Tests/AnimationViewTests.swift
@@ -1,0 +1,45 @@
+// Created by Cal Stephens on 11/11/22.
+// Copyright © 2022 Airbnb Inc. All rights reserved.
+
+import Lottie
+import XCTest
+
+@MainActor
+final class AnimationViewTests: XCTestCase {
+
+  func loadJsonFile() {
+    let animationView = LottieAnimationView(
+      name: "LottieLogo1",
+      bundle: .module,
+      subdirectory: Samples.directoryName)
+
+    XCTAssertNotNil(animationView.animation)
+  }
+
+  func loadDotLottieFileAsync() async throws {
+    let animationView = try await LottieAnimationView(
+      dotLottieName: "DotLottie/animation",
+      bundle: .module,
+      subdirectory: Samples.directoryName)
+
+    XCTAssertNotNil(animationView.animation)
+  }
+
+  func loadDotLottieFileAsyncWithClosure() {
+    let expectation = XCTestExpectation(description: "DotLottie file is loaded asynchronously")
+
+    let animationView = LottieAnimationView(
+      dotLottieName: "DotLottie/animation",
+      bundle: .module,
+      subdirectory: Samples.directoryName,
+      completion: { animationView, error in
+        XCTAssertNil(error)
+        XCTAssertNotNil(animationView.animation)
+        expectation.fulfill()
+      })
+
+    XCTAssertNil(animationView.animation)
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+}


### PR DESCRIPTION
When using the various `LottieAnimationView` DotLottie initializers, there is currently no way to actually configure the animation playback after the animation is loaded. This is because the `DotLottieFile` is loaded asynchronously, but  there was no callback for when it finished loaded:

```swift
let animationView = LottieAnimationView(
  dotLottieName: "DotLottie/animation",
  bundle: .module,
  subdirectory: Samples.directoryName)

XCTAssertNotNil(animationView.animation) // 🛑 not loaded yet, this is still nil
```

These initializers now take a callback which lets you configure the animation view once the animation is loaded:

```swift
let animationView = LottieAnimationView(
  dotLottieName: "DotLottie/animation",
  bundle: .module,
  subdirectory: Samples.directoryName,
  completion: { animationView, error in
    XCTAssertNotNil(animationView.animation) // ✅
  })
```

As suggested in #1802 we also provide a codepath that can be used to configure a `LottieAnimationView` once the animation finishes loading, regardless of the initializer called. This simplifies adoption of dot lottie files since there is a single codepath that works regardless of the animation format:

```swift
let animationView: LottieAnimationView

if loadDotLottieFile {
  // Loads the .lottie file asynchronously
  animationView = LottieAnimationView(dotLottieName: "animation")
} else {
  // Loads the .json file synchronously
  animationView = LottieAnimationView(name: "animation")
}

animationView.animationLoaded = { animationView, animation in
  // If using a .lottie file, this is called once the file finishes loading.
  // If using a .json file, this is called immediately (since the animation is loaded synchronously).
  animationView.play()
}
```