### PR TITLE
Update Package.resolved version in Lottie.xcodeproj to fix Swift Package Index support Xcode 13.2.1 / Swift 5.5

### DIFF
--- a/Lottie.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lottie.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,22 +1,25 @@
 {
-  "pins" : [
-    {
-      "identity" : "difference",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzysztofzablocki/Difference",
-      "state" : {
-        "revision" : "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
-        "version" : "1.0.1"
+  "object": {
+    "pins": [
+      {
+        "package": "Difference",
+        "repositoryURL": "https://github.com/krzysztofzablocki/Difference",
+        "state": {
+          "branch": null,
+          "revision": "f627d00718033c3d7888acd5f4e3524a843db1cf",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "package": "swift-snapshot-testing",
+        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
+        "state": {
+          "branch": null,
+          "revision": "0c2826f26d00ff5ddf2de92cb6b2139b0dd3d1ee",
+          "version": null
+        }
       }
-    },
-    {
-      "identity" : "swift-snapshot-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
-      "state" : {
-        "revision" : "0c2826f26d00ff5ddf2de92cb6b2139b0dd3d1ee"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }


### PR DESCRIPTION
I noticed Swift Package Index was reporting that we don't support Swift 5.5. Chatting with them in https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2225 pointed to an issue with the `Package.resolved` inside the `Lottie.xcodeproj` bundle. Updating it from `"version" : 2` to `"version" : 1` should fix the issue.