### PR TITLE
add support for loading DotLottieFile by name and filename synchronously

### DIFF
--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -68,9 +68,7 @@ extension DotLottieFile {
 
       do {
         /// Decode animation.
-        guard let data = try bundle.dotLottieData(name, subdirectory: subdirectory) else {
-          throw DotLottieError.invalidData
-        }
+        let data = try bundle.dotLottieData(name, subdirectory: subdirectory)
         let lottie = try DotLottieFile(data: data, filename: name)
         dotLottieCache?.setFile(lottie, forKey: cacheKey)
         return .success(lottie)

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -9,6 +9,79 @@ import Foundation
 
 extension DotLottieFile {
 
+  public enum SynchronouslyBlockingCurrentThread {
+    /// Loads an DotLottie from a specific filepath synchronously. Returns a `Result<DotLottieFile, Error>`
+    /// Please use the asynchronous methods whenever possible. This operation will block the Thread it is running in.
+    ///
+    /// - Parameter filepath: The absolute filepath of the lottie to load. EG "/User/Me/starAnimation.lottie"
+    /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
+    public static func loadedFrom(
+      filepath: String,
+      dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache)
+      -> Result<DotLottieFile, Error>
+    {
+      /// Check cache for lottie
+      if
+        let dotLottieCache = dotLottieCache,
+        let lottie = dotLottieCache.file(forKey: filepath)
+      {
+        return .success(lottie)
+      }
+
+      do {
+        /// Decode the lottie.
+        let url = URL(fileURLWithPath: filepath)
+        let data = try Data(contentsOf: url)
+        let lottie = try DotLottieFile(data: data, filename: url.deletingPathExtension().lastPathComponent)
+        dotLottieCache?.setFile(lottie, forKey: filepath)
+        return .success(lottie)
+      } catch {
+        /// Decoding Error.
+        return .failure(error)
+      }
+    }
+
+    /// Loads a DotLottie model from a bundle by its name synchronously. Returns a `Result<DotLottieFile, Error>`
+    /// Please use the asynchronous methods whenever possible. This operation will block the Thread it is running in.
+    ///
+    /// - Parameter name: The name of the lottie file without the lottie extension. EG "StarAnimation"
+    /// - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
+    /// - Parameter subdirectory: A subdirectory in the bundle in which the lottie is located. Optional.
+    /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
+    public static func named(
+      _ name: String,
+      bundle: Bundle = Bundle.main,
+      subdirectory: String? = nil,
+      dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache)
+      -> Result<DotLottieFile, Error>
+    {
+      /// Create a cache key for the lottie.
+      let cacheKey = bundle.bundlePath + (subdirectory ?? "") + "/" + name
+
+      /// Check cache for lottie
+      if
+        let dotLottieCache = dotLottieCache,
+        let lottie = dotLottieCache.file(forKey: cacheKey)
+      {
+        return .success(lottie)
+      }
+
+      do {
+        /// Decode animation.
+        guard let data = try bundle.dotLottieData(name, subdirectory: subdirectory) else {
+          throw DotLottieError.invalidData
+        }
+        let lottie = try DotLottieFile(data: data, filename: name)
+        dotLottieCache?.setFile(lottie, forKey: cacheKey)
+        return .success(lottie)
+      } catch {
+        /// Decoding error.
+        LottieLogger.shared.warn("Error when decoding lottie \"\(name)\": \(error)")
+        return .failure(error)
+      }
+    }
+  }
+
   /// Loads a DotLottie model from a bundle by its name. Returns `nil` if a file is not found.
   ///
   /// - Parameter name: The name of the lottie file without the lottie extension. EG "StarAnimation"
@@ -47,7 +120,11 @@ extension DotLottieFile {
     handleResult: @escaping (Result<DotLottieFile, Error>) -> Void)
   {
     dispatchQueue.async {
-      let result = SynchronouslyBlockingCurrentThread.named(name, bundle: bundle, subdirectory: subdirectory, dotLottieCache: dotLottieCache)
+      let result = SynchronouslyBlockingCurrentThread.named(
+        name,
+        bundle: bundle,
+        subdirectory: subdirectory,
+        dotLottieCache: dotLottieCache)
 
       DispatchQueue.main.async {
         handleResult(result)
@@ -83,7 +160,9 @@ extension DotLottieFile {
     handleResult: @escaping (Result<DotLottieFile, Error>) -> Void)
   {
     dispatchQueue.async {
-      let result = SynchronouslyBlockingCurrentThread.loadedFrom(filepath: filepath, dotLottieCache: dotLottieCache)
+      let result = SynchronouslyBlockingCurrentThread.loadedFrom(
+        filepath: filepath,
+        dotLottieCache: dotLottieCache)
 
       DispatchQueue.main.async {
         handleResult(result)
@@ -212,76 +291,4 @@ extension DotLottieFile {
     }
   }
 
-  public enum SynchronouslyBlockingCurrentThread {
-    /// Loads an DotLottie from a specific filepath synchronously. Returns a `Result<DotLottieFile, Error>`
-    /// Please use the asynchronous methods whenever possible. This operation will block the Thread it is running in.
-    ///
-    /// - Parameter filepath: The absolute filepath of the lottie to load. EG "/User/Me/starAnimation.lottie"
-    /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
-    public static func loadedFrom(
-      filepath: String,
-      dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache)
-      -> Result<DotLottieFile, Error>
-    {
-      /// Check cache for lottie
-      if
-        let dotLottieCache = dotLottieCache,
-        let lottie = dotLottieCache.file(forKey: filepath)
-      {
-        return .success(lottie)
-      }
-
-      do {
-        /// Decode the lottie.
-        let url = URL(fileURLWithPath: filepath)
-        let data = try Data(contentsOf: url)
-        let lottie = try DotLottieFile(data: data, filename: url.deletingPathExtension().lastPathComponent)
-        dotLottieCache?.setFile(lottie, forKey: filepath)
-        return .success(lottie)
-      } catch {
-        /// Decoding Error.
-        return .failure(error)
-      }
-    }
-
-    /// Loads a DotLottie model from a bundle by its name synchronously. Returns a `Result<DotLottieFile, Error>`
-    /// Please use the asynchronous methods whenever possible. This operation will block the Thread it is running in.
-    ///
-    /// - Parameter name: The name of the lottie file without the lottie extension. EG "StarAnimation"
-    /// - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
-    /// - Parameter subdirectory: A subdirectory in the bundle in which the lottie is located. Optional.
-    /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
-    public static func named(
-      _ name: String,
-      bundle: Bundle = Bundle.main,
-      subdirectory: String? = nil,
-      dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache)
-      -> Result<DotLottieFile, Error>
-    {
-      /// Create a cache key for the lottie.
-      let cacheKey = bundle.bundlePath + (subdirectory ?? "") + "/" + name
-
-      /// Check cache for lottie
-      if
-        let dotLottieCache = dotLottieCache,
-        let lottie = dotLottieCache.file(forKey: cacheKey)
-      {
-        return .success(lottie)
-      }
-
-      do {
-        /// Decode animation.
-        guard let data = try bundle.dotLottieData(name, subdirectory: subdirectory) else {
-          throw DotLottieError.invalidData
-        }
-        let lottie = try DotLottieFile(data: data, filename: name)
-        dotLottieCache?.setFile(lottie, forKey: cacheKey)
-        return .success(lottie)
-      } catch {
-        /// Decoding error.
-        LottieLogger.shared.warn("Error when decoding lottie \"\(name)\": \(error)")
-        return .failure(error)
-      }
-    }
-  }
 }

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -258,4 +258,69 @@ extension DotLottieFile {
     }
   }
 
+  /// Loads an DotLottie from a specific filepath synchronously.
+  /// - Parameter filepath: The absolute filepath of the lottie to load. EG "/User/Me/starAnimation.lottie"
+  /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
+  public static func loadedFrom(
+    filepath: String,
+    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache
+  ) -> Result<DotLottieFile, Error> {
+    /// Check cache for lottie
+    if
+      let dotLottieCache = dotLottieCache,
+      let lottie = dotLottieCache.file(forKey: filepath)
+    {
+      return .success(lottie)
+    }
+
+    do {
+      /// Decode the lottie.
+      let url = URL(fileURLWithPath: filepath)
+      let data = try Data(contentsOf: url)
+      let lottie = try DotLottieFile(data: data, filename: url.deletingPathExtension().lastPathComponent)
+      dotLottieCache?.setFile(lottie, forKey: filepath)
+      return .success(lottie)
+    } catch {
+      /// Decoding Error.
+      return .failure(error)
+    }
+  }
+
+  /// Loads a DotLottie model from a bundle by its name synchronously. Returns a `Result<DotLottieFile, Error>`
+  ///
+  /// - Parameter name: The name of the lottie file without the lottie extension. EG "StarAnimation"
+  /// - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
+  /// - Parameter subdirectory: A subdirectory in the bundle in which the lottie is located. Optional.
+  /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
+  public static func named(
+    _ name: String,
+    bundle: Bundle = Bundle.main,
+    subdirectory: String? = nil,
+    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache
+  ) -> Result<DotLottieFile, Error> {
+    /// Create a cache key for the lottie.
+    let cacheKey = bundle.bundlePath + (subdirectory ?? "") + "/" + name
+
+    /// Check cache for lottie
+    if
+      let dotLottieCache = dotLottieCache,
+      let lottie = dotLottieCache.file(forKey: cacheKey)
+    {
+      return .success(lottie)
+    }
+
+    do {
+      /// Decode animation.
+      guard let data = try bundle.dotLottieData(name, subdirectory: subdirectory) else {
+        throw DotLottieError.invalidData
+      }
+      let lottie = try DotLottieFile(data: data, filename: name)
+      dotLottieCache?.setFile(lottie, forKey: cacheKey)
+      return .success(lottie)
+    } catch {
+      /// Decoding error.
+      LottieLogger.shared.warn("Error when decoding lottie \"\(name)\": \(error)")
+      return .failure(error)
+    }
+  }
 }

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -47,35 +47,10 @@ extension DotLottieFile {
     handleResult: @escaping (Result<DotLottieFile, Error>) -> Void)
   {
     dispatchQueue.async {
-      /// Create a cache key for the lottie.
-      let cacheKey = bundle.bundlePath + (subdirectory ?? "") + "/" + name
+      let result = named(name, bundle: bundle, subdirectory: subdirectory, dotLottieCache: dotLottieCache)
 
-      /// Check cache for lottie
-      if
-        let dotLottieCache = dotLottieCache,
-        let lottie = dotLottieCache.file(forKey: cacheKey)
-      {
-        DispatchQueue.main.async {
-          /// If found, return the lottie.
-          handleResult(.success(lottie))
-        }
-        return
-      }
-
-      do {
-        /// Decode animation.
-        let data = try bundle.dotLottieData(name, subdirectory: subdirectory)
-        let lottie = try DotLottieFile(data: data, filename: name)
-        dotLottieCache?.setFile(lottie, forKey: cacheKey)
-        DispatchQueue.main.async {
-          handleResult(.success(lottie))
-        }
-      } catch {
-        /// Decoding error.
-        LottieLogger.shared.warn("Error when decoding lottie \"\(name)\": \(error)")
-        DispatchQueue.main.async {
-          handleResult(.failure(error))
-        }
+      DispatchQueue.main.async {
+        handleResult(result)
       }
     }
   }
@@ -108,31 +83,10 @@ extension DotLottieFile {
     handleResult: @escaping (Result<DotLottieFile, Error>) -> Void)
   {
     dispatchQueue.async {
-      /// Check cache for lottie
-      if
-        let dotLottieCache = dotLottieCache,
-        let lottie = dotLottieCache.file(forKey: filepath)
-      {
-        DispatchQueue.main.async {
-          handleResult(.success(lottie))
-        }
-        return
-      }
+      let result = loadedFrom(filepath: filepath, dotLottieCache: dotLottieCache)
 
-      do {
-        /// Decode the lottie.
-        let url = URL(fileURLWithPath: filepath)
-        let data = try Data(contentsOf: url)
-        let lottie = try DotLottieFile(data: data, filename: url.deletingPathExtension().lastPathComponent)
-        dotLottieCache?.setFile(lottie, forKey: filepath)
-        DispatchQueue.main.async {
-          handleResult(.success(lottie))
-        }
-      } catch {
-        /// Decoding Error.
-        DispatchQueue.main.async {
-          handleResult(.failure(error))
-        }
+      DispatchQueue.main.async {
+        handleResult(result)
       }
     }
   }

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -263,8 +263,9 @@ extension DotLottieFile {
   /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
   public static func loadedFrom(
     filepath: String,
-    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache
-  ) -> Result<DotLottieFile, Error> {
+    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache)
+    -> Result<DotLottieFile, Error>
+  {
     /// Check cache for lottie
     if
       let dotLottieCache = dotLottieCache,
@@ -296,8 +297,9 @@ extension DotLottieFile {
     _ name: String,
     bundle: Bundle = Bundle.main,
     subdirectory: String? = nil,
-    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache
-  ) -> Result<DotLottieFile, Error> {
+    dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache)
+    -> Result<DotLottieFile, Error>
+  {
     /// Create a cache key for the lottie.
     let cacheKey = bundle.bundlePath + (subdirectory ?? "") + "/" + name
 


### PR DESCRIPTION
We need to be able to load `dotLottie` files synchronously in out project. This PR enables us to create `DotLottieFile` directly.

Reference: https://github.com/airbnb/lottie-ios/issues/1967