### PR TITLE
Revert workaround for Xcode 14.0 SPM binary dependency issue (#1705)

### DIFF
--- a/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/airbnb/swift",
         "state": {
           "branch": null,
-          "revision": "7884f265499752cc5eccaa9eba08b4a2f8b73357",
-          "version": null
+          "revision": "07bb2e0822ca6e464bf3610ed452568931fdbf65",
+          "version": "1.0.3"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "AirbnbSwift",
+        "repositoryURL": "https://github.com/airbnb/swift",
+        "state": {
+          "branch": null,
+          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "df9ee6676cd5b3bf5b330ec7568a5644f547201b",
+          "version": "1.1.3"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/airbnb/swift",
         "state": {
           "branch": null,
-          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
-          "version": "1.0.1"
+          "revision": "07bb2e0822ca6e464bf3610ed452568931fdbf65",
+          "version": "1.0.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -6,3 +6,8 @@ let package = Package(
   platforms: [.iOS("11.0"), .macOS("10.10"), .tvOS("11.0")],
   products: [.library(name: "Lottie", targets: ["Lottie"])],
   targets: [.target(name: "Lottie", path: "Sources")])
+
+#if swift(>=5.6)
+// Add the Airbnb Swift formatting plugin if possible
+package.dependencies.append(.package(url: "https://github.com/airbnb/swift", .upToNextMajor(from: "1.0.1")))
+#endif

--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,7 @@ end
 namespace :lint do
   desc 'Lints swift files'
   task :swift do
-    formatTool('format --lint')
+    sh 'swift package --allow-writing-to-package-directory format --lint'
   end
 
   desc 'Lints the CocoaPods podspec'
@@ -105,7 +105,7 @@ end
 namespace :format do
   desc 'Formats swift files'
   task :swift do
-    formatTool('format')
+    sh 'swift package --allow-writing-to-package-directory format'
   end
 end
 
@@ -118,43 +118,4 @@ def xcodebuild(command)
   else
     sh "xcodebuild #{command}"
   end
-end
-
-def formatTool(command)
-  # As of Xcode 13.4 / Xcode 14 beta 4, including airbnb/swift as a dependency
-  # causes Xcode to spin indefinitely at 100% CPU (due to the remote binary dependencies
-  # used by that package). As a workaround, we can specifically add that dependency
-  # to our Package.swift file when linting / formatting and remove it afterwards.
-  packageDefinition = File.read('Package.swift')
-  packageDefinitionWithFormatDependency = packageDefinition +
-  <<~EOC
-  
-  #if swift(>=5.6)
-  // Add the Airbnb Swift formatting plugin if possible
-  package.dependencies.append(
-    .package(
-      url: "https://github.com/airbnb/swift",
-      // Since we don't have a Package.resolved for this, we need to reference a specific commit
-      // so changes to the style guide don't cause this repo's checks to start failing.
-      .revision("7884f265499752cc5eccaa9eba08b4a2f8b73357")))
-  #endif
-  EOC
-
-  # Add the format tool dependency to our Package.swift
-  File.write('Package.swift', packageDefinitionWithFormatDependency)
-
-  exitCode = 0
-
-  # Run the given command
-  begin
-    sh "swift package --allow-writing-to-package-directory #{command}"
-  rescue
-    exitCode = $?.exitstatus
-  ensure
-    # Revert the changes to Package.swift
-    File.write('Package.swift', packageDefinition)
-    File.delete('Package.resolved')
-  end
-
-  exit exitCode
 end

--- a/Sources/Private/CoreAnimation/Animations/GradientAnimations.swift
+++ b/Sources/Private/CoreAnimation/Animations/GradientAnimations.swift
@@ -34,7 +34,8 @@ extension GradientRenderLayer {
   func addGradientAnimations(
     for gradient: GradientShapeItem,
     type: GradientContentType,
-    context: LayerAnimationContext) throws
+    context: LayerAnimationContext)
+    throws
   {
     // We have to set `colors` and `locations` to non-nil values
     // for the animations below to actually take effect

--- a/Sources/Private/CoreAnimation/Animations/ShapeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/ShapeAnimation.swift
@@ -10,7 +10,8 @@ extension CAShapeLayer {
     for shape: ShapeItem,
     context: LayerAnimationContext,
     pathMultiplier: PathMultiplier,
-    roundedCorners: RoundedCorners?) throws
+    roundedCorners: RoundedCorners?)
+    throws
   {
     switch shape {
     case let customShape as Shape:

--- a/Sources/Private/Model/DotLottie/Zip/Data+Compression.swift
+++ b/Sources/Private/Model/DotLottie/Zip/Data+Compression.swift
@@ -74,8 +74,8 @@ extension Data {
     size: Int64,
     bufferSize: Int,
     provider: ZipDataProvider,
-    consumer: ZipDataCallback) throws
-    -> UInt32
+    consumer: ZipDataCallback)
+    throws -> UInt32
   {
     var crc32 = UInt32(0)
     let destPointer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -173,8 +173,8 @@ extension LottieAnimation {
   public static func loadedFrom(
     url: URL,
     session: URLSession = .shared,
-    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared) async
-    -> LottieAnimation?
+    animationCache: AnimationCacheProvider? = LottieAnimationCache.shared)
+    async -> LottieAnimation?
   {
     await withCheckedContinuation { continuation in
       LottieAnimation.loadedFrom(

--- a/Tests/AnimationKeypathTests.swift
+++ b/Tests/AnimationKeypathTests.swift
@@ -81,7 +81,8 @@ final class AnimationKeypathTests: XCTestCase {
     animationName: String,
     configuration: LottieConfiguration,
     function: String = #function,
-    line: UInt = #line) async
+    line: UInt = #line)
+    async
   {
     let hierarchyKeypaths = await hierarchyKeypaths(animationName: animationName, configuration: configuration)
 


### PR DESCRIPTION
This PR reverts #1705, which was a workaround for an issue in Xcode 14.0 where SPM binary dependencies would cause Xcode to spin indefinitely at 100% CPU load. This has been fixed in Xcode 14.1+, so we don't need to use the workaround anymore.

This also fixes an issue where `Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved` was often unnecessarily marked as modified by git, since the Airbnb formatter tool was being added locally when running the formatter but not present on master. 