### PR TITLE
Updating currentFrame on MainThreadAnimationLayer to reflect the actual current value

### DIFF
--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -126,6 +126,7 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
   public override func display() {
     guard Thread.isMainThread else { return }
     var newFrame: CGFloat
+    defer { currentFrame = newFrame }
     if
       let animationKeys = animationKeys(),
       !animationKeys.isEmpty


### PR DESCRIPTION
This PR adds updates the currentFrame property on  MainThreadAnimationLayer to reflect the actual current value.

## Background
The `currentFrame` value never represented the actual value (verified on Lottie 3.1.5) of the animation progress but was mainly a way to update the animation. The introduction of `CoreAnimationLayer` added the expectation that `currentProgress` on the `AnimationView` actually returns the elapsed animation progress. This PR introduces that behavior for the MainThreadAnimationLayer.