### PR TITLE
Remove unused CocoaPods configuration

### DIFF
--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -28,7 +28,6 @@ Lottie enables designers to create and ship beautiful animations without an engi
   s.tvos.deployment_target = '11.0'
 
   s.source_files = 'Sources/**/*'
-  s.exclude_files = 'Sources/Lottie.swift'
   s.ios.exclude_files = 'Sources/Public/MacOS/**/*'
   s.tvos.exclude_files = 'Sources/Public/MacOS/**/*'
   s.osx.exclude_files = 'Sources/Public/iOS/**/*'
@@ -37,5 +36,4 @@ Lottie enables designers to create and ship beautiful animations without an engi
   s.tvos.frameworks = ['UIKit', 'CoreGraphics', 'QuartzCore']
   s.osx.frameworks = ['AppKit', 'CoreGraphics', 'QuartzCore']
   s.module_name = 'Lottie'
-  s.header_dir = 'Lottie'
 end


### PR DESCRIPTION
It seems like these were left over from previous versions