### PR TITLE
#1962 Renaming bundle name

### DIFF
--- a/Tests/AnimationViewTests.swift
+++ b/Tests/AnimationViewTests.swift
@@ -10,7 +10,7 @@ final class AnimationViewTests: XCTestCase {
   func testLoadJsonFile() {
     let animationView = LottieAnimationView(
       name: "LottieLogo1",
-      bundle: .module,
+      bundle: .lottie,
       subdirectory: Samples.directoryName)
 
     XCTAssertNotNil(animationView.animation)
@@ -31,7 +31,7 @@ final class AnimationViewTests: XCTestCase {
 
     _ = LottieAnimationView(
       dotLottieName: "DotLottie/animation",
-      bundle: .module,
+      bundle: .lottie,
       subdirectory: Samples.directoryName,
       completion: { animationView, error in
         XCTAssertNil(error)
@@ -48,7 +48,7 @@ final class AnimationViewTests: XCTestCase {
 
     let animationView = LottieAnimationView(
       dotLottieName: "DotLottie/animation",
-      bundle: .module,
+      bundle: .lottie,
       subdirectory: Samples.directoryName)
 
     animationView.animationLoaded = { [weak animationView] view, animation in
@@ -76,7 +76,7 @@ final class AnimationViewTests: XCTestCase {
 
     let animation = LottieAnimation.named(
       "Issues/issue_1877",
-      bundle: .module,
+      bundle: .lottie,
       subdirectory: Samples.directoryName)
 
     XCTAssertNotNil(animation)

--- a/Tests/BundleTests.swift
+++ b/Tests/BundleTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 final class BundleTests: XCTestCase {
 
-  var bundle: Bundle { .module }
+  var bundle: Bundle { .lottie }
 
   func testGetAnimationDataWithSuffix() throws {
     let data = try bundle.getAnimationData("HamburgerArrow.json", subdirectory: "Samples")

--- a/Tests/CompatibleAnimationViewTests.swift
+++ b/Tests/CompatibleAnimationViewTests.swift
@@ -12,7 +12,7 @@ final class CompatibleAnimationViewTests: XCTestCase {
     guard try SnapshotTests.enabled else { return }
 
     #if os(iOS)
-    let animation = CompatibleAnimation(name: "LottieLogo2", subdirectory: Samples.directoryName, bundle: .module)
+    let animation = CompatibleAnimation(name: "LottieLogo2", subdirectory: Samples.directoryName, bundle: .lottie)
     let animationView = CompatibleAnimationView(compatibleAnimation: animation)
     animationView.frame.size = animation.animation!.snapshotSize
     animationView.currentProgress = 0.5

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -64,13 +64,13 @@ final class PerformanceTests: XCTestCase {
   }
 
   func testParsing_simpleAnimation() throws {
-    let data = try XCTUnwrap(Bundle.module.getAnimationData("loading_dots_1", subdirectory: "Samples/LottieFiles"))
+    let data = try XCTUnwrap(Bundle.lottie.getAnimationData("loading_dots_1", subdirectory: "Samples/LottieFiles"))
     let ratio = try compareDeserializationPerformance(data: data, iterations: 2000)
     XCTAssertEqual(ratio, 2, accuracy: 1.0)
   }
 
   func testParsing_complexAnimation() throws {
-    let data = try XCTUnwrap(Bundle.module.getAnimationData("LottieLogo2", subdirectory: "Samples"))
+    let data = try XCTUnwrap(Bundle.lottie.getAnimationData("LottieLogo2", subdirectory: "Samples"))
     let ratio = try compareDeserializationPerformance(data: data, iterations: 500)
     XCTAssertEqual(ratio, 1.7, accuracy: 1.0)
   }
@@ -87,12 +87,12 @@ final class PerformanceTests: XCTestCase {
 
   private let simpleAnimation = LottieAnimation.named(
     "loading_dots_1",
-    bundle: .module,
+    bundle: .lottie,
     subdirectory: "Samples/LottieFiles")!
 
   private let complexAnimation = LottieAnimation.named(
     "LottieLogo2",
-    bundle: .module,
+    bundle: .lottie,
     subdirectory: "Samples")!
 
   /// Compares initializing the given animation with the two given engines,

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -68,7 +68,7 @@ class SnapshotTests: XCTestCase {
   /// reference a sample json file that actually exists
   func testCustomSnapshotConfigurationsHaveCorrespondingSampleFile() {
     for (animationName, _) in SnapshotConfiguration.customMapping {
-      let expectedSampleFile = Bundle.module.bundleURL.appendingPathComponent("Samples/\(animationName).json")
+      let expectedSampleFile = Bundle.lottie.bundleURL.appendingPathComponent("Samples/\(animationName).json")
 
       XCTAssert(
         Samples.sampleAnimationURLs.contains(expectedSampleFile),
@@ -201,13 +201,13 @@ enum Samples {
   static let directoryName = "Samples"
 
   /// The list of snapshot image files in `Tests/__Snapshots__`
-  static let snapshotURLs = Bundle.module.fileURLs(
+  static let snapshotURLs = Bundle.lottie.fileURLs(
     in: "__Snapshots__/SnapshotTests",
     withSuffix: "png")
 
   /// The list of sample animation files in `Tests/Samples`
-  static let sampleAnimationURLs = Bundle.module.fileURLs(in: Samples.directoryName, withSuffix: "json")
-    + Bundle.module.fileURLs(in: Samples.directoryName, withSuffix: "lottie")
+  static let sampleAnimationURLs = Bundle.lottie.fileURLs(in: Samples.directoryName, withSuffix: "json")
+    + Bundle.lottie.fileURLs(in: Samples.directoryName, withSuffix: "lottie")
 
   /// The list of sample animation names in `Tests/Samples`
   static let sampleAnimationNames = sampleAnimationURLs.lazy
@@ -230,7 +230,7 @@ enum Samples {
     guard
       let animation = LottieAnimation.named(
         sampleAnimationName,
-        bundle: .module,
+        bundle: .lottie,
         subdirectory: Samples.directoryName)
     else { return nil }
 
@@ -241,7 +241,7 @@ enum Samples {
     guard
       let dotLottieFile = try? await DotLottieFile.named(
         sampleDotLottieName,
-        bundle: .module,
+        bundle: .lottie,
         subdirectory: Samples.directoryName)
     else {
       XCTFail("Could not parse Samples/\(sampleDotLottieName).lottie")

--- a/Tests/Utils/Bundle+Module.swift
+++ b/Tests/Utils/Bundle+Module.swift
@@ -5,13 +5,13 @@ import Foundation
 
 extension Bundle {
   /// The Bundle representing files in this module
-  static var module: Bundle {
+  static var lottie: Bundle {
     Bundle(for: SnapshotTests.self)
   }
 
   /// Retrieves URLs for all of the files in the given directory with the given suffix
   func fileURLs(in directory: String, withSuffix suffix: String) -> [URL] {
-    let enumerator = FileManager.default.enumerator(atPath: Bundle.module.bundlePath)!
+    let enumerator = FileManager.default.enumerator(atPath: Bundle.lottie.bundlePath)!
 
     var fileURLs: [URL] = []
 
@@ -20,7 +20,7 @@ extension Bundle {
         fileSubpath.hasPrefix(directory),
         fileSubpath.contains(suffix)
       {
-        let fileURL = Bundle.module.bundleURL.appendingPathComponent(fileSubpath)
+        let fileURL = Bundle.lottie.bundleURL.appendingPathComponent(fileSubpath)
         fileURLs.append(fileURL)
       }
     }

--- a/Tests/Utils/HardcodedImageProvider.swift
+++ b/Tests/Utils/HardcodedImageProvider.swift
@@ -15,7 +15,7 @@ struct HardcodedImageProvider: AnimationImageProvider {
 
   func imageForAsset(asset _: ImageAsset) -> CGImage? {
     #if os(iOS)
-    return UIImage(named: imageName, in: .module, compatibleWith: nil)?.cgImage
+    return UIImage(named: imageName, in: .lottie, compatibleWith: nil)?.cgImage
     #else
     return nil
     #endif


### PR DESCRIPTION
Fixes #1962

- Renaming bundle name to avoid conflict with the swift-generated module name