### PR TITLE
Add support for display P3 color space

### DIFF
--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
@@ -110,7 +110,7 @@ private final class GradientFillLayer: CALayer {
     /// Now draw the gradient
     guard
       let gradient = CGGradient(
-        colorsSpace: CGColorSpaceCreateDeviceRGB(),
+        colorsSpace: LottieConfiguration.shared.colorSpace,
         colors: gradientColors as CFArray,
         locations: colorLocations)
     else { return }

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/LegacyGradientFillRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/LegacyGradientFillRenderer.swift
@@ -132,7 +132,7 @@ final class LegacyGradientFillRenderer: PassThroughOutputNode, Renderable {
     /// Now draw the gradient
     guard
       let gradient = CGGradient(
-        colorsSpace: CGColorSpaceCreateDeviceRGB(),
+        colorsSpace: LottieConfiguration.shared.colorSpace,
         colors: gradientColors as CFArray,
         locations: colorLocations)
     else { return }

--- a/Sources/Private/Utility/Extensions/CGColor+RGB.swift
+++ b/Sources/Private/Utility/Extensions/CGColor+RGB.swift
@@ -19,7 +19,7 @@ extension CGColor {
   /// Initializes a `CGColor` using the given `RGBA` values
   static func rgba(_ red: CGFloat, _ green: CGFloat, _ blue: CGFloat, _ alpha: CGFloat) -> CGColor {
     CGColor(
-      colorSpace: CGColorSpaceCreateDeviceRGB(),
+      colorSpace: LottieConfiguration.shared.colorSpace,
       components: [red, green, blue, alpha])!
   }
 }

--- a/Sources/Public/LottieConfiguration.swift
+++ b/Sources/Public/LottieConfiguration.swift
@@ -1,6 +1,8 @@
 // Created by Cal Stephens on 12/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+import QuartzCore
+
 // MARK: - LottieConfiguration
 
 /// Global configuration options for Lottie animations
@@ -10,10 +12,12 @@ public struct LottieConfiguration: Hashable {
 
   public init(
     renderingEngine: RenderingEngineOption = .automatic,
-    decodingStrategy: DecodingStrategy = .dictionaryBased)
+    decodingStrategy: DecodingStrategy = .dictionaryBased,
+    colorSpace: CGColorSpace = CGColorSpaceCreateDeviceRGB())
   {
     self.renderingEngine = renderingEngine
     self.decodingStrategy = decodingStrategy
+    self.colorSpace = colorSpace
   }
 
   // MARK: Public
@@ -32,6 +36,9 @@ public struct LottieConfiguration: Hashable {
   /// The decoding implementation to use when parsing an animation JSON file
   public var decodingStrategy: DecodingStrategy
 
+  /// The color space to be used for rendering
+  ///  - Defaults to `CGColorSpaceCreateDeviceRGB()`
+  public var colorSpace: CGColorSpace
 }
 
 // MARK: - RenderingEngineOption

--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -238,8 +238,8 @@ public final class CompatibleAnimationView: UIView {
     var green: CGFloat = 0
     var blue: CGFloat = 0
     var alpha: CGFloat = 0
-    // TODO: Fix color spaces
-    let colorspace = CGColorSpaceCreateDeviceRGB()
+
+    let colorspace = LottieConfiguration.shared.colorSpace
 
     let convertedColor = color.cgColor.converted(to: colorspace, intent: .defaultIntent, options: nil)
 


### PR DESCRIPTION
This PR adds support for display P3 color space. The changes are opt-in only, anyone willing to use the P3 color space would have to explicitly enable through a new flag in `LottieConfiguration` like so:
```
LottieConfiguration.shared.useDisplayP3 = true
```
