### PR TITLE
Add dotLottie error handling

### DIFF
--- a/Sources/Private/Model/DotLottie/DotLottieAnimation.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieAnimation.swift
@@ -24,7 +24,7 @@ struct DotLottieAnimation: Codable {
   var mode: String? = "normal"
 
   /// URL to animation, to be set internally
-  var animationUrl: URL?
+  var animationUrl: URL
 
   /// Loop mode for animation
   var loopMode: LottieLoopMode {
@@ -39,9 +39,6 @@ struct DotLottieAnimation: Codable {
   /// Loads `LottieAnimation` from `animationUrl`
   /// - Returns: Deserialized `LottieAnimation`. Optional.
   func animation() throws -> LottieAnimation {
-    guard let animationUrl = animationUrl else {
-      throw DotLottieError.animationNotAvailable
-    }
     let data = try Data(contentsOf: animationUrl)
     return try LottieAnimation.from(data: data)
   }

--- a/Sources/Private/Model/DotLottie/DotLottieAnimation.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieAnimation.swift
@@ -23,9 +23,6 @@ struct DotLottieAnimation: Codable {
   /// mode - "bounce" | "normal"
   var mode: String? = "normal"
 
-  /// URL to animation, to be set internally
-  var animationUrl: URL
-
   /// Loop mode for animation
   var loopMode: LottieLoopMode {
     mode == "bounce" ? .autoReverse : ((loop ?? false) ? .loop : .playOnce)
@@ -38,9 +35,9 @@ struct DotLottieAnimation: Codable {
 
   /// Loads `LottieAnimation` from `animationUrl`
   /// - Returns: Deserialized `LottieAnimation`. Optional.
-  func animation() throws -> LottieAnimation {
+  func animation(url: URL) throws -> LottieAnimation {
+    let animationUrl = url.appendingPathComponent("\(id).json")
     let data = try Data(contentsOf: animationUrl)
     return try LottieAnimation.from(data: data)
   }
-
 }

--- a/Sources/Private/Model/DotLottie/DotLottieUtils.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieUtils.swift
@@ -54,5 +54,4 @@ extension FileManager {
 public enum DotLottieError: Error {
   case invalidFileFormat
   case invalidData
-  case animationNotAvailable
 }

--- a/Sources/Private/Model/DotLottie/DotLottieUtils.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieUtils.swift
@@ -52,7 +52,9 @@ extension FileManager {
 // MARK: - DotLottieError
 
 public enum DotLottieError: Error {
-  case urlLoadingFailed
+  /// URL response has no data.
+  case noDataLoaded
+  /// Asset with this name was not found in the provided bundle.
   case assetNotFound(name: String, bundle: Bundle?)
   /// Animation loading from asset is not supported on macOS 10.10.
   case loadingFromAssetNotSupported

--- a/Sources/Private/Model/DotLottie/DotLottieUtils.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieUtils.swift
@@ -52,6 +52,8 @@ extension FileManager {
 // MARK: - DotLottieError
 
 public enum DotLottieError: Error {
-  case invalidFileFormat
-  case invalidData
+  case urlLoadingFailed
+  case assetNotFound(name: String, bundle: Bundle?)
+  /// Animation loading from asset is not supported on macOS 10.10.
+  case loadingFromAssetNotSupported
 }

--- a/Sources/Private/Model/Extensions/Bundle.swift
+++ b/Sources/Private/Model/Extensions/Bundle.swift
@@ -4,36 +4,27 @@ import UIKit
 #endif
 
 extension Bundle {
-  func getAnimationData(_ name: String, subdirectory: String? = nil) throws -> Data? {
+  func getAnimationData(_ name: String, subdirectory: String? = nil) throws -> Data {
     // Check for files in the bundle at the given path
     let name = name.removingJSONSuffix()
     if let url = url(forResource: name, withExtension: "json", subdirectory: subdirectory) {
       return try Data(contentsOf: url)
     }
 
-    // Check for data assets (not available on macOS)
-    #if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
+    // Check for data assets
     let assetKey = subdirectory != nil ? "\(subdirectory ?? "")/\(name)" : name
-    return NSDataAsset(name: assetKey, bundle: self)?.data
-    #else
-    return nil
-    #endif
+    return try Data(assetName: assetKey, in: self)
   }
 
-  func dotLottieData(_ name: String, subdirectory: String? = nil) throws -> Data? {
+  func dotLottieData(_ name: String, subdirectory: String? = nil) throws -> Data {
     // Check for files in the bundle at the given path
     let name = name.removingDotLottieSuffix()
     if let url = url(forResource: name, withExtension: "lottie", subdirectory: subdirectory) {
       return try Data(contentsOf: url)
     }
 
-    // Check for data assets (not available on macOS)
-    #if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
     let assetKey = subdirectory != nil ? "\(subdirectory ?? "")/\(name)" : name
-    return NSDataAsset(name: assetKey, bundle: self)?.data
-    #else
-    return nil
-    #endif
+    return try Data(assetName: assetKey, in: self)
   }
 }
 

--- a/Sources/Private/Utility/Extensions/DataExtension.swift
+++ b/Sources/Private/Utility/Extensions/DataExtension.swift
@@ -14,14 +14,24 @@ import AppKit
 
 extension Data {
 
-  static func jsonData(from assetName: String, in bundle: Bundle) -> Data? {
+  init(assetName: String, in bundle: Bundle) throws {
     #if canImport(UIKit)
-    return NSDataAsset(name: assetName, bundle: bundle)?.data
+      if let asset =  NSDataAsset(name: assetName, bundle: bundle) {
+          self = asset.data
+          return
+      } else {
+          throw DotLottieError.assetNotFound(name: assetName, bundle: bundle)
+      }
     #else
     if #available(macOS 10.11, *) {
-      return NSDataAsset(name: assetName, bundle: bundle)?.data
+        if let asset =  NSDataAsset(name: assetName, bundle: bundle) {
+            self = asset.data
+            return
+        } else {
+            throw DotLottieError.assetNotFound(name: assetName, bundle: bundle)
+        }
     }
-    return nil
+    throw DotLottieError.loadingFromAssetNotSupported
     #endif
   }
 }

--- a/Sources/Private/Utility/Extensions/DataExtension.swift
+++ b/Sources/Private/Utility/Extensions/DataExtension.swift
@@ -16,20 +16,20 @@ extension Data {
 
   init(assetName: String, in bundle: Bundle) throws {
     #if canImport(UIKit)
-      if let asset =  NSDataAsset(name: assetName, bundle: bundle) {
-          self = asset.data
-          return
-      } else {
-          throw DotLottieError.assetNotFound(name: assetName, bundle: bundle)
-      }
+    if let asset = NSDataAsset(name: assetName, bundle: bundle) {
+      self = asset.data
+      return
+    } else {
+      throw DotLottieError.assetNotFound(name: assetName, bundle: bundle)
+    }
     #else
     if #available(macOS 10.11, *) {
-        if let asset =  NSDataAsset(name: assetName, bundle: bundle) {
-            self = asset.data
-            return
-        } else {
-            throw DotLottieError.assetNotFound(name: assetName, bundle: bundle)
-        }
+      if let asset = NSDataAsset(name: assetName, bundle: bundle) {
+        self = asset.data
+        return
+      } else {
+        throw DotLottieError.assetNotFound(name: assetName, bundle: bundle)
+      }
     }
     throw DotLottieError.loadingFromAssetNotSupported
     #endif

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -95,7 +95,7 @@ extension LottieAnimation {
       animationCache?.setAnimation(animation, forKey: filepath)
       return animation
     } catch {
-      LottieLogger.shared.assertionFailure("""
+      LottieLogger.shared.warn("""
         Failed to load animation from filepath \(filepath)
         with underlying error: \(error.localizedDescription)
         """)
@@ -134,7 +134,7 @@ extension LottieAnimation {
       animationCache?.setAnimation(animation, forKey: cacheKey)
       return animation
     } catch {
-      LottieLogger.shared.assertionFailure("""
+      LottieLogger.shared.warn("""
         Failed to load animation with asset name \(name)
         in \(bundle.bundlePath)
         with underlying error: \(error.localizedDescription)

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -95,10 +95,10 @@ extension LottieAnimation {
       animationCache?.setAnimation(animation, forKey: filepath)
       return animation
     } catch {
-        LottieLogger.shared.assertionFailure("""
-          Failed to load animation from filepath \(filepath)
-          with underlying error: \(error.localizedDescription)
-          """)
+      LottieLogger.shared.assertionFailure("""
+        Failed to load animation from filepath \(filepath)
+        with underlying error: \(error.localizedDescription)
+        """)
       return nil
     }
   }

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -59,9 +59,7 @@ extension LottieAnimation {
 
     do {
       /// Decode animation.
-      guard let json = try bundle.getAnimationData(name, subdirectory: subdirectory) else {
-        return nil
-      }
+      let json = try bundle.getAnimationData(name, subdirectory: subdirectory)
       let animation = try LottieAnimation.from(data: json)
       animationCache?.setAnimation(animation, forKey: cacheKey)
       return animation
@@ -97,7 +95,10 @@ extension LottieAnimation {
       animationCache?.setAnimation(animation, forKey: filepath)
       return animation
     } catch {
-      /// Decoding Error.
+        LottieLogger.shared.assertionFailure("""
+          Failed to load animation from filepath \(filepath)
+          with underlying error: \(error.localizedDescription)
+          """)
       return nil
     }
   }
@@ -125,18 +126,19 @@ extension LottieAnimation {
       return animation
     }
 
-    /// Load jsonData from Asset
-    guard let json = Data.jsonData(from: name, in: bundle) else {
-      return nil
-    }
-
     do {
+      /// Load jsonData from Asset
+      let json = try Data(assetName: name, in: bundle)
       /// Decode animation.
       let animation = try LottieAnimation.from(data: json)
       animationCache?.setAnimation(animation, forKey: cacheKey)
       return animation
     } catch {
-      /// Decoding error.
+      LottieLogger.shared.assertionFailure("""
+        Failed to load animation with asset name \(name)
+        in \(bundle.bundlePath)
+        with underlying error: \(error.localizedDescription)
+        """)
       return nil
     }
   }

--- a/Sources/Public/DotLottie/DotLottieFile.swift
+++ b/Sources/Public/DotLottie/DotLottieFile.swift
@@ -39,42 +39,17 @@ public final class DotLottieFile {
   /// Image provider for animations
   private(set) var imageProvider: AnimationImageProvider?
 
-  /// Manifest.json file loading
-  lazy var manifest: DotLottieManifest? = {
-    let path = fileUrl.appendingPathComponent(DotLottieFile.manifestFileName)
-    do {
-        return try DotLottieManifest.load(from: path)
-    } catch {
-      LottieLogger.shared.assertionFailure("""
-        Failed to load manifest at \(path)
-        with underlying error: \(error.localizedDescription)
-        """)
-      return nil
-    }
-  }()
-
-  /// Animation url for main animation
-  lazy var animationUrl: URL? = {
-    guard let animationId = manifest?.animations.first?.id else { return nil }
-    let dotLottieJson = "\(DotLottieFile.animationsFolderName)/\(animationId).json"
-    return fileUrl.appendingPathComponent(dotLottieJson)
-  }()
-
   /// Animations folder url
   lazy var animationsUrl: URL = fileUrl.appendingPathComponent("\(DotLottieFile.animationsFolderName)")
 
   /// All files in animations folder
-  lazy var animationUrls: [URL] = {
-    FileManager.default.urls(for: animationsUrl) ?? []
-  }()
+  lazy var animationUrls: [URL] = FileManager.default.urls(for: animationsUrl) ?? []
 
   /// Images folder url
   lazy var imagesUrl: URL = fileUrl.appendingPathComponent("\(DotLottieFile.imagesFolderName)")
 
   /// All images in images folder
-  lazy var imageUrls: [URL] = {
-    FileManager.default.urls(for: imagesUrl) ?? []
-  }()
+  lazy var imageUrls: [URL] = FileManager.default.urls(for: imagesUrl) ?? []
 
   /// The `LottieAnimation` and `DotLottieConfiguration` for the given animation ID in this file
   func animation(for id: String? = nil) -> DotLottieFile.Animation? {

--- a/Sources/Public/DotLottie/DotLottieFile.swift
+++ b/Sources/Public/DotLottie/DotLottieFile.swift
@@ -123,7 +123,7 @@ public final class DotLottieFile {
   private func loadContent() throws {
     imageProvider = DotLottieImageProvider(filepath: imagesUrl)
 
-    animations = try manifest?.animations.map { dotLottieAnimation in
+    animations = try loadManifest().animations.map { dotLottieAnimation in
       let animation = try dotLottieAnimation.animation(url: animationsUrl)
       let configuration = DotLottieConfiguration(
         id: dotLottieAnimation.id,
@@ -134,7 +134,12 @@ public final class DotLottieFile {
       return DotLottieFile.Animation(
         animation: animation,
         configuration: configuration)
-    } ?? []
+    }
+  }
+
+  private func loadManifest() throws -> DotLottieManifest {
+    let path = fileUrl.appendingPathComponent(DotLottieFile.manifestFileName)
+    return try DotLottieManifest.load(from: path)
   }
 }
 

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -238,7 +238,7 @@ extension DotLottieFile {
       let task = session.dataTask(with: url) { data, _, error in
         do {
           if let error = error {
-              throw error
+            throw error
           }
           guard let data = data else {
             throw DotLottieError.noDataLoaded

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -241,7 +241,7 @@ extension DotLottieFile {
               throw error
           }
           guard let data = data else {
-            throw DotLottieError.urlLoadingFailed
+            throw DotLottieError.noDataLoaded
           }
           let lottie = try DotLottieFile(data: data, filename: url.deletingPathExtension().lastPathComponent)
           DispatchQueue.main.async {

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -64,12 +64,7 @@ extension DotLottieFile {
 
       do {
         /// Decode animation.
-        guard let data = try bundle.dotLottieData(name, subdirectory: subdirectory) else {
-          DispatchQueue.main.async {
-            handleResult(.failure(DotLottieError.invalidData))
-          }
-          return
-        }
+        let data = try bundle.dotLottieData(name, subdirectory: subdirectory)
         let lottie = try DotLottieFile(data: data, filename: name)
         dotLottieCache?.setFile(lottie, forKey: cacheKey)
         DispatchQueue.main.async {
@@ -189,15 +184,10 @@ extension DotLottieFile {
         return
       }
 
-      /// Load data from Asset
-      guard let data = Data.jsonData(from: name, in: bundle) else {
-        DispatchQueue.main.async {
-          handleResult(.failure(DotLottieError.invalidData))
-        }
-        return
-      }
-
       do {
+        /// Load data from Asset
+        let data = try Data(assetName: name, in: bundle)
+
         /// Decode lottie.
         let lottie = try DotLottieFile(data: data, filename: name)
         dotLottieCache?.setFile(lottie, forKey: cacheKey)
@@ -246,13 +236,13 @@ extension DotLottieFile {
       handleResult(.success(lottie))
     } else {
       let task = session.dataTask(with: url) { data, _, error in
-        guard error == nil, let data = data else {
-          DispatchQueue.main.async {
-            handleResult(.failure(DotLottieError.invalidData))
-          }
-          return
-        }
         do {
+          if let error = error {
+              throw error
+          }
+          guard let data = data else {
+            throw DotLottieError.urlLoadingFailed
+          }
           let lottie = try DotLottieFile(data: data, filename: url.deletingPathExtension().lastPathComponent)
           DispatchQueue.main.async {
             dotLottieCache?.setFile(lottie, forKey: url.absoluteString)


### PR DESCRIPTION
Previously discussed in https://github.com/airbnb/lottie-ios/discussions/1957.

- Adds proper error propagation to dotLottie loading.
  - Handles manifest loading errors.
  - Handles animation loading errors.
- Adds `LottieLogger` warnings to methods loading from dotLottie.
- Removes unnecessary `animationUrl` property from DotLottieAnimation.
- Unifies asset loading mechanism for dotLottie and standard .json files.

Propagating errors has actually made the error handling shorter and easier to debug.