### PR TITLE
Fix heap buffer overflow in CGColor+RGB extensions

### DIFF
--- a/Sources/Private/Utility/Extensions/CGColor+RGB.swift
+++ b/Sources/Private/Utility/Extensions/CGColor+RGB.swift
@@ -6,22 +6,20 @@ import QuartzCore
 extension CGColor {
   /// Initializes a `CGColor` using the given `RGB` values
   static func rgb(_ red: CGFloat, _ green: CGFloat, _ blue: CGFloat) -> CGColor {
-    CGColor(
-      colorSpace: CGColorSpaceCreateDeviceRGB(),
-      components: [red, green, blue])!
-      .copy(alpha: 1)!
+    rgba(red, green, blue, 1.0)
   }
 
   /// Initializes a `CGColor` using the given grayscale value
   static func gray(_ gray: CGFloat) -> CGColor {
     CGColor(
       colorSpace: CGColorSpaceCreateDeviceGray(),
-      components: [gray])!
-      .copy(alpha: 1)!
+      components: [gray, 1.0])!
   }
 
   /// Initializes a `CGColor` using the given `RGBA` values
   static func rgba(_ red: CGFloat, _ green: CGFloat, _ blue: CGFloat, _ alpha: CGFloat) -> CGColor {
-    CGColor.rgb(red, green, blue).copy(alpha: alpha)!
+    CGColor(
+      colorSpace: CGColorSpaceCreateDeviceRGB(),
+      components: [red, green, blue, alpha])!
   }
 }


### PR DESCRIPTION
Running Lottie with Address Sanitizer (ASan) enabled reveals a heap buffer overflow when `CGColor`s are constructed. This is regression from https://github.com/airbnb/lottie-ios/pull/1801.

This happens because the provided `components` array does not include enough elements as per [init's documentation](https://developer.apple.com/documentation/coregraphics/cgcolor/1455927-init):
> An array of intensity values describing the color. The array should contain n+1 values that correspond to the n color components in the specified color space, followed by the alpha component. Each component value should be in the range appropriate for the color space. Values outside this range will be clamped to the nearest correct value.

This causes the internal CoreGraphics `create_color` function to access array index out of bounds.

Two things that should be noted:
- I could not verify the fix to `gray` function works in the context of the framework since I could not find an animation that uses it in the project. It might also be worth it to add unit tests for them that could be run with ASan enabled? I did craft some code by hand and verified that the current implementation causes heap buffer overflow and that this PR fixes it.
- I did not understand the calls to `copy` so I removed them, but I can restore them in case they are necessary. Should also then add comments describing why it's done as it's non-obvious to me at least. Based on the original PR it looks like they were added due to iOS 11 minimum deployment target, but I don't think that's necessary since the used API is available since iOS 2.0.