### PR TITLE
Log a warning when playing animation that uses unsupported After Effects expressions

### DIFF
--- a/Sources/Private/CoreAnimation/Animations/CALayer+addAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CALayer+addAnimation.swift
@@ -49,14 +49,15 @@ extension CALayer {
     let keyframes = keyframeGroup.keyframes
     guard !keyframes.isEmpty else { return nil }
 
-    // Check if this set of keyframes uses javascript expressions, which aren't supported.
-    if let unsupportedJavascriptExpression = keyframeGroup.unsupportedJavascriptExpression {
+    // Check if this set of keyframes uses After Effects expressions, which aren't supported.
+    if let unsupportedAfterEffectsExpression = keyframeGroup.unsupportedAfterEffectsExpression {
       context.logger.info("""
         `\(property.caLayerKeypath)` animation for "\(context.currentKeypath.fullPath)" \
-        includes a javascript expression, which is not supported by lottie-ios \
-        (expressions are only supported by lottie-web). This animation may not play correctly.
+        includes an After Effects expression (https://helpx.adobe.com/after-effects/using/expression-language.html), \
+        which is not supported by lottie-ios (expressions are only supported by lottie-web). \
+        This animation may not play correctly.
 
-          \(unsupportedJavascriptExpression.replacingOccurrences(of: "\n", with: "\n  "))
+          \(unsupportedAfterEffectsExpression.replacingOccurrences(of: "\n", with: "\n  "))
 
         """)
     }

--- a/Sources/Private/CoreAnimation/Animations/CALayer+addAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CALayer+addAnimation.swift
@@ -12,7 +12,7 @@ extension CALayer {
   @nonobjc
   func addAnimation<KeyframeValue, ValueRepresentation>(
     for property: LayerProperty<ValueRepresentation>,
-    keyframes: ContiguousArray<Keyframe<KeyframeValue>>,
+    keyframes: KeyframeGroup<KeyframeValue>,
     value keyframeValueMapping: (KeyframeValue) throws -> ValueRepresentation,
     context: LayerAnimationContext)
     throws
@@ -41,12 +41,25 @@ extension CALayer {
   @nonobjc
   private func defaultAnimation<KeyframeValue, ValueRepresentation>(
     for property: LayerProperty<ValueRepresentation>,
-    keyframes: ContiguousArray<Keyframe<KeyframeValue>>,
+    keyframes keyframeGroup: KeyframeGroup<KeyframeValue>,
     value keyframeValueMapping: (KeyframeValue) throws -> ValueRepresentation,
     context: LayerAnimationContext)
     throws -> CAAnimation?
   {
+    let keyframes = keyframeGroup.keyframes
     guard !keyframes.isEmpty else { return nil }
+
+    // Check if this set of keyframes uses javascript expressions, which aren't supported.
+    if let unsupportedJavascriptExpression = keyframeGroup.unsupportedJavascriptExpression {
+      context.logger.info("""
+        `\(property.caLayerKeypath)` animation for "\(context.currentKeypath.fullPath)" \
+        includes a javascript expression, which is not supported by lottie-ios \
+        (expressions are only supported by lottie-web). This animation may not play correctly.
+
+          \(unsupportedJavascriptExpression.replacingOccurrences(of: "\n", with: "\n  "))
+
+        """)
+    }
 
     // If there is exactly one keyframe value, we can improve performance
     // by applying that value directly to the layer instead of creating

--- a/Sources/Private/CoreAnimation/Animations/CombinedShapeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CombinedShapeAnimation.swift
@@ -14,7 +14,7 @@ extension CAShapeLayer {
   {
     try addAnimation(
       for: .path,
-      keyframes: combinedShapes.shapes.keyframes,
+      keyframes: combinedShapes.shapes,
       value: { paths in
         let combinedPath = CGMutablePath()
         for path in paths {

--- a/Sources/Private/CoreAnimation/Animations/CustomPathAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CustomPathAnimation.swift
@@ -20,7 +20,7 @@ extension CAShapeLayer {
 
     try addAnimation(
       for: .path,
-      keyframes: combinedKeyframes.keyframes,
+      keyframes: combinedKeyframes,
       value: { pathKeyframe in
         var path = pathKeyframe.path
         if let cornerRadius = pathKeyframe.cornerRadius {

--- a/Sources/Private/CoreAnimation/Animations/EllipseAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/EllipseAnimation.swift
@@ -14,7 +14,7 @@ extension CAShapeLayer {
   {
     try addAnimation(
       for: .path,
-      keyframes: ellipse.combinedKeyframes().keyframes,
+      keyframes: ellipse.combinedKeyframes(),
       value: { keyframe in
         BezierPath.ellipse(
           size: keyframe.size.sizeValue,

--- a/Sources/Private/CoreAnimation/Animations/GradientAnimations.swift
+++ b/Sources/Private/CoreAnimation/Animations/GradientAnimations.swift
@@ -57,7 +57,7 @@ extension GradientRenderLayer {
 
     try addAnimation(
       for: .colors,
-      keyframes: gradient.colors.keyframes,
+      keyframes: gradient.colors,
       value: { colorComponents in
         gradient.colorConfiguration(from: colorComponents, type: type).map { $0.color }
       },
@@ -65,7 +65,7 @@ extension GradientRenderLayer {
 
     try addAnimation(
       for: .locations,
-      keyframes: gradient.colors.keyframes,
+      keyframes: gradient.colors,
       value: { colorComponents in
         gradient.colorConfiguration(from: colorComponents, type: type).map { $0.location }
       },
@@ -94,7 +94,7 @@ extension GradientRenderLayer {
 
     try addAnimation(
       for: .startPoint,
-      keyframes: gradient.startPoint.keyframes,
+      keyframes: gradient.startPoint,
       value: { absoluteStartPoint in
         percentBasedPointInBounds(from: absoluteStartPoint.pointValue)
       },
@@ -102,7 +102,7 @@ extension GradientRenderLayer {
 
     try addAnimation(
       for: .endPoint,
-      keyframes: gradient.endPoint.keyframes,
+      keyframes: gradient.endPoint,
       value: { absoluteEndPoint in
         percentBasedPointInBounds(from: absoluteEndPoint.pointValue)
       },
@@ -128,13 +128,13 @@ extension GradientRenderLayer {
 
     try addAnimation(
       for: .startPoint,
-      keyframes: combinedKeyframes.keyframes,
+      keyframes: combinedKeyframes,
       value: \.startPoint,
       context: context)
 
     try addAnimation(
       for: .endPoint,
-      keyframes: combinedKeyframes.keyframes,
+      keyframes: combinedKeyframes,
       value: \.endPoint,
       context: context)
   }

--- a/Sources/Private/CoreAnimation/Animations/OpacityAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/OpacityAnimation.swift
@@ -40,7 +40,7 @@ extension CALayer {
   func addOpacityAnimation(for opacity: OpacityAnimationModel, context: LayerAnimationContext) throws {
     try addAnimation(
       for: .opacity,
-      keyframes: opacity.opacity.keyframes,
+      keyframes: opacity.opacity,
       value: {
         // Lottie animation files express opacity as a numerical percentage value
         // (e.g. 0%, 50%, 100%) so we divide by 100 to get the decimal values

--- a/Sources/Private/CoreAnimation/Animations/RectangleAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/RectangleAnimation.swift
@@ -15,7 +15,7 @@ extension CAShapeLayer {
   {
     try addAnimation(
       for: .path,
-      keyframes: try rectangle.combinedKeyframes(roundedCorners: roundedCorners).keyframes,
+      keyframes: try rectangle.combinedKeyframes(roundedCorners: roundedCorners),
       value: { keyframe in
         BezierPath.rectangle(
           position: keyframe.position.pointValue,

--- a/Sources/Private/CoreAnimation/Animations/ShapeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/ShapeAnimation.swift
@@ -57,7 +57,7 @@ extension CAShapeLayer {
 
     try addAnimation(
       for: .fillColor,
-      keyframes: fill.color.keyframes,
+      keyframes: fill.color,
       value: \.cgColorValue,
       context: context)
 
@@ -71,7 +71,7 @@ extension CAShapeLayer {
 
     try addAnimation(
       for: .strokeStart,
-      keyframes: strokeStartKeyframes.keyframes,
+      keyframes: strokeStartKeyframes,
       value: { strokeStart in
         // Lottie animation files express stoke trims as a numerical percentage value
         // (e.g. 25%, 50%, 100%) so we divide by 100 to get the decimal values
@@ -81,7 +81,7 @@ extension CAShapeLayer {
 
     try addAnimation(
       for: .strokeEnd,
-      keyframes: strokeEndKeyframes.keyframes,
+      keyframes: strokeEndKeyframes,
       value: { strokeEnd in
         // Lottie animation files express stoke trims as a numerical percentage value
         // (e.g. 25%, 50%, 100%) so we divide by 100 to get the decimal values

--- a/Sources/Private/CoreAnimation/Animations/StarAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/StarAnimation.swift
@@ -36,7 +36,7 @@ extension CAShapeLayer {
   {
     try addAnimation(
       for: .path,
-      keyframes: try star.combinedKeyframes().keyframes,
+      keyframes: try star.combinedKeyframes(),
       value: { keyframe in
         BezierPath.star(
           position: keyframe.position.pointValue,
@@ -62,7 +62,7 @@ extension CAShapeLayer {
   {
     try addAnimation(
       for: .path,
-      keyframes: try star.combinedKeyframes().keyframes,
+      keyframes: try star.combinedKeyframes(),
       value: { keyframe in
         BezierPath.polygon(
           position: keyframe.position.pointValue,

--- a/Sources/Private/CoreAnimation/Animations/StrokeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/StrokeAnimation.swift
@@ -54,14 +54,14 @@ extension CAShapeLayer {
     if let strokeColor = stroke.strokeColor {
       try addAnimation(
         for: .strokeColor,
-        keyframes: strokeColor.keyframes,
+        keyframes: strokeColor,
         value: \.cgColorValue,
         context: context)
     }
 
     try addAnimation(
       for: .lineWidth,
-      keyframes: stroke.width.keyframes,
+      keyframes: stroke.width,
       value: \.cgFloatValue,
       context: context)
 
@@ -79,7 +79,7 @@ extension CAShapeLayer {
 
       try addAnimation(
         for: .lineDashPhase,
-        keyframes: dashPhase,
+        keyframes: KeyframeGroup(keyframes: dashPhase),
         value: \.cgFloatValue,
         context: context)
     }

--- a/Sources/Private/CoreAnimation/Animations/TransformAnimations.swift
+++ b/Sources/Private/CoreAnimation/Animations/TransformAnimations.swift
@@ -93,15 +93,15 @@ extension CALayer {
     context: LayerAnimationContext)
     throws
   {
-    if let positionKeyframes = transformModel._position?.keyframes {
+    if let positionKeyframes = transformModel._position {
       try addAnimation(
         for: .position,
         keyframes: positionKeyframes,
         value: \.pointValue,
         context: context)
     } else if
-      let xKeyframes = transformModel._positionX?.keyframes,
-      let yKeyframes = transformModel._positionY?.keyframes
+      let xKeyframes = transformModel._positionX,
+      let yKeyframes = transformModel._positionY
     {
       try addAnimation(
         for: .positionX,
@@ -129,7 +129,7 @@ extension CALayer {
   {
     try addAnimation(
       for: .anchorPoint,
-      keyframes: transformModel.anchorPoint.keyframes,
+      keyframes: transformModel.anchorPoint,
       value: { absoluteAnchorPoint in
         guard bounds.width > 0, bounds.height > 0 else {
           context.logger.assertionFailure("Size must be non-zero before an animation can be played")
@@ -154,7 +154,7 @@ extension CALayer {
   {
     try addAnimation(
       for: .scaleX,
-      keyframes: transformModel.scale.keyframes,
+      keyframes: transformModel.scale,
       value: { scale in
         // Lottie animation files express scale as a numerical percentage value
         // (e.g. 50%, 100%, 200%) so we divide by 100 to get the decimal values
@@ -207,7 +207,7 @@ extension CALayer {
 
       try addAnimation(
         for: .rotationY,
-        keyframes: transformModel.scale.keyframes,
+        keyframes: transformModel.scale,
         value: { scale in
           if scale.x < 0 {
             return .pi
@@ -220,7 +220,7 @@ extension CALayer {
 
     try addAnimation(
       for: .scaleY,
-      keyframes: transformModel.scale.keyframes,
+      keyframes: transformModel.scale,
       value: { scale in
         // Lottie animation files express scale as a numerical percentage value
         // (e.g. 50%, 100%, 200%) so we divide by 100 to get the decimal values
@@ -263,7 +263,7 @@ extension CALayer {
 
     try addAnimation(
       for: .rotationX,
-      keyframes: transformModel.rotationX.keyframes,
+      keyframes: transformModel.rotationX,
       value: { rotationDegrees in
         rotationDegrees.cgFloatValue * .pi / 180
       },
@@ -271,7 +271,7 @@ extension CALayer {
 
     try addAnimation(
       for: .rotationY,
-      keyframes: transformModel.rotationY.keyframes,
+      keyframes: transformModel.rotationY,
       value: { rotationDegrees in
         rotationDegrees.cgFloatValue * .pi / 180
       },
@@ -279,7 +279,7 @@ extension CALayer {
 
     try addAnimation(
       for: .rotationZ,
-      keyframes: transformModel.rotationZ.keyframes,
+      keyframes: transformModel.rotationZ,
       value: { rotationDegrees in
         // Lottie animation files express rotation in degrees
         // (e.g. 90º, 180º, 360º) so we covert to radians to get the
@@ -321,7 +321,7 @@ extension CALayer {
 
     try addAnimation(
       for: .transform,
-      keyframes: combinedTransformKeyframes.keyframes,
+      keyframes: combinedTransformKeyframes,
       value: { $0 },
       context: context)
   }

--- a/Sources/Private/Model/Keyframes/KeyframeGroup.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeGroup.swift
@@ -21,32 +21,32 @@ final class KeyframeGroup<T> {
 
   init(
     keyframes: ContiguousArray<Keyframe<T>>,
-    unsupportedJavascriptExpression: String? = nil)
+    unsupportedAfterEffectsExpression: String? = nil)
   {
     self.keyframes = keyframes
-    self.unsupportedJavascriptExpression = unsupportedJavascriptExpression
+    self.unsupportedAfterEffectsExpression = unsupportedAfterEffectsExpression
   }
 
   init(
     _ value: T,
-    unsupportedJavascriptExpression: String? = nil)
+    unsupportedAfterEffectsExpression: String? = nil)
   {
     keyframes = [Keyframe(value)]
-    self.unsupportedJavascriptExpression = unsupportedJavascriptExpression
+    self.unsupportedAfterEffectsExpression = unsupportedAfterEffectsExpression
   }
 
   // MARK: Internal
 
   enum KeyframeWrapperKey: String, CodingKey {
     case keyframeData = "k"
-    case unsupportedJavascriptExpression = "x"
+    case unsupportedAfterEffectsExpression = "x"
   }
 
   let keyframes: ContiguousArray<Keyframe<T>>
 
-  /// lottie-ios doesn't support javascript expressions,
-  /// but we parse them so we can log diagnostics.
-  let unsupportedJavascriptExpression: String?
+  /// lottie-ios doesn't support After Effects expressions, but we parse them so we can log diagnostics.
+  /// More info: https://helpx.adobe.com/after-effects/using/expression-basics.html
+  let unsupportedAfterEffectsExpression: String?
 
 }
 
@@ -55,13 +55,13 @@ final class KeyframeGroup<T> {
 extension KeyframeGroup: Decodable where T: Decodable {
   convenience init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: KeyframeWrapperKey.self)
-    let unsupportedJavascriptExpression = try? container.decode(String.self, forKey: .unsupportedJavascriptExpression)
+    let unsupportedAfterEffectsExpression = try? container.decode(String.self, forKey: .unsupportedAfterEffectsExpression)
 
     if let keyframeData: T = try? container.decode(T.self, forKey: .keyframeData) {
       /// Try to decode raw value; No keyframe data.
       self.init(
         keyframes: [Keyframe<T>(keyframeData)],
-        unsupportedJavascriptExpression: unsupportedJavascriptExpression)
+        unsupportedAfterEffectsExpression: unsupportedAfterEffectsExpression)
     } else {
       // Decode and array of keyframes.
       //
@@ -107,7 +107,7 @@ extension KeyframeGroup: Decodable where T: Decodable {
       }
       self.init(
         keyframes: keyframes,
-        unsupportedJavascriptExpression: unsupportedJavascriptExpression)
+        unsupportedAfterEffectsExpression: unsupportedAfterEffectsExpression)
     }
   }
 }
@@ -147,7 +147,7 @@ extension KeyframeGroup: Encodable where T: Encodable {
 extension KeyframeGroup: DictionaryInitializable where T: AnyInitializable {
   convenience init(dictionary: [String: Any]) throws {
     var keyframes = ContiguousArray<Keyframe<T>>()
-    let unsupportedJavascriptExpression = dictionary[KeyframeWrapperKey.unsupportedJavascriptExpression.rawValue] as? String
+    let unsupportedAfterEffectsExpression = dictionary[KeyframeWrapperKey.unsupportedAfterEffectsExpression.rawValue] as? String
     if
       let rawValue = dictionary[KeyframeWrapperKey.keyframeData.rawValue],
       let value = try? T(value: rawValue)
@@ -183,7 +183,7 @@ extension KeyframeGroup: DictionaryInitializable where T: AnyInitializable {
 
     self.init(
       keyframes: keyframes,
-      unsupportedJavascriptExpression: unsupportedJavascriptExpression)
+      unsupportedAfterEffectsExpression: unsupportedAfterEffectsExpression)
   }
 }
 
@@ -224,7 +224,7 @@ extension KeyframeGroup {
       keyframes: ContiguousArray(try keyframes.map { keyframe in
         keyframe.withValue(try transformation(keyframe.value))
       }),
-      unsupportedJavascriptExpression: unsupportedJavascriptExpression)
+      unsupportedAfterEffectsExpression: unsupportedAfterEffectsExpression)
   }
 }
 


### PR DESCRIPTION
lottie-ios doesn't support [After Effects expressions](https://helpx.adobe.com/after-effects/using/expression-language.html) (only supported by lottie-web). This is a common point of confusion, since it can cause animations to render incorrectly / unexpectedly on iOS. 

This PR adds a new warning that's logged when attempting to play an animation that uses a javascript expression.

For example:

```
`transform.scale.y` animation for "sparkle Konturen.Gruppe 7.Transformieren" includes an 
After Effects expression (https://helpx.adobe.com/after-effects/using/expression-language.html),
which is not supported by lottie-ios (expressions are only supported by lottie-web).
This animation may not play correctly.

  var $bm_rt;
  $bm_rt = loopOut('pingpong');

```