### PR TITLE
make LottieAnimationView open & expose key methods

### DIFF
--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -346,61 +346,6 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Value Providers that have been registered using `setValueProvider(_:keypath:)`
   public private(set) var valueProviders = [AnimationKeypath: AnyValueProvider]()
 
-  /// Sets the current animation time with a Progress Time
-  ///
-  /// Note: Setting this will stop the current animation, if any.
-  /// Note 2: If `animation` is nil, setting this will fallback to 0
-  public var currentProgress: AnimationProgressTime {
-    set {
-      if let animation = animation {
-        currentFrame = animation.frameTime(forProgress: newValue)
-      } else {
-        currentFrame = 0
-      }
-    }
-    get {
-      if let animation = animation {
-        return animation.progressTime(forFrame: currentFrame)
-      } else {
-        return 0
-      }
-    }
-  }
-
-  /// Sets the current animation time with a time in seconds.
-  ///
-  /// Note: Setting this will stop the current animation, if any.
-  /// Note 2: If `animation` is nil, setting this will fallback to 0
-  public var currentTime: TimeInterval {
-    set {
-      if let animation = animation {
-        currentFrame = animation.frameTime(forTime: newValue)
-      } else {
-        currentFrame = 0
-      }
-    }
-    get {
-      if let animation = animation {
-        return animation.time(forFrame: currentFrame)
-      } else {
-        return 0
-      }
-    }
-  }
-
-  /// Sets the current animation time with a frame in the animations framerate.
-  ///
-  /// Note: Setting this will stop the current animation, if any.
-  public var currentFrame: AnimationFrameTime {
-    set {
-      removeCurrentAnimationIfNecessary()
-      updateAnimationFrame(newValue)
-    }
-    get {
-      animationLayer?.currentFrame ?? 0
-    }
-  }
-
   /// Describes the behavior of an AnimationView when the app is moved to the background.
   ///
   /// The default for the Main Thread animation engine is `pause`,
@@ -543,6 +488,61 @@ open class LottieAnimationView: LottieAnimationViewBase {
   public var shouldRasterizeWhenIdle = false {
     didSet {
       updateRasterizationState()
+    }
+  }
+
+  /// Sets the current animation time with a Progress Time
+  ///
+  /// Note: Setting this will stop the current animation, if any.
+  /// Note 2: If `animation` is nil, setting this will fallback to 0
+  public var currentProgress: AnimationProgressTime {
+    set {
+      if let animation = animation {
+        currentFrame = animation.frameTime(forProgress: newValue)
+      } else {
+        currentFrame = 0
+      }
+    }
+    get {
+      if let animation = animation {
+        return animation.progressTime(forFrame: currentFrame)
+      } else {
+        return 0
+      }
+    }
+  }
+
+  /// Sets the current animation time with a time in seconds.
+  ///
+  /// Note: Setting this will stop the current animation, if any.
+  /// Note 2: If `animation` is nil, setting this will fallback to 0
+  public var currentTime: TimeInterval {
+    set {
+      if let animation = animation {
+        currentFrame = animation.frameTime(forTime: newValue)
+      } else {
+        currentFrame = 0
+      }
+    }
+    get {
+      if let animation = animation {
+        return animation.time(forFrame: currentFrame)
+      } else {
+        return 0
+      }
+    }
+  }
+
+  /// Sets the current animation time with a frame in the animations framerate.
+  ///
+  /// Note: Setting this will stop the current animation, if any.
+  public var currentFrame: AnimationFrameTime {
+    set {
+      removeCurrentAnimationIfNecessary()
+      updateAnimationFrame(newValue)
+    }
+    get {
+      animationLayer?.currentFrame ?? 0
     }
   }
 

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -88,7 +88,7 @@ extension LottieLoopMode: Equatable {
 // MARK: - LottieAnimationView
 
 @IBDesignable
-final public class LottieAnimationView: LottieAnimationViewBase {
+open class LottieAnimationView: LottieAnimationViewBase {
 
   // MARK: Lifecycle
 
@@ -495,7 +495,7 @@ final public class LottieAnimationView: LottieAnimationViewBase {
   /// Plays the animation from its current state to the end.
   ///
   /// - Parameter completion: An optional completion closure to be called when the animation completes playing.
-  public func play(completion: LottieCompletionBlock? = nil) {
+  open func play(completion: LottieCompletionBlock? = nil) {
     guard let animation = animation else {
       return
     }
@@ -515,7 +515,7 @@ final public class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter toProgress: The end progress of the animation.
   /// - Parameter loopMode: The loop behavior of the animation. If `nil` the view's `loopMode` property will be used.
   /// - Parameter completion: An optional completion closure to be called when the animation stops.
-  public func play(
+  open func play(
     fromProgress: AnimationProgressTime? = nil,
     toProgress: AnimationProgressTime,
     loopMode: LottieLoopMode? = nil,
@@ -543,7 +543,7 @@ final public class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter toFrame: The end frame of the animation.
   /// - Parameter loopMode: The loop behavior of the animation. If `nil` the view's `loopMode` property will be used.
   /// - Parameter completion: An optional completion closure to be called when the animation stops.
-  public func play(
+  open func play(
     fromFrame: AnimationFrameTime? = nil,
     toFrame: AnimationFrameTime,
     loopMode: LottieLoopMode? = nil,
@@ -577,7 +577,7 @@ final public class LottieAnimationView: LottieAnimationViewBase {
   /// represents the beginning of the next section, it should be false.
   /// - Parameter loopMode: The loop behavior of the animation. If `nil` the view's `loopMode` property will be used.
   /// - Parameter completion: An optional completion closure to be called when the animation stops.
-  public func play(
+  open func play(
     fromMarker: String? = nil,
     toMarker: String,
     playEndMarkerFrame: Bool = true,
@@ -619,7 +619,7 @@ final public class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter marker: The start marker for the animation playback.
   /// - Parameter loopMode: The loop behavior of the animation. If `nil` the view's `loopMode` property will be used.
   /// - Parameter completion: An optional completion closure to be called when the animation stops.
-  public func play(
+  open func play(
     marker: String,
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
@@ -638,7 +638,7 @@ final public class LottieAnimationView: LottieAnimationViewBase {
   /// Stops the animation and resets the view to its start frame.
   ///
   /// The completion closure will be called with `false`
-  public func stop() {
+  open func stop() {
     removeCurrentAnimation()
     currentFrame = 0
   }
@@ -646,7 +646,7 @@ final public class LottieAnimationView: LottieAnimationViewBase {
   /// Pauses the animation in its current state.
   ///
   /// The completion closure will be called with `false`
-  public func pause() {
+  open func pause() {
     removeCurrentAnimation()
   }
 

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -335,7 +335,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Note: Setting this will stop the current animation, if any.
   /// Note 2: If `animation` is nil, setting this will fallback to 0
-  public var currentProgress: AnimationProgressTime {
+  open var currentProgress: AnimationProgressTime {
     set {
       if let animation = animation {
         currentFrame = animation.frameTime(forProgress: newValue)
@@ -356,7 +356,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Note: Setting this will stop the current animation, if any.
   /// Note 2: If `animation` is nil, setting this will fallback to 0
-  public var currentTime: TimeInterval {
+  open var currentTime: TimeInterval {
     set {
       if let animation = animation {
         currentFrame = animation.frameTime(forTime: newValue)
@@ -376,7 +376,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Sets the current animation time with a frame in the animations framerate.
   ///
   /// Note: Setting this will stop the current animation, if any.
-  public var currentFrame: AnimationFrameTime {
+  open var currentFrame: AnimationFrameTime {
     set {
       removeCurrentAnimationIfNecessary()
       updateAnimationFrame(newValue)

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -180,61 +180,6 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   // MARK: Open
 
-  /// Sets the current animation time with a Progress Time
-  ///
-  /// Note: Setting this will stop the current animation, if any.
-  /// Note 2: If `animation` is nil, setting this will fallback to 0
-  open var currentProgress: AnimationProgressTime {
-    set {
-      if let animation = animation {
-        currentFrame = animation.frameTime(forProgress: newValue)
-      } else {
-        currentFrame = 0
-      }
-    }
-    get {
-      if let animation = animation {
-        return animation.progressTime(forFrame: currentFrame)
-      } else {
-        return 0
-      }
-    }
-  }
-
-  /// Sets the current animation time with a time in seconds.
-  ///
-  /// Note: Setting this will stop the current animation, if any.
-  /// Note 2: If `animation` is nil, setting this will fallback to 0
-  open var currentTime: TimeInterval {
-    set {
-      if let animation = animation {
-        currentFrame = animation.frameTime(forTime: newValue)
-      } else {
-        currentFrame = 0
-      }
-    }
-    get {
-      if let animation = animation {
-        return animation.time(forFrame: currentFrame)
-      } else {
-        return 0
-      }
-    }
-  }
-
-  /// Sets the current animation time with a frame in the animations framerate.
-  ///
-  /// Note: Setting this will stop the current animation, if any.
-  open var currentFrame: AnimationFrameTime {
-    set {
-      removeCurrentAnimationIfNecessary()
-      updateAnimationFrame(newValue)
-    }
-    get {
-      animationLayer?.currentFrame ?? 0
-    }
-  }
-
   /// Plays the animation from its current state to the end.
   ///
   /// - Parameter completion: An optional completion closure to be called when the animation completes playing.
@@ -400,6 +345,61 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   /// Value Providers that have been registered using `setValueProvider(_:keypath:)`
   public private(set) var valueProviders = [AnimationKeypath: AnyValueProvider]()
+
+  /// Sets the current animation time with a Progress Time
+  ///
+  /// Note: Setting this will stop the current animation, if any.
+  /// Note 2: If `animation` is nil, setting this will fallback to 0
+  public var currentProgress: AnimationProgressTime {
+    set {
+      if let animation = animation {
+        currentFrame = animation.frameTime(forProgress: newValue)
+      } else {
+        currentFrame = 0
+      }
+    }
+    get {
+      if let animation = animation {
+        return animation.progressTime(forFrame: currentFrame)
+      } else {
+        return 0
+      }
+    }
+  }
+
+  /// Sets the current animation time with a time in seconds.
+  ///
+  /// Note: Setting this will stop the current animation, if any.
+  /// Note 2: If `animation` is nil, setting this will fallback to 0
+  public var currentTime: TimeInterval {
+    set {
+      if let animation = animation {
+        currentFrame = animation.frameTime(forTime: newValue)
+      } else {
+        currentFrame = 0
+      }
+    }
+    get {
+      if let animation = animation {
+        return animation.time(forFrame: currentFrame)
+      } else {
+        return 0
+      }
+    }
+  }
+
+  /// Sets the current animation time with a frame in the animations framerate.
+  ///
+  /// Note: Setting this will stop the current animation, if any.
+  public var currentFrame: AnimationFrameTime {
+    set {
+      removeCurrentAnimationIfNecessary()
+      updateAnimationFrame(newValue)
+    }
+    get {
+      animationLayer?.currentFrame ?? 0
+    }
+  }
 
   /// Describes the behavior of an AnimationView when the app is moved to the background.
   ///

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -11,7 +11,7 @@ import UIKit
 /// The base view for `LottieAnimationView` on iOS, tvOS, watchOS, and macCatalyst.
 ///
 /// Enables the `LottieAnimationView` implementation to be shared across platforms.
-public class LottieAnimationViewBase: UIView {
+open class LottieAnimationViewBase: UIView {
 
   // MARK: Public
 

--- a/Sources/Public/macOS/LottieAnimationViewBase.macOS.swift
+++ b/Sources/Public/macOS/LottieAnimationViewBase.macOS.swift
@@ -27,7 +27,7 @@ public enum LottieContentMode: Int {
 /// The base view for `LottieAnimationView` on macOs.
 ///
 /// Enables the `LottieAnimationView` implementation to be shared across platforms.
-public class LottieAnimationViewBase: NSView {
+open class LottieAnimationViewBase: NSView {
 
   // MARK: Public
 


### PR DESCRIPTION
At Duolingo we disable certain animations to comply with the reduced motion and soon will also be disabling certain animations in order to improve performance on older devices. To implement this functionality we currently have a class that wraps a LottieAnimationView forwarding method calls to its child LottieAnimationView while performing some extra checks around some of the methods.

It would be neater if we could override some of the methods in LottieAnimationView instead of wrapping it. This is possible in our android app because LottieAnimationView [isn't declared as final](https://github.com/airbnb/lottie-android/blob/master/lottie/src/main/java/com/airbnb/lottie/LottieAnimationView.java) but on ios it is.

Thoughts on allowing overriding?

I exposed only animation methods (e.g. play, pause, stop) & frame progress properties, because those seem like the methods that make the most sense to make open to overriding, and are sufficient for our needs.