### PR TITLE
Add script for building .xcframework, instructions to README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,20 @@ jobs:
           name: TestArtifacts
           path: Tests/Artifacts
 
+  build-xcframework:
+    name: "Build XCFramework"
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup
+      - name: Build XCFramework
+        run: bundle exec rake build:xcframework
+      - name: Upload XCFramework
+        uses: actions/upload-artifact@v2
+        with:
+          name: Lottie.xcframework
+          path: .build/archives/Lottie.xcframework.zip
+
   cocoapod:
     name: "Lint CocoaPods podspec"
     runs-on: macos-12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           xcode: ${{ matrix.xcode }}
       - name: Build Package
-        run: bundle exec rake build:xcframework
+        run: bundle exec rake build:package:all
 
   build-example:
     name: "Build Example App"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           xcode: ${{ matrix.xcode }}
       - name: Build Package
-        run: bundle exec rake build:package:all
+        run: bundle exec rake build:xcframework
 
   build-example:
     name: "Build Example App"

--- a/README.md
+++ b/README.md
@@ -33,10 +33,16 @@ You can pull the [Lottie Github Repo](https://github.com/airbnb/lottie-ios/) and
 
 ### Swift Package Manager
 
-To install Lottie using [Swift Package Manager](https://github.com/apple/swift-package-manager)  you can follow the [tutorial published by Apple](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app) using the URL for the Lottie repo with the current version:
+To install Lottie using [Swift Package Manager](https://github.com/apple/swift-package-manager) you can follow the [tutorial published by Apple](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app) using the URL for the Lottie repo with the current version:
 
-1. In Xcode, select “File” → “Swift Packages” → “Add Package Dependency”
+1. In Xcode, select “File” → “Add Packages...”
 1. Enter https://github.com/airbnb/lottie-ios.git
+
+or you can add the following dependency to your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/airbnb/lottie-ios.git", from: "4.0.0")
+```
 
 ### CocoaPods
 Add the pod to your Podfile:
@@ -52,6 +58,7 @@ After installing the cocoapod into your project import Lottie with
 ```swift
 import Lottie
 ```
+
 ### Carthage
 Add Lottie to your Cartfile:
 ```
@@ -63,6 +70,27 @@ And then run:
 carthage update
 ```
 In your application targets “General” tab under the “Linked Frameworks and Libraries” section, drag and drop lottie-ios.framework from the Carthage/Build/iOS directory that `carthage update` produced.
+
+### Binary dependency (`xcframework`)
+
+Lottie is also available as a `xcframework` binary dependency. Lottie's git repository is somewhat large (300+ MB), so using an `xcframework` (~10MB) reduces the amount of data that needs to be downloaded.
+
+Since Lottie 4.0.1, a `Lottie.xcframework.zip` archive is attached to each release. You can find the latest release [here](https://github.com/airbnb/lottie-ios/releases/latest). 
+
+`xcframework`s can be installed manually in your Xcode project. If using Swift Package Manager, you can add the following dependency to your `Package.swift`:
+
+```swift
+// You can either use a remote binary dependency where SPM downloads the xcframework from GitHub
+.binaryTarget(
+  name: "Lottie",
+  url: "https://github.com/airbnb/lottie-ios/releases/download/4.0.1/Lottie.xcframework.zip",
+  checksum: "b6d8b0b81975d91965b8bb00cffb0eae4b3d94538b6950a90bc1366afd5d4239")
+
+// Or you can download the xcframework locally and include it in your project's git repo:
+.binaryTarget(
+  name: "Lottie",
+  path: "path/to/Lottie.xcframework")
+```
 
 ### Data collection
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Since Lottie 4.0.1, a `Lottie.xcframework.zip` archive is attached to each relea
   path: "path/to/Lottie.xcframework")
 ```
 
+If using Lottie as a remote binary depdenceny, you'll need to specify the checksum of `xcframework` file. The checksum is included in the release notes for each version. You can also calculate this locally by running `swift package compute-checksum Lottie.xcframework.zip`.
+
 ### Data collection
 
 The Lottie SDK does not collect any data. We provide this notice to help you fill out [App Privacy Details](https://developer.apple.com/app-store/app-privacy-details/).

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 namespace :build do
   desc 'Builds all packages and executables'
-  task all: ['package:all', 'example:all']
+  task all: ['package:all', 'example:all', 'xcframework']
 
   desc 'Builds the Lottie package for supported platforms'
   namespace :package do
@@ -42,6 +42,28 @@ namespace :build do
     task :tvOS do
       xcodebuild('build -scheme "Example (tvOS)" -destination "platform=tvOS Simulator,name=Apple TV" -workspace Lottie.xcworkspace')
     end
+  end
+
+  desc 'Builds an xcframework for all supported platforms'
+  task :xcframework do
+    sh 'rm -rf .build/archives'
+    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (iOS)" -destination generic/platform=iOS -archivePath ".build/archives/Lottie_iOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES')
+    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (iOS)" -destination "generic/platform=iOS Simulator" -archivePath ".build/archives/Lottie_iOS_Simulator" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES')
+    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (macOS)" -destination generic/platform=macOS -archivePath ".build/archives/Lottie_macOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES')
+    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (tvOS)" -destination generic/platform=tvOS -archivePath ".build/archives/Lottie_tvOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES')
+    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (tvOS)" -destination "generic/platform=tvOS Simulator" -archivePath ".build/archives/Lottie_tvOS_Simulator" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES')
+    xcodebuild(
+      '-create-xcframework ' +
+      '-framework .build/archives/Lottie_iOS.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
+      '-framework .build/archives/Lottie_iOS_Simulator.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
+      '-framework .build/archives/Lottie_macOS.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
+      '-framework .build/archives/Lottie_tvOS.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
+      '-framework .build/archives/Lottie_tvOS_Simulator.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
+      '-output .build/archives/Lottie.xcframework')
+    Dir.chdir('.build/archives') do
+      sh 'zip -r Lottie.xcframework.zip Lottie.xcframework'
+    end
+    sh 'swift package compute-checksum .build/archives/Lottie.xcframework.zip'
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -53,13 +53,15 @@ namespace :build do
     xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (tvOS)" -destination generic/platform=tvOS -archivePath ".build/archives/Lottie_tvOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES')
     xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (tvOS)" -destination "generic/platform=tvOS Simulator" -archivePath ".build/archives/Lottie_tvOS_Simulator" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES')
     xcodebuild(
-      '-create-xcframework ' +
-      '-framework .build/archives/Lottie_iOS.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
-      '-framework .build/archives/Lottie_iOS_Simulator.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
-      '-framework .build/archives/Lottie_macOS.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
-      '-framework .build/archives/Lottie_tvOS.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
-      '-framework .build/archives/Lottie_tvOS_Simulator.xcarchive/Products/Library/Frameworks/Lottie.framework ' + 
-      '-output .build/archives/Lottie.xcframework')
+      [
+        '-create-xcframework',
+        '-framework .build/archives/Lottie_iOS.xcarchive/Products/Library/Frameworks/Lottie.framework',
+        '-framework .build/archives/Lottie_iOS_Simulator.xcarchive/Products/Library/Frameworks/Lottie.framework',
+        '-framework .build/archives/Lottie_macOS.xcarchive/Products/Library/Frameworks/Lottie.framework',
+        '-framework .build/archives/Lottie_tvOS.xcarchive/Products/Library/Frameworks/Lottie.framework',
+        '-framework .build/archives/Lottie_tvOS_Simulator.xcarchive/Products/Library/Frameworks/Lottie.framework',
+        '-output .build/archives/Lottie.xcframework'
+      ].join(" "))
     Dir.chdir('.build/archives') do
       sh 'zip -r Lottie.xcframework.zip Lottie.xcframework'
     end

--- a/script/ReleaseInstructions.md
+++ b/script/ReleaseInstructions.md
@@ -1,0 +1,9 @@
+## Release Instructions for Lottie iOS
+
+Lottie is made available through multiple package managers, each of which has to be updated individually for each release.
+
+ 1. Make sure `lottie-ios.podspec` and `package.json` list the correct version number
+ 2. Update the [Cocoapod](https://cocoapods.org/pods/lottie-ios) by running `pod trunk push lottie-ios.podspec`
+ 3. Update the [npm package](https://www.npmjs.com/package/lottie-ios) by running `npm publish`
+ 4. Attach `Lottie.xframework.zip` to the GitHub release and include the checksum in the release notes.
+   - For every PR / commit, `Lottie.xcframework.zip` is build by CI and uploaded to the job summary.


### PR DESCRIPTION
This PR adds a script for building `Lottie.xframework`, which we'll be attaching to releases from now on.

I built a `Lottie.xcframework.zip` using `bundle exec rake build:xcframework` and attached it to the release for 4.0.1: https://github.com/airbnb/lottie-ios/releases/tag/4.0.1