### PR TITLE
Expose AnimationTextProvider in objc wrapper

### DIFF
--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -190,9 +190,7 @@ public final class CompatibleAnimationView: UIView {
   @objc
   public var compatibleAnimationTextProvider: CompatibleAnimationTextProvider? {
     didSet {
-      if let textProvider = compatibleAnimationTextProvider?.textProvider {
-        animationView.textProvider = textProvider
-      }
+      animationView.textProvider = compatibleAnimationTextProvider?.textProvider ?? DefaultTextProvider()
     }
   }
 

--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -470,8 +470,7 @@ public final class CompatibleAnimationTextProvider: NSObject {
   // MARK: Lifecycle
 
   @objc
-  public init(values: [String: String])
-  {
+  public init(values: [String: String]) {
     self.values = values
     super.init()
   }
@@ -479,7 +478,7 @@ public final class CompatibleAnimationTextProvider: NSObject {
   // MARK: Internal
 
   internal var textProvider: AnimationTextProvider? {
-    return DictionaryTextProvider(self.values)
+    DictionaryTextProvider(values)
   }
 
   // MARK: Private

--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -188,6 +188,15 @@ public final class CompatibleAnimationView: UIView {
   }
 
   @objc
+  public var compatibleAnimationTextProvider: CompatibleAnimationTextProvider? {
+    didSet {
+      if let textProvider = compatibleAnimationTextProvider?.textProvider {
+        animationView.textProvider = textProvider;
+      }
+    }
+  }
+
+  @objc
   public override var contentMode: UIView.ContentMode {
     set { animationView.contentMode = newValue }
     get { animationView.contentMode }
@@ -450,5 +459,31 @@ public final class CompatibleAnimationView: UIView {
     animationView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
     animationView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
   }
+}
+
+/// An Objective-C compatible wrapper around Lottie's AnimationTextProvider.
+/// Use in tandem with CompatibleAnimationView to supply text to LottieAnimationView
+/// when using Lottie in Objective-C.
+@objc
+public final class CompatibleAnimationTextProvider: NSObject {
+
+  // MARK: Lifecycle
+
+  @objc
+  public init(values: [String: String])
+  {
+    self.values = values
+    super.init()
+  }
+
+  // MARK: Internal
+
+  internal var textProvider: AnimationTextProvider? {
+    return DictionaryTextProvider(self.values);
+  }
+
+  // MARK: Private
+
+  private let values: [String: String]
 }
 #endif

--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -191,7 +191,7 @@ public final class CompatibleAnimationView: UIView {
   public var compatibleAnimationTextProvider: CompatibleAnimationTextProvider? {
     didSet {
       if let textProvider = compatibleAnimationTextProvider?.textProvider {
-        animationView.textProvider = textProvider;
+        animationView.textProvider = textProvider
       }
     }
   }
@@ -479,7 +479,7 @@ public final class CompatibleAnimationTextProvider: NSObject {
   // MARK: Internal
 
   internal var textProvider: AnimationTextProvider? {
-    return DictionaryTextProvider(self.values);
+    return DictionaryTextProvider(self.values)
   }
 
   // MARK: Private

--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -188,9 +188,9 @@ public final class CompatibleAnimationView: UIView {
   }
 
   @objc
-  public var compatibleAnimationTextProvider: CompatibleAnimationTextProvider? {
+  public var compatibleDictionaryTextProvider: CompatibleDictionaryTextProvider? {
     didSet {
-      animationView.textProvider = compatibleAnimationTextProvider?.textProvider ?? DefaultTextProvider()
+      animationView.textProvider = compatibleDictionaryTextProvider?.textProvider ?? DefaultTextProvider()
     }
   }
 
@@ -459,11 +459,11 @@ public final class CompatibleAnimationView: UIView {
   }
 }
 
-/// An Objective-C compatible wrapper around Lottie's AnimationTextProvider.
+/// An Objective-C compatible wrapper around Lottie's DictionaryTextProvider.
 /// Use in tandem with CompatibleAnimationView to supply text to LottieAnimationView
 /// when using Lottie in Objective-C.
 @objc
-public final class CompatibleAnimationTextProvider: NSObject {
+public final class CompatibleDictionaryTextProvider: NSObject {
 
   // MARK: Lifecycle
 


### PR DESCRIPTION
## This PR updates CompatibleAnimationView to expose textProvider. 

Exposing `textProvider` in `CompatibleAnimationView` will allow usage of Lottie in Objective-C access to the api to dynamically set texts in animations. 

Updates to `CompatibleAnimationView`:
- New class `CompatibleAnimationTextProvider` with class member returning an `AnimationTextProvider`.
- New public class member to CompatibleAnimationView to set textProvider from `CompatibleAnimationTextProvider`.