### PR TITLE
Fix issue where completion handler could be called unexpectedly when setting up animation

### DIFF
--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -1216,6 +1216,12 @@ open class LottieAnimationView: LottieAnimationViewBase {
     let animationContext = animationContext
     let currentFrame = currentFrame
 
+    // Disable the completion handler delegate before tearing down the `CoreAnimationLayer`
+    // and building the `MainThreadAnimationLayer`. Otherwise deinitializing the
+    // `CoreAnimationLayer` would trigger the animation completion handler even though
+    // the animation hasn't even started playing yet.
+    animationContext?.closure.ignoreDelegate = true
+
     makeAnimationLayer(usingEngine: .mainThread)
 
     // Set up the Main Thread animation layer using the same configuration that

--- a/Tests/AnimationViewTests.swift
+++ b/Tests/AnimationViewTests.swift
@@ -7,6 +7,14 @@ import XCTest
 @MainActor
 final class AnimationViewTests: XCTestCase {
 
+  override func setUp() async throws {
+    LottieLogger.shared = .printToConsole
+  }
+
+  override func tearDown() {
+    LottieLogger.shared = LottieLogger()
+  }
+
   func testLoadJsonFile() {
     let animationView = LottieAnimationView(
       name: "LottieLogo1",
@@ -74,67 +82,87 @@ final class AnimationViewTests: XCTestCase {
       ("automatic", .automatic),
     ]
 
-    let animation = LottieAnimation.named(
+    let animationSupportedByCoreAnimationRenderingEngine = LottieAnimation.named(
       "Issues/issue_1877",
       bundle: .lottie,
       subdirectory: Samples.directoryName)
 
-    XCTAssertNotNil(animation)
+    let animationUnsupportedByCoreAnimationRenderingEngine = LottieAnimation.named(
+      "TypeFace/G",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName)
 
-    let window = UIWindow()
+    let animations = [
+      animationSupportedByCoreAnimationRenderingEngine,
+      animationUnsupportedByCoreAnimationRenderingEngine,
+    ]
 
-    for (test, values) in tests.enumerated() {
-      for engine in engineOptions {
-        let animationView = LottieAnimationView(
-          animation: animation,
-          configuration: .init(renderingEngine: engine.engine))
+    for animation in animations {
+      XCTAssertNotNil(animation)
+      let window = UIWindow()
 
-        window.addSubview(animationView)
-        defer {
-          animationView.removeFromSuperview()
+      for (test, values) in tests.enumerated() {
+        for engine in engineOptions {
+          let animationView = LottieAnimationView(
+            animation: animation,
+            configuration: .init(renderingEngine: engine.engine))
+
+          window.addSubview(animationView)
+          defer {
+            animationView.removeFromSuperview()
+          }
+
+          let animationPlayingExpectation = XCTestExpectation(
+            description: "Animation playing case \(test) on engine: \(engine.label)")
+
+          let animationCompleteExpectation = XCTestExpectation(
+            description: "Finished playing case \(test) on engine: \(engine.label)")
+
+          animationView.play(fromFrame: values.fromFrame, toFrame: values.toFrame, loopMode: .playOnce) { finished in
+            XCTAssertTrue(
+              finished,
+              "Failed case \(test) on engine: \(engine.label)")
+
+            XCTAssertEqual(
+              animationView.currentFrame,
+              values.toFrame,
+              accuracy: 0.01,
+              "Failed case \(test) on engine: \(engine.label)")
+
+            XCTAssertFalse(
+              animationView.isAnimationPlaying,
+              "Failed case \(test) on engine: \(engine.label)")
+
+            animationCompleteExpectation.fulfill()
+          }
+
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            animationPlayingExpectation.fulfill()
+
+            // Verify that we're testing at least one case where .automatic falls back to the main thread engine
+            if engine.engine == .automatic {
+              if animation === animationUnsupportedByCoreAnimationRenderingEngine {
+                XCTAssertEqual(animationView.currentRenderingEngine, .mainThread)
+              } else {
+                XCTAssertEqual(animationView.currentRenderingEngine, .coreAnimation)
+              }
+            }
+
+            XCTAssertTrue(
+              animationView.isAnimationPlaying,
+              "Failed case \(test) on engine: \(engine.label)")
+
+            // Check that the animation is playing in the correct direction:
+            // After a brief delay we should be closer to the from frame than the to frame
+            let distanceFromStartFrame = abs((values.fromFrame ?? 0) - animationView.realtimeAnimationFrame)
+            let distanceFromEndFrame = abs(values.toFrame - animationView.realtimeAnimationFrame)
+            XCTAssertTrue(
+              distanceFromStartFrame < distanceFromEndFrame,
+              "Failed case \(test) on engine: \(engine.label)")
+          }
+
+          wait(for: [animationPlayingExpectation, animationCompleteExpectation], timeout: 1.0)
         }
-
-        let animationPlayingExpectation = XCTestExpectation(
-          description: "Animation playing case \(test) on engine: \(engine.label)")
-
-        let animationCompleteExpectation = XCTestExpectation(
-          description: "Finished playing case \(test) on engine: \(engine.label)")
-
-        animationView.play(fromFrame: values.fromFrame, toFrame: values.toFrame, loopMode: .playOnce) { finished in
-          XCTAssertTrue(
-            finished,
-            "Failed case \(test) on engine: \(engine.label)")
-
-          XCTAssertEqual(
-            animationView.currentFrame,
-            values.toFrame,
-            accuracy: 0.01,
-            "Failed case \(test) on engine: \(engine.label)")
-
-          XCTAssertFalse(
-            animationView.isAnimationPlaying,
-            "Failed case \(test) on engine: \(engine.label)")
-
-          animationCompleteExpectation.fulfill()
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-          animationPlayingExpectation.fulfill()
-
-          XCTAssertTrue(
-            animationView.isAnimationPlaying,
-            "Failed case \(test) on engine: \(engine.label)")
-
-          // Check that the animation is playing in the correct direction:
-          // After a brief delay we should be closer to the from frame than the to frame
-          let distanceFromStartFrame = abs((values.fromFrame ?? 0) - animationView.realtimeAnimationFrame)
-          let distanceFromEndFrame = abs(values.toFrame - animationView.realtimeAnimationFrame)
-          XCTAssertTrue(
-            distanceFromStartFrame < distanceFromEndFrame,
-            "Failed case \(test) on engine: \(engine.label)")
-        }
-
-        wait(for: [animationPlayingExpectation, animationCompleteExpectation], timeout: 1.0)
       }
     }
   }


### PR DESCRIPTION
This PR fixes an issue where `LottieAnimationView`'s animation completion handlers could be called unexpectedly when setting up an animation. Fixes #1984.

Specifically, this would happen when using `RenderingEngineOption.automatic` with an animation not supported by the Core Animation rendering engine. We would initialize the Core Animation animation layer, detect it was unsupported, deinitialize the Core Animation layer, and then initialize the Main Thread animation layer. Previously, when this flow deinitialized the Core Animation animation layer it also unexpectedly triggered the animation completion handler.