### PR TITLE
fix : Add typealias to support 3.1.2

### DIFF
--- a/Sources/Public/Animation/LottieAnimation.swift
+++ b/Sources/Public/Animation/LottieAnimation.swift
@@ -16,6 +16,8 @@ public enum CoordinateSpace: Int, Codable {
 
 // MARK: - LottieAnimation
 
+public typealias Animation = LottieAnimation
+
 /// The `LottieAnimation` model is the top level model object in Lottie.
 ///
 /// A `LottieAnimation` holds all of the animation data backing a Lottie Animation.

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -87,6 +87,8 @@ extension LottieLoopMode: Equatable {
 
 // MARK: - LottieAnimationView
 
+public typealias AnimationView = LottieAnimationView
+
 @IBDesignable
 final public class LottieAnimationView: LottieAnimationViewBase {
 


### PR DESCRIPTION
- Older implementation uses `AnimationView` and `Lottie.Animation` instead of `LottieAnimationView` and `LottieAnimation`
- Added typealias to make them comaptible