### PR TITLE
Add dispatch queue parameter to dotLottie loading methods

### DIFF
--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -36,15 +36,17 @@ extension DotLottieFile {
   /// - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
   /// - Parameter subdirectory: A subdirectory in the bundle in which the lottie is located. Optional.
   /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
+  /// - Parameter dispatchQueue: A dispatch queue used to load animations. Defaults to `DispatchQueue.global()`. Optional.
   /// - Parameter handleResult: A closure to be called when the file has loaded.
   public static func named(
     _ name: String,
     bundle: Bundle = Bundle.main,
     subdirectory: String? = nil,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
+    dispatchQueue: DispatchQueue = .global(),
     handleResult: @escaping (Result<DotLottieFile, Error>) -> Void)
   {
-    DispatchQueue.global().async {
+    dispatchQueue.async {
       /// Create a cache key for the lottie.
       let cacheKey = bundle.bundlePath + (subdirectory ?? "") + "/" + name
 
@@ -102,13 +104,15 @@ extension DotLottieFile {
   /// Loads an DotLottie from a specific filepath.
   /// - Parameter filepath: The absolute filepath of the lottie to load. EG "/User/Me/starAnimation.lottie"
   /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
+  /// - Parameter dispatchQueue: A dispatch queue used to load animations. Defaults to `DispatchQueue.global()`. Optional.
   /// - Parameter handleResult: A closure to be called when the file has loaded.
   public static func loadedFrom(
     filepath: String,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
+    dispatchQueue: DispatchQueue = .global(),
     handleResult: @escaping (Result<DotLottieFile, Error>) -> Void)
   {
-    DispatchQueue.global().async {
+    dispatchQueue.async {
       /// Check cache for lottie
       if
         let dotLottieCache = dotLottieCache,
@@ -160,14 +164,16 @@ extension DotLottieFile {
   ///    - Parameter name: The name of the lottie file in the asset catalog. EG "StarAnimation"
   ///    - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
   ///    - Parameter dotLottieCache: A cache for holding loaded lottie files. Defaults to `LRUDotLottieCache.sharedCache` Optional.
+  ///    - Parameter dispatchQueue: A dispatch queue used to load animations. Defaults to `DispatchQueue.global()`. Optional.
   ///    - Parameter handleResult: A closure to be called when the file has loaded.
   public static func asset(
     named name: String,
     bundle: Bundle = Bundle.main,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache,
+    dispatchQueue: DispatchQueue = .global(),
     handleResult: @escaping (Result<DotLottieFile, Error>) -> Void)
   {
-    DispatchQueue.global().async {
+    dispatchQueue.async {
       /// Create a cache key for the lottie.
       let cacheKey = bundle.bundlePath + "/" + name
 


### PR DESCRIPTION
## Reason

In some cases dotLottie animations will not be loaded correctly due to asynchronous nature of the loading mechanism.

This is due to race condition inside `DotLottieFile` loading methods. It uses `DispatchQueue.global()` which is concurrent. Loading the animation might fail in these examples:

- Initialisation of more animation views (typical for cells in collection/table view) with the same animation.
- If you have some stateful animation view (let's say play/pause button) and the user taps it quickly, then there might be race condition in case the animation was not loaded in time before.

```swift
playButton.updateAnimation(true)
playButton.updateAnimation(false)
playButton.updateAnimation(true)
playButton.updateAnimation(false)
```

```swift
func updateAnimation(_ playing: Bool) {
    DotLottieFile.asset(playing ? "pause" : "play") { success in
        guard case let .success(animation) = result else { return }
        animationView.loadAnimation(from: animation)
    }
}
```

Of course this depends on the usage of Lottie in your code, but it makes rewrites to async loading much more complex. Fixing this outside of Lottie is possible, by keeping flags with information about animation loading, wrapping everything in OperationQueue etc. But all of these solutions are hard to implement and would cause additional overhead.

## Solution

Add parameter to pass dispatch queue to dotLottie loading methods to enable passing serial or higher priority queue.

## Alternatives considered

### Adding DispatchQueue to Lottie configuration

Can be combined with this solution. Did not add this since Lottie configuration has only few flags and did not want to add any unnecessary feature flags to cause feature flag hell.

### Using serial queue by default.

Wanted to make this backward compatible and do not break current behavior.