### PR TITLE
Change veryLargeRect size to fix issue with masks (#1880)

### DIFF
--- a/Sources/Private/MainThread/LayerContainers/CompLayers/MaskContainerLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/MaskContainerLayer.swift
@@ -84,10 +84,10 @@ final class MaskContainerLayer: CALayer {
 extension CGRect {
   static var veryLargeRect: CGRect {
     CGRect(
-      x: -100_000_000,
-      y: -100_000_000,
-      width: 200_000_000,
-      height: 200_000_000)
+      x: -10_000_000,
+      y: -10_000_000,
+      width: 20_000_000,
+      height: 20_000_000)
   }
 }
 


### PR DESCRIPTION
When using scaleToFill / scaleAspectFit / scaleAspectFill mode with an animation that has a subtract mask, the animation could sometimes fail to render. `veryLargeRect` is used as the size of the "bounds" rect from which the path is subtracted.

**Alternative considered**
I digged through the old code and found that the old Objective-C implementation actually passed in the bounds size.
I guess that could be an alternative solution if needed.

```objective-c
- (void)updateForFrame:(NSNumber *)frame withViewBounds:(CGRect)viewBounds {
   if ([self hasUpdateForFrame:frame]) {
     LOTBezierPath *path = [_pathInterpolator pathForFrame:frame cacheLengths:NO];

     if (self.maskNode.maskMode == LOTMaskModeSubtract) {
       CGMutablePathRef pathRef = CGPathCreateMutable();
       CGPathAddRect(pathRef, NULL, viewBounds);
       CGPathAddPath(pathRef, NULL, path.CGPath);
       self.path = pathRef;
       self.fillRule = @"even-odd";
     } else {
       self.path = path.CGPath;
     }

     self.opacity = [_opacityInterpolator floatValueForFrame:frame];
   }
 }
```
https://github.com/airbnb/lottie-ios/commit/502b18ff#diff-233d9c9fcd51dcb99d9884451e850073e2712d14d3c05e0e91bae1c551abe91eR42

Video capture before/after the change

iPhone14 Pro Simulator
| Before | After |
| ------ | ------ |
| <video src="https://user-images.githubusercontent.com/36905/209914152-a2eb6eee-c7ce-4dc6-bd19-5efb9a7fe115.mp4" /> | <video src="https://user-images.githubusercontent.com/36905/209914166-f734f5b6-8bf6-478a-8d77-56ba8fe3ee64.mp4" /> |



 