### PR TITLE
Fixes heap buffer overflow in CGColor(colorSpace:components:)

### DIFF
--- a/Sources/Private/Utility/Extensions/CGColor+RGB.swift
+++ b/Sources/Private/Utility/Extensions/CGColor+RGB.swift
@@ -8,7 +8,7 @@ extension CGColor {
   static func rgb(_ red: CGFloat, _ green: CGFloat, _ blue: CGFloat) -> CGColor {
     CGColor(
       colorSpace: CGColorSpaceCreateDeviceRGB(),
-      components: [red, green, blue])!
+      components: [red, green, blue, 1])! // Fixes heap buffer overflow
       .copy(alpha: 1)!
   }
 


### PR DESCRIPTION
Xcode sanity checker is reporting a heap buffer overflow in your CGColor+RGB extension. It can be easily reproduced by enabling sanity checks for your project and open any Lottie animation. 

The error is resolved pretty easily, by just adding the alpha component to the components array. It seems that copying the color and assigning an alpha value is causing this overflow. 

I could not verify if `static func gray(_ gray: CGFloat)`is also effected (same file).

```
=================================================================
==21344==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x0001387be018 at pc 0x0001097d44a4 bp 0x00016f3a49b0 sp 0x00016f3a4168
READ of size 32 at 0x0001387be018 thread T0
    #0 0x1097d44a0 in wrap_memcpy+0x138 (libclang_rt.asan_iossim_dynamic.dylib:arm64+0x184a0)
    #1 0x1880ab2c4 in create_color+0xc8 (CoreGraphics:arm64+0x742c4)
    #2 0x102041620 in static CGColorRef.rgb(_:_:_:)+0x694 (App:arm64+0x1015f1620)
    #3 0x102042540 in static CGColorRef.rgba(_:_:_:_:)+0x310 (App:arm64+0x1015f2540)
    #4 0x102089944 in LottieColor.cgColorValue.getter+0x248 (App:arm64+0x101639944)
    #5 0x101c6f540 in key path getter for LottieColor.cgColorValue : LottieColor+0xf4 (App:arm64+0x10121f540)
    #6 0x18bdcddc8 in RawKeyPathComponent._projectReadOnly<A, B, C>(_:to:endingWith:)+0x224 (libswiftCore.dylib:arm64+0x119dc8)
    #7 0x18bdcd8d0 in closure #1 in KeyPath._projectReadOnly(from:)+0x1d8 (libswiftCore.dylib:arm64+0x1198d0)
    #8 0x18bdd103c in swift_getAtKeyPath+0xa0 (libswiftCore.dylib:arm64+0x11d03c)
    #9 0x101c6f38c in implicit closure #2 in implicit closure #1 in CAShapeLayer.addAnimations(for:context:)+0x208 (App:arm64+0x10121f38c)
    #10 0x101c6f6a0 in thunk for @callee_guaranteed (@unowned LottieColor) -> (@owned CGColorRef, @error @owned Error)+0x110 (App:arm64+0x10121f6a0)
    #11 0x101c6f738 in partial apply for thunk for @callee_guaranteed (@unowned LottieColor) -> (@owned CGColorRef, @error @owned Error)+0x18 (App:arm64+0x10121f738)
    #12 0x101c37474 in CALayer.defaultAnimation<A, B>(for:keyframes:value:context:)+0x754 (App:arm64+0x1011e7474)
    #13 0x101c35b88 in CALayer.addAnimation<A, B>(for:keyframes:value:context:)+0x470 (App:arm64+0x1011e5b88)
    #14 0x101c6eed4 in CAShapeLayer.addAnimations(for:context:)+0x4c0 (App:arm64+0x10121eed4)
    #15 0x101cf737c in ShapeItemLayer.setupSolidFillAnimations(shapeLayer:context:)+0x26bc (App:arm64+0x1012a737c)
    #16 0x101cf4640 in ShapeItemLayer.setupAnimations(context:)+0x700 (App:arm64+0x1012a4640)
    #17 0x101cc5134 in protocol witness for AnimationLayer.setupAnimations(context:) in conformance BaseAnimationLayer+0xdc (App:arm64+0x101275134)
    #18 0x101cc3220 in BaseAnimationLayer.setupAnimations(context:)+0x444 (App:arm64+0x101273220)
    #19 0x101d0ae78 in GroupLayer.setupAnimations(context:)+0x268 (App:arm64+0x1012bae78)
    #20 0x101cc5134 in protocol witness for AnimationLayer.setupAnimations(context:) in conformance BaseAnimationLayer+0xdc (App:arm64+0x101275134)
    #21 0x101cc3220 in BaseAnimationLayer.setupAnimations(context:)+0x444 (App:arm64+0x101273220)
    #22 0x101cc80c4 in BaseCompositionLayer.setupChildAnimations(context:)+0x1cc (App:arm64+0x1012780c4)
    #23 0x101cc7414 in BaseCompositionLayer.setupAnimations(context:)+0x980 (App:arm64+0x101277414)
    #24 0x101cc5134 in protocol witness for AnimationLayer.setupAnimations(context:) in conformance BaseAnimationLayer+0xdc (App:arm64+0x101275134)
    #25 0x101ca0364 in CoreAnimationLayer.setupAnimation(for:)+0x1424 (App:arm64+0x101250364)
    #26 0x101c9e468 in CoreAnimationLayer.display()+0xe54 (App:arm64+0x10124e468)
    #27 0x101ca1290 in @objc CoreAnimationLayer.display()+0x7c (App:arm64+0x101251290)
    #28 0x187f23400 in CA::Layer::layout_and_display_if_needed(CA::Transaction*)+0x184 (QuartzCore:arm64+0x1a7400)
    #29 0x187e51054 in CA::Context::commit_transaction(CA::Transaction*, double, double*)+0x1c0 (QuartzCore:arm64+0xd5054)
    #30 0x187e7ce24 in CA::Transaction::commit()+0x288 (QuartzCore:arm64+0x100e24)
    #31 0x10c96d5c4 in _afterCACommitHandler+0x60 (UIKitCore:arm64+0xa915c4)
    #32 0x180372178 in __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__+0x1c (CoreFoundation:arm64+0x85178)
    #33 0x18036cb18 in __CFRunLoopDoObservers+0x1fc (CoreFoundation:arm64+0x7fb18)
    #34 0x18036cfd0 in __CFRunLoopRun+0x3c4 (CoreFoundation:arm64+0x7ffd0)
    #35 0x18036c7f0 in CFRunLoopRunSpecific+0x244 (CoreFoundation:arm64+0x7f7f0)
    #36 0x188faec94 in GSEventRunModal+0x9c (GraphicsServices:arm64+0x3c94)
    #37 0x10c9445d0 in -[UIApplication _run]+0x360 (UIKitCore:arm64+0xa685d0)
    #38 0x10c9485c8 in UIApplicationMain+0x78 (UIKitCore:arm64+0xa6c5c8)
    #39 0x110d42b14  (SwiftUI:arm64+0xf4ab14)
    #40 0x110d429bc  (SwiftUI:arm64+0xf4a9bc)
    #41 0x1104e6368  (SwiftUI:arm64+0x6ee368)
    #42 0x100c84938 in static MainApp.main() MainApp.swift:13
    #43 0x100c849b8 in static MainApp.$main() MainApp.swift:10
    #44 0x100c849d0 in main MainApp.swift
    #45 0x10940df9c  (<unknown module>)
    #46 0x109135088  (<unknown module>)
    #47 0x2e16fffffffffffc  (<unknown module>)

0x0001387be018 is located 0 bytes to the right of 56-byte region [0x0001387bdfe0,0x0001387be018)
allocated by thread T0 here:
    #0 0x1097f9d08 in __sanitizer_mz_malloc+0x88 (libclang_rt.asan_iossim_dynamic.dylib:arm64+0x3dd08)
    #1 0x1801913c0 in _malloc_zone_malloc_instrumented_or_legacy+0x64 (libsystem_malloc.dylib:arm64+0x183c0)
    #2 0x18bfa834c in swift_slowAlloc+0x38 (libswiftCore.dylib:arm64+0x2f434c)
    #3 0x18bfa8508 in swift_allocObject+0x30 (libswiftCore.dylib:arm64+0x2f4508)
    #4 0x18bcd816c in _allocateUninitializedArray<A>(_:)+0x50 (libswiftCore.dylib:arm64+0x2416c)
    #5 0x1020412a0 in static CGColorRef.rgb(_:_:_:)+0x314 (App:arm64+0x1015f12a0)
    #6 0x102042540 in static CGColorRef.rgba(_:_:_:_:)+0x310 (App:arm64+0x1015f2540)
    #7 0x102089944 in LottieColor.cgColorValue.getter+0x248 (App:arm64+0x101639944)
    #8 0x101c6f540 in key path getter for LottieColor.cgColorValue : LottieColor+0xf4 (App:arm64+0x10121f540)
    #9 0x18bdcddc8 in RawKeyPathComponent._projectReadOnly<A, B, C>(_:to:endingWith:)+0x224 (libswiftCore.dylib:arm64+0x119dc8)
    #10 0x18bdcd8d0 in closure #1 in KeyPath._projectReadOnly(from:)+0x1d8 (libswiftCore.dylib:arm64+0x1198d0)
    #11 0x18bdd103c in swift_getAtKeyPath+0xa0 (libswiftCore.dylib:arm64+0x11d03c)
    #12 0x101c6f38c in implicit closure #2 in implicit closure #1 in CAShapeLayer.addAnimations(for:context:)+0x208 (App:arm64+0x10121f38c)
    #13 0x101c6f6a0 in thunk for @callee_guaranteed (@unowned LottieColor) -> (@owned CGColorRef, @error @owned Error)+0x110 (App:arm64+0x10121f6a0)
    #14 0x101c6f738 in partial apply for thunk for @callee_guaranteed (@unowned LottieColor) -> (@owned CGColorRef, @error @owned Error)+0x18 (App:arm64+0x10121f738)
    #15 0x101c37474 in CALayer.defaultAnimation<A, B>(for:keyframes:value:context:)+0x754 (App:arm64+0x1011e7474)
    #16 0x101c35b88 in CALayer.addAnimation<A, B>(for:keyframes:value:context:)+0x470 (App:arm64+0x1011e5b88)
    #17 0x101c6eed4 in CAShapeLayer.addAnimations(for:context:)+0x4c0 (App:arm64+0x10121eed4)
    #18 0x101cf737c in ShapeItemLayer.setupSolidFillAnimations(shapeLayer:context:)+0x26bc (App:arm64+0x1012a737c)
    #19 0x101cf4640 in ShapeItemLayer.setupAnimations(context:)+0x700 (App:arm64+0x1012a4640)
    #20 0x101cc5134 in protocol witness for AnimationLayer.setupAnimations(context:) in conformance BaseAnimationLayer+0xdc (App:arm64+0x101275134)
    #21 0x101cc3220 in BaseAnimationLayer.setupAnimations(context:)+0x444 (App:arm64+0x101273220)
    #22 0x101d0ae78 in GroupLayer.setupAnimations(context:)+0x268 (App:arm64+0x1012bae78)
    #23 0x101cc5134 in protocol witness for AnimationLayer.setupAnimations(context:) in conformance BaseAnimationLayer+0xdc (App:arm64+0x101275134)
    #24 0x101cc3220 in BaseAnimationLayer.setupAnimations(context:)+0x444 (App:arm64+0x101273220)
    #25 0x101cc80c4 in BaseCompositionLayer.setupChildAnimations(context:)+0x1cc (App:arm64+0x1012780c4)
    #26 0x101cc7414 in BaseCompositionLayer.setupAnimations(context:)+0x980 (App:arm64+0x101277414)
    #27 0x101cc5134 in protocol witness for AnimationLayer.setupAnimations(context:) in conformance BaseAnimationLayer+0xdc (App:arm64+0x101275134)
    #28 0x101ca0364 in CoreAnimationLayer.setupAnimation(for:)+0x1424 (App:arm64+0x101250364)
    #29 0x101c9e468 in CoreAnimationLayer.display()+0xe54 (App:arm64+0x10124e468)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_iossim_dynamic.dylib:arm64+0x184a0) in wrap_memcpy+0x138
Shadow bytes around the buggy address:
  0x007027117bb0: fa fa fa fa 00 00 00 00 00 00 00 fa fa fa fa fa
  0x007027117bc0: 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
  0x007027117bd0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fa
  0x007027117be0: fa fa fa fa fd fd fd fd fd fd fd fa fa fa fa fa
  0x007027117bf0: fa fa fa fa fa fa fa fa fa fa fa fa 00 00 00 00
=>0x007027117c00: 00 00 00[fa]fa fa fa fa fa fa fa fa fa fa fa fa
  0x007027117c10: fa fa fa fa fd fd fd fd fd fd fd fd fa fa fa fa
  0x007027117c20: 00 00 00 00 00 00 00 00 fa fa fa fa 00 00 00 00
  0x007027117c30: 00 00 00 fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x007027117c40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x007027117c50: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==21344==ABORTING
```