### PR TITLE
Add back public error values that were removed in #1969

### DIFF
--- a/Sources/Private/Model/DotLottie/DotLottieUtils.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieUtils.swift
@@ -58,4 +58,11 @@ public enum DotLottieError: Error {
   case assetNotFound(name: String, bundle: Bundle?)
   /// Animation loading from asset is not supported on macOS 10.10.
   case loadingFromAssetNotSupported
+
+  @available(*, deprecated, message: "Unused")
+  case invalidFileFormat
+  @available(*, deprecated, message: "Unused")
+  case invalidData
+  @available(*, deprecated, message: "Unused")
+  case animationNotAvailable
 }


### PR DESCRIPTION
#1969 removed some cases from the public `DotLottieError` type, which is potentially breaking change for consumers. This PR adds back those previous cases, but with deprecation warnings indicating that they are no longer used.