### PR TITLE
Add more directories to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,7 @@
 _AeFiles
 _Gifs
 Example
+script
+Tests
+.build
+.swiftpm


### PR DESCRIPTION
This PR adds more directories to our `.npmignore`

We don't want to include these directories when uploading new versions of Lottie to npm, since these directories are fairly large. Previously I had been manually excluding these directories by deleting them, uploading the package to npm, and then un-deleting them. Turns out we can just add them to the `.npmignore`.