### PR TITLE
Bump cocoapods-downloader from 1.5.1 to 1.6.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.5.1)
+    cocoapods-downloader (1.6.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)


### PR DESCRIPTION
fixing security issue: CVE-2022-21223, CVE-2022-24440. 
same fix already applied to [lottie-react-native](https://github.com/lottie-react-native/lottie-react-native/pull/859/files/2778288a1420665ff0ebda87f9aacecb2d21ef69)