### PR TITLE
Build XCFramework using Xcode 13.2.1 / Swift 5.5.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
+        with:
+          # XCFrameworks are forwards-compatible but not backwards-compatible.
+          # The Xcode version we use for this job is that oldest Xcode version that
+          # will be able to use these XCFrameworks and the lottie-spm package.
+          xcode: '13.2.1' # Swift 5.5.2
       - name: Build XCFramework
         run: bundle exec rake build:xcframework
       - name: Upload XCFramework


### PR DESCRIPTION
This PR updates the XCFramework job to run using Xcode 13.2.1 / Swift 5.5.2.

Precompiled Swift libraries are forwards-compatible but not backwards-compatible. The XCFramework published with 4.0.1 was built with Swift 5.7 / Xcode 14.x and can't be used by older Xcode versions.

Xcode 13.2.1 is the last Xcode version with Swift 5.5.x, and is also the version we use in the main test job that verifies support for Swift 5.5.