### PR TITLE
Fix issue where `play(fromProgress: 1, toProgress: 0)` animation would not actually play

### DIFF
--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -1374,7 +1374,7 @@ final public class LottieAnimationView: LottieAnimationViewBase {
         // `playFrom` time to be the `currentFrame`. Since the animation duration
         // is based on `playFrom` and `playTo`, this automatically truncates the
         // duration (so the animation stops playing at `playFrom`).
-        //  - Don't do this is the animation is already at that frame
+        //  - Don't do this if the animation is already at that frame
         //    (e.g. playing from 100% to 0% when the animation is already at 0%)
         //    since that would cause the animation to not play at all.
         case .playOnce:

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -1374,8 +1374,13 @@ final public class LottieAnimationView: LottieAnimationViewBase {
         // `playFrom` time to be the `currentFrame`. Since the animation duration
         // is based on `playFrom` and `playTo`, this automatically truncates the
         // duration (so the animation stops playing at `playFrom`).
+        //  - Don't do this is the animation is already at that frame
+        //    (e.g. playing from 100% to 0% when the animation is already at 0%)
+        //    since that would cause the animation to not play at all.
         case .playOnce:
-          animationContext.playFrom = currentFrame
+          if animationContext.playTo != currentFrame {
+            animationContext.playFrom = currentFrame
+          }
 
         // When looping, we specifically _don't_ want to affect the duration of the animation,
         // since that would affect the duration of all subsequent loops. We just want to adjust


### PR DESCRIPTION
This PR fixes an issue where animations would be ignored when `toFrame == currentFrame`. For example, when playing from 100% to 0% when the animation view is created (and `currentFrame == 0`), the animation was previously ignored. Fixes #1901 and #1907.

| Before | After |
| ---- | ---- |
| <img src="https://user-images.githubusercontent.com/1811727/211405973-0e38b019-fb03-45d2-af1e-76c9779a4078.gif" width=350> | <img src="https://user-images.githubusercontent.com/1811727/211406143-1f8114a0-b0c4-4fa4-a72c-b59aabbada68.gif" width=350> |

