### PR TITLE
Fix compilation of iOS example project in Xcode 14.3 beta

### DIFF
--- a/Example/iOS/Views/AnimatedButtonRow.swift
+++ b/Example/iOS/Views/AnimatedButtonRow.swift
@@ -57,33 +57,31 @@ final class AnimatedButtonRow: UIView, EpoxyableView {
     guard let content = content else { return }
 
     group.setItems {
-      if let animationName = content.animationName {
-        GroupItem<AnimatedButton>(
-          dataID: DataID.animatedButton,
-          content: content,
-          make: {
-            let animatedButton = AnimatedButton()
-            animatedButton.translatesAutoresizingMaskIntoConstraints = false
+      GroupItem<AnimatedButton>(
+        dataID: DataID.animatedButton,
+        content: content,
+        make: {
+          let animatedButton = AnimatedButton()
+          animatedButton.translatesAutoresizingMaskIntoConstraints = false
 
-            NSLayoutConstraint.activate([
-              animatedButton.widthAnchor.constraint(equalToConstant: 80),
-              animatedButton.heightAnchor.constraint(equalToConstant: 80),
-            ])
+          NSLayoutConstraint.activate([
+            animatedButton.widthAnchor.constraint(equalToConstant: 80),
+            animatedButton.heightAnchor.constraint(equalToConstant: 80),
+          ])
 
-            return animatedButton
-          },
-          setContent: { context, content in
-            context.constrainable.animation = .named(animationName)
-            context.constrainable.contentMode = .scaleAspectFit
+          return animatedButton
+        },
+        setContent: { context, content in
+          context.constrainable.animation = .named(content.animationName)
+          context.constrainable.contentMode = .scaleAspectFit
 
-            for playRange in content.playRanges {
-              context.constrainable.setPlayRange(
-                fromMarker: playRange.fromMarker,
-                toMarker: playRange.toMarker,
-                event: playRange.event)
-            }
-          })
-      }
+          for playRange in content.playRanges {
+            context.constrainable.setPlayRange(
+              fromMarker: playRange.fromMarker,
+              toMarker: playRange.toMarker,
+              event: playRange.event)
+          }
+        })
 
       GroupItem<UILabel>(
         dataID: DataID.title,

--- a/Example/iOS/Views/AnimatedSwitchRow.swift
+++ b/Example/iOS/Views/AnimatedSwitchRow.swift
@@ -59,47 +59,45 @@ final class AnimatedSwitchRow: UIView, EpoxyableView {
     guard let content = content else { return }
 
     group.setItems {
-      if let animationName = content.animationName {
-        GroupItem<AnimatedSwitch>(
-          dataID: DataID.animatedSwitch,
-          content: content,
-          make: {
-            let animatedSwitch = AnimatedSwitch()
-            animatedSwitch.translatesAutoresizingMaskIntoConstraints = false
+      GroupItem<AnimatedSwitch>(
+        dataID: DataID.animatedSwitch,
+        content: content,
+        make: {
+          let animatedSwitch = AnimatedSwitch()
+          animatedSwitch.translatesAutoresizingMaskIntoConstraints = false
 
-            NSLayoutConstraint.activate([
-              animatedSwitch.widthAnchor.constraint(equalToConstant: 80),
-              animatedSwitch.heightAnchor.constraint(equalToConstant: 80),
-            ])
+          NSLayoutConstraint.activate([
+            animatedSwitch.widthAnchor.constraint(equalToConstant: 80),
+            animatedSwitch.heightAnchor.constraint(equalToConstant: 80),
+          ])
 
-            animatedSwitch.addTarget(self, action: #selector(self.switchWasToggled), for: .touchUpInside)
-            return animatedSwitch
-          },
-          setContent: { context, content in
-            context.constrainable.animation = .named(animationName)
-            context.constrainable.contentMode = .scaleAspectFit
+          animatedSwitch.addTarget(self, action: #selector(self.switchWasToggled), for: .touchUpInside)
+          return animatedSwitch
+        },
+        setContent: { context, content in
+          context.constrainable.animation = .named(content.animationName)
+          context.constrainable.contentMode = .scaleAspectFit
 
-            if let offTimeRange = content.offTimeRange {
-              context.constrainable.setProgressForState(
-                fromProgress: offTimeRange.lowerBound,
-                toProgress: offTimeRange.upperBound,
-                forOnState: false)
-            }
+          if let offTimeRange = content.offTimeRange {
+            context.constrainable.setProgressForState(
+              fromProgress: offTimeRange.lowerBound,
+              toProgress: offTimeRange.upperBound,
+              forOnState: false)
+          }
 
-            if let onTimeRange = content.onTimeRange {
-              context.constrainable.setProgressForState(
-                fromProgress: onTimeRange.lowerBound,
-                toProgress: onTimeRange.upperBound,
-                forOnState: true)
-            }
+          if let onTimeRange = content.onTimeRange {
+            context.constrainable.setProgressForState(
+              fromProgress: onTimeRange.lowerBound,
+              toProgress: onTimeRange.upperBound,
+              forOnState: true)
+          }
 
-            for (keypath, color) in content.colorValueProviders {
-              context.constrainable.animationView.setValueProvider(
-                ColorValueProvider(color),
-                keypath: AnimationKeypath(keypath: keypath))
-            }
-          })
-      }
+          for (keypath, color) in content.colorValueProviders {
+            context.constrainable.animationView.setValueProvider(
+              ColorValueProvider(color),
+              keypath: AnimationKeypath(keypath: keypath))
+          }
+        })
 
       GroupItem<UILabel>(
         dataID: DataID.title,


### PR DESCRIPTION
Removes 2 unnecessary conditional unwraps in example project, which now throw compilation error in the new Xcode 14.3 beta.

<img width="1512" alt="Screenshot 2023-02-19 at 22 18 35" src="https://user-images.githubusercontent.com/708312/219975832-1fcf1413-3eab-4510-8c9a-6ccca29797ce.png">
