### PR TITLE
Remove `.../ZipFoundation/README.md` from targets and `*.md` files from podspec

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -7,9 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		087584AE29B2BA6C00BC168F /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 087584AD29B2BA6C00BC168F /* README.md */; };
-		087584AF29B2BA6C00BC168F /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 087584AD29B2BA6C00BC168F /* README.md */; };
-		087584B029B2BA6C00BC168F /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 087584AD29B2BA6C00BC168F /* README.md */; };
 		087584C329B2BC8200BC168F /* Archive+BackingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087584B129B2BC8100BC168F /* Archive+BackingConfiguration.swift */; };
 		087584C429B2BC8200BC168F /* Archive+BackingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087584B129B2BC8100BC168F /* Archive+BackingConfiguration.swift */; };
 		087584C529B2BC8200BC168F /* Archive+BackingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087584B129B2BC8100BC168F /* Archive+BackingConfiguration.swift */; };
@@ -1855,7 +1852,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				087584AE29B2BA6C00BC168F /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1872,7 +1868,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				087584AF29B2BA6C00BC168F /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1880,7 +1875,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				087584B029B2BA6C00BC168F /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -28,6 +28,7 @@ Lottie enables designers to create and ship beautiful animations without an engi
   s.tvos.deployment_target = '11.0'
 
   s.source_files = 'Sources/**/*'
+  s.exclude_files = 'Sources/**/*.md'
   s.ios.exclude_files = 'Sources/Public/MacOS/**/*'
   s.tvos.exclude_files = 'Sources/Public/MacOS/**/*'
   s.osx.exclude_files = 'Sources/Public/iOS/**/*'


### PR DESCRIPTION
* `README.md` files do not need to be included in the Frameworks so the `.../ZipFoundation/README.md` is removed from all the Framework targets.
* In general the `*.md` files are not considered as sources thus the exclusion filter is introduced in `lottie-ios.podspec`

Resolves #2056 