### PR TITLE
Update minimum macOS version to 10.11, fix build

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -2836,7 +2836,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
@@ -2866,7 +2866,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,8 @@ import PackageDescription
 
 let package = Package(
   name: "Lottie",
-  platforms: [.iOS("11.0"), .macOS("10.10"), .tvOS("11.0")],
+  // Minimum platform versions should be kept in sync with the per-platform targets in Lottie.xcodeproj
+  platforms: [.iOS("11.0"), .macOS("10.11"), .tvOS("11.0")],
   products: [.library(name: "Lottie", targets: ["Lottie"])],
   targets: [.target(name: "Lottie", path: "Sources")])
 

--- a/Sources/Private/Model/DotLottie/DotLottieUtils.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieUtils.swift
@@ -15,7 +15,7 @@ struct DotLottieUtils {
 
   /// Temp folder to app directory
   static var tempDirectoryURL: URL {
-    if #available(iOS 10.0, *) {
+    if #available(iOS 10.0, macOS 10.12, *) {
       return FileManager.default.temporaryDirectory
     }
     return URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
#1995 pointed out that Lottie was failing to build when targeting a minimum macOS version of 10.10 or 10.11. We were referencing symbols that are only available in 10.11 / 10.12. CI didn't catch this because the minimum macOS version in `Lottie.xcodeproj` (which is how we run the tests in CI) was incorrectly 10.13.

ZipFoundation requires 10.11, so I had to bump the minimum macOS version from 10.10 to 10.11. 

This PR also:
 - fixes CI so it actually verifies we support 10.11 and 10.12
 - fixes a build issue when targeting 10.11

Fixes #1995.