### PR TITLE
Fix issue where XCFramework archive was double-zipped and rejected by SPM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,14 +68,14 @@ jobs:
       - name: Upload XCFramework
         uses: actions/upload-artifact@v2
         with:
-          name: XCFramework
-          # The xcframework is at the path `.build/archives/XCFramework/Lottie.xcframework.zip`.
+          name: BuildProducts
+          # The xcframework is at the path `.build/archives/Lottie.xcframework.zip`.
           # GitHub always zips the artifacts before uploading, so if we uploaded the .xframework.zip
           # directly then it would actually upload a double-zip (a .zip containing our `Lottie.xcframework.zip`).
           # This is confusing especially since macOS Archive Utility automatially unzips both layers at once.
-          # Instead, we upload the entire XCFramework folder, resulting in an `XCFramework.zip` that unzips
-          # to an `XCFramework` directory containing our `Lottie.xcframework.zip`.
-          path: .build/archives/XCFramework
+          # Instead, we upload the entire archives folder, resulting in an `XCFramework.zip` that unzips
+          # to an `archives` directory containing our `Lottie.xcframework.zip`.
+          path: .build/archives
 
   cocoapod:
     name: "Lint CocoaPods podspec"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,14 @@ jobs:
       - name: Upload XCFramework
         uses: actions/upload-artifact@v2
         with:
-          name: Lottie.xcframework
-          path: .build/archives/Lottie.xcframework
+          name: XCFramework
+          # The xcframework is at the path `.build/archives/XCFramework/Lottie.xcframework.zip`.
+          # GitHub always zips the artifacts before uploading, so if we uploaded the .xframework.zip
+          # directly then it would actually upload a double-zip (a .zip containing our `Lottie.xcframework.zip`).
+          # This is confusing especially since macOS Archive Utility automatially unzips both layers at once.
+          # Instead, we upload the entire XCFramework folder, resulting in an `XCFramework.zip` that unzips
+          # to an `XCFramework` directory containing our `Lottie.xcframework.zip`.
+          path: .build/archives/XCFramework
 
   cocoapod:
     name: "Lint CocoaPods podspec"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Lottie.xcframework
-          path: .build/archives/Lottie.xcframework.zip
+          path: .build/archives/Lottie.xcframework
 
   cocoapod:
     name: "Lint CocoaPods podspec"

--- a/Rakefile
+++ b/Rakefile
@@ -60,8 +60,13 @@ namespace :build do
         '-framework .build/archives/Lottie_macOS.xcarchive/Products/Library/Frameworks/Lottie.framework',
         '-framework .build/archives/Lottie_tvOS.xcarchive/Products/Library/Frameworks/Lottie.framework',
         '-framework .build/archives/Lottie_tvOS_Simulator.xcarchive/Products/Library/Frameworks/Lottie.framework',
-        '-output .build/archives/Lottie.xcframework'
+        '-output .build/archives/XCFramework/Lottie.xcframework'
       ].join(" "))
+    Dir.chdir('.build/archives/XCFramework') do
+      sh 'zip -r Lottie.xcframework.zip Lottie.xcframework'
+      sh 'rm -rf Lottie.xcframework'
+    end
+    sh 'swift package compute-checksum .build/archives/XCFramework/Lottie.xcframework.zip'
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -60,13 +60,13 @@ namespace :build do
         '-framework .build/archives/Lottie_macOS.xcarchive/Products/Library/Frameworks/Lottie.framework',
         '-framework .build/archives/Lottie_tvOS.xcarchive/Products/Library/Frameworks/Lottie.framework',
         '-framework .build/archives/Lottie_tvOS_Simulator.xcarchive/Products/Library/Frameworks/Lottie.framework',
-        '-output .build/archives/XCFramework/Lottie.xcframework'
+        '-output .build/archives/Lottie.xcframework'
       ].join(" "))
-    Dir.chdir('.build/archives/XCFramework') do
+    Dir.chdir('.build/archives') do
       sh 'zip -r Lottie.xcframework.zip Lottie.xcframework'
       sh 'rm -rf Lottie.xcframework'
     end
-    sh 'swift package compute-checksum .build/archives/XCFramework/Lottie.xcframework.zip'
+    sh 'swift package compute-checksum .build/archives/Lottie.xcframework.zip'
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -62,10 +62,6 @@ namespace :build do
         '-framework .build/archives/Lottie_tvOS_Simulator.xcarchive/Products/Library/Frameworks/Lottie.framework',
         '-output .build/archives/Lottie.xcframework'
       ].join(" "))
-    Dir.chdir('.build/archives') do
-      sh 'zip -r Lottie.xcframework.zip Lottie.xcframework'
-    end
-    sh 'swift package compute-checksum .build/archives/Lottie.xcframework.zip'
   end
 end
 

--- a/script/ReleaseInstructions.md
+++ b/script/ReleaseInstructions.md
@@ -8,7 +8,9 @@ Lottie is made available through multiple package managers, each of which has to
  3. Update the [Cocoapod](https://cocoapods.org/pods/lottie-ios) by running `pod trunk push lottie-ios.podspec`
  4. Update the [npm package](https://www.npmjs.com/package/lottie-ios) by running `npm publish`
  5. Attach `Lottie.xframework.zip` to the GitHub release
-   - For every PR / commit, `Lottie.xcframework.zip` is build by CI and uploaded to the job summary.
+   - For every PR / commit, `Lottie.xcframework.zip` is built by CI and uploaded to the job summary once all jobs are completed.
+   - Make sure to use the `Lottie.xcframework.zip` from the CI job for the commit on master / the specific release tag and not from a PR CI job.
  6. Update the [lottie-spm](https://github.com/airbnb/lottie-spm) [Package.swift](https://github.com/airbnb/lottie-spm/blob/main/Package.swift) manifest to reference the new version's XCFramework.
+   - You can compute the checksum by running `swift package compute-checksum Lottie.xcframework.zip`.
    - Optionally, consider updating the version number in `README.md` as well.
  7. Publish the new release in the [lottie-spm](https://github.com/airbnb/lottie-spm) repo


### PR DESCRIPTION
The XCFramework uploaded by the CI job was double-zipped (a `.zip` that contains a `.zip`), causing it to be rejected by SPM. This PR fixes the job to upload a `.zip` that actually works when used as an SPM dependencies.