### PR TITLE
Fix issue where calling `setValueProvider` would reset animation progress

### DIFF
--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -72,7 +72,10 @@ final class CoreAnimationLayer: BaseAnimationLayer {
   }
 
   enum PlaybackState: Equatable {
-    /// The animation is playing in real-time
+    /// The animation is has started playing, and may still be playing.
+    ///  - When animating with a finite duration (e.g. `playOnce`), playback
+    ///    state will still be `playing` when the animation completes.
+    ///    To check if the animation is currently playing, prefer `isAnimationPlaying`.
     case playing
     /// The animation is statically displaying a specific frame
     case paused(frame: AnimationFrameTime)
@@ -90,6 +93,9 @@ final class CoreAnimationLayer: BaseAnimationLayer {
         && ((lhs.recordHierarchyKeypath == nil) == (rhs.recordHierarchyKeypath == nil))
     }
   }
+
+  /// The parent `LottieAnimationView` that manages this layer
+  weak var animationView: LottieAnimationView?
 
   /// A closure that is called after this layer sets up its animation.
   /// If the animation setup was unsuccessful and encountered compatibility issues,
@@ -155,7 +161,9 @@ final class CoreAnimationLayer: BaseAnimationLayer {
     //    allocate a very large amount of memory (400mb+).
     //  - Alternatively this layer could subclass `CATransformLayer`,
     //    but this causes Core Animation to emit unnecessary logs.
-    if let pendingAnimationConfiguration = pendingAnimationConfiguration {
+    if var pendingAnimationConfiguration = pendingAnimationConfiguration {
+      pendingAnimationConfigurationModification?(&pendingAnimationConfiguration.animationConfiguration)
+      pendingAnimationConfigurationModification = nil
       self.pendingAnimationConfiguration = nil
 
       do {
@@ -186,6 +194,9 @@ final class CoreAnimationLayer: BaseAnimationLayer {
   private var pendingAnimationConfiguration: (
     animationConfiguration: AnimationConfiguration,
     playbackState: PlaybackState)?
+
+  /// A modification that should be applied to the next animation configuration
+  private var pendingAnimationConfigurationModification: ((inout AnimationConfiguration) -> Void)?
 
   /// Configuration for the animation that is currently setup in this layer
   private var currentAnimationConfiguration: AnimationConfiguration?
@@ -296,32 +307,20 @@ final class CoreAnimationLayer: BaseAnimationLayer {
 
   // Removes the current `CAAnimation`s, and rebuilds new animations
   // using the same configuration as the previous animations.
-  private func rebuildCurrentAnimation(with newConfiguration: AnimationConfiguration? = nil) {
+  private func rebuildCurrentAnimation() {
     guard
-      let currentConfiguration = currentAnimationConfiguration,
-      let playbackState = playbackState,
       // Don't replace any pending animations that are queued to begin
       // on the next run loop cycle, since an existing pending animation
       // will cause the animation to be rebuilt anyway.
       pendingAnimationConfiguration == nil
-    else {
-      // If we already have a pending animation setup pass, but a new configuration was provided,
-      // replace the pending configuration with the new configuration
-      if let newConfiguration = newConfiguration {
-        pendingAnimationConfiguration?.animationConfiguration = newConfiguration
-      }
+    else { return }
 
-      return
-    }
-
-    removeAnimations()
-
-    switch playbackState {
-    case .paused(let frame):
-      currentFrame = frame
-
-    case .playing:
-      playAnimation(configuration: newConfiguration ?? currentConfiguration)
+    if isAnimationPlaying == true {
+      animationView?.updateInFlightAnimation()
+    } else {
+      let currentFrame = self.currentFrame
+      removeAnimations()
+      self.currentFrame = currentFrame
     }
   }
 
@@ -335,6 +334,9 @@ extension CoreAnimationLayer: RootAnimationLayer {
     .specific(#keyPath(animationProgress))
   }
 
+  /// Whether or not the animation is currently playing.
+  ///  - Handles case where CAAnimations with a finite duration animation (e.g. `playOnce`)
+  ///    have finished playing but still present on this layer.
   var isAnimationPlaying: Bool? {
     switch pendingAnimationConfiguration?.playbackState {
     case .playing:
@@ -351,6 +353,8 @@ extension CoreAnimationLayer: RootAnimationLayer {
     }
   }
 
+  /// The current frame of the animation being displayed,
+  /// accounting for the realtime progress of any active CAAnimations.
   var currentFrame: AnimationFrameTime {
     get {
       switch playbackState {
@@ -455,7 +459,7 @@ extension CoreAnimationLayer: RootAnimationLayer {
   }
 
   func allHierarchyKeypaths() -> [String] {
-    guard var configuration = pendingAnimationConfiguration?.animationConfiguration ?? currentAnimationConfiguration else {
+    guard pendingAnimationConfiguration?.animationConfiguration ?? currentAnimationConfiguration != nil else {
       logger.info("Cannot log hierarchy keypaths until animation has been set up at least once")
       return []
     }
@@ -463,11 +467,13 @@ extension CoreAnimationLayer: RootAnimationLayer {
     logger.info("Lottie: Rebuilding animation with hierarchy keypath logging enabled")
 
     var allAnimationKeypaths = [String]()
-    configuration.recordHierarchyKeypath = { keypath in
-      allAnimationKeypaths.append(keypath)
+    pendingAnimationConfigurationModification = { configuration in
+      configuration.recordHierarchyKeypath = { keypath in
+        allAnimationKeypaths.append(keypath)
+      }
     }
 
-    rebuildCurrentAnimation(with: configuration)
+    rebuildCurrentAnimation()
     displayIfNeeded()
 
     return allAnimationKeypaths

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -318,7 +318,7 @@ final class CoreAnimationLayer: BaseAnimationLayer {
     if isAnimationPlaying == true {
       animationView?.updateInFlightAnimation()
     } else {
-      let currentFrame = self.currentFrame
+      let currentFrame = currentFrame
       removeAnimations()
       self.currentFrame = currentFrame
     }

--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -147,6 +147,9 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
   /// The animatable Current Frame Property
   @NSManaged var currentFrame: CGFloat
 
+  /// The parent `LottieAnimationView` that manages this layer
+  weak var animationView: LottieAnimationView?
+
   var animationLayers: ContiguousArray<CompositionLayer>
 
   var primaryAnimationKey: AnimationKey {

--- a/Sources/Private/RootAnimationLayer.swift
+++ b/Sources/Private/RootAnimationLayer.swift
@@ -8,7 +8,7 @@ import QuartzCore
 /// A root `CALayer` responsible for playing a Lottie animation
 protocol RootAnimationLayer: CALayer {
   var animationView: LottieAnimationView? { get set }
-  
+
   var currentFrame: AnimationFrameTime { get set }
   var renderScale: CGFloat { get set }
   var respectAnimationFrameRate: Bool { get set }

--- a/Sources/Private/RootAnimationLayer.swift
+++ b/Sources/Private/RootAnimationLayer.swift
@@ -7,6 +7,8 @@ import QuartzCore
 
 /// A root `CALayer` responsible for playing a Lottie animation
 protocol RootAnimationLayer: CALayer {
+  var animationView: LottieAnimationView? { get set }
+  
   var currentFrame: AnimationFrameTime { get set }
   var renderScale: CGFloat { get set }
   var respectAnimationFrameRate: Bool { get set }

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -1076,6 +1076,33 @@ open class LottieAnimationView: LottieAnimationViewBase {
     }
   }
 
+  /// Updates an in flight animation.
+  func updateInFlightAnimation() {
+    guard let animationContext = animationContext else { return }
+
+    guard animationContext.closure.animationState != .complete else {
+      // Tried to re-add an already completed animation. Cancel.
+      self.animationContext = nil
+      return
+    }
+
+    /// Tell existing context to ignore its closure
+    animationContext.closure.ignoreDelegate = true
+
+    /// Make a new context, stealing the completion block from the previous.
+    let newContext = AnimationContext(
+      playFrom: animationContext.playFrom,
+      playTo: animationContext.playTo,
+      closure: animationContext.closure.completionBlock)
+
+    /// Remove current animation, and freeze the current frame.
+    let pauseFrame = realtimeAnimationFrame
+    animationLayer?.removeAnimation(forKey: activeAnimationName)
+    animationLayer?.currentFrame = pauseFrame
+
+    addNewAnimationForContext(newContext)
+  }
+
   // MARK: Fileprivate
 
   /// Context describing the animation that is currently playing in this `LottieAnimationView`
@@ -1320,33 +1347,6 @@ open class LottieAnimationView: LottieAnimationViewBase {
     animationLayer?.removeAnimation(forKey: activeAnimationName)
     updateAnimationFrame(pauseFrame)
     animationContext = nil
-  }
-
-  /// Updates an in flight animation.
-  func updateInFlightAnimation() {
-    guard let animationContext = animationContext else { return }
-
-    guard animationContext.closure.animationState != .complete else {
-      // Tried to re-add an already completed animation. Cancel.
-      self.animationContext = nil
-      return
-    }
-
-    /// Tell existing context to ignore its closure
-    animationContext.closure.ignoreDelegate = true
-
-    /// Make a new context, stealing the completion block from the previous.
-    let newContext = AnimationContext(
-      playFrom: animationContext.playFrom,
-      playTo: animationContext.playTo,
-      closure: animationContext.closure.completionBlock)
-
-    /// Remove current animation, and freeze the current frame.
-    let pauseFrame = realtimeAnimationFrame
-    animationLayer?.removeAnimation(forKey: activeAnimationName)
-    animationLayer?.currentFrame = pauseFrame
-
-    addNewAnimationForContext(newContext)
   }
 
   /// Adds animation to animation layer and sets the delegate. If animation layer or animation are nil, exits.

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -1126,6 +1126,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
       return
     }
 
+    animationLayer.animationView = self
     animationLayer.renderScale = screenScale
 
     viewLayer?.addSublayer(animationLayer)
@@ -1322,7 +1323,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   /// Updates an in flight animation.
-  fileprivate func updateInFlightAnimation() {
+  func updateInFlightAnimation() {
     guard let animationContext = animationContext else { return }
 
     guard animationContext.closure.animationState != .complete else {


### PR DESCRIPTION
This PR fixes an issue where calling `setValueProvider` would reset the animation progress, and in some cases trigger a paused animation to start animating again. Fixes #2003 


### `playOnce`, after animation has finished:

| Before | After |
| ---- | ---- |
| ![2023-04-27 11 05 14](https://user-images.githubusercontent.com/1811727/234961306-f4233111-17fc-4a30-aeef-aadc308b0c21.gif) | ![2023-04-27 11 04 45](https://user-images.githubusercontent.com/1811727/234961329-f0be2d05-368a-4a6d-b631-f19d13c5ca83.gif) |

### `playOnce`, while animation is playing:

| Before | After |
| ---- | ---- |
| ![2023-04-27 11 11 37](https://user-images.githubusercontent.com/1811727/234961472-48c14c02-4db7-4ac0-8691-33998bef22a9.gif) | ![2023-04-27 11 13 31](https://user-images.githubusercontent.com/1811727/234961496-d8a69819-7161-463a-9452-410486c22330.gif) |

### `autoreverse`, while animation is playing:

| Before | After |
| ---- | ---- |
| ![2023-04-27 11 24 57](https://user-images.githubusercontent.com/1811727/234961585-35cac182-7933-4fae-b002-7e7e610193e1.gif) | ![2023-04-27 11 23 39](https://user-images.githubusercontent.com/1811727/234961641-76b71e7b-758e-4c02-adab-827ac05c4d9d.gif) |
