### PR TITLE
Fix Swift 5.9 warnings

### DIFF
--- a/Sources/Private/CoreAnimation/Extensions/Keyframes+combined.swift
+++ b/Sources/Private/CoreAnimation/Extensions/Keyframes+combined.swift
@@ -262,7 +262,7 @@ enum Keyframes {
 extension KeyframeGroup {
   /// Whether or not all of the keyframes in this `KeyframeGroup` have the same
   /// timing parameters as the corresponding keyframe in the other given `KeyframeGroup`
-  func hasSameTimingParameters<T>(as other: KeyframeGroup<T>) -> Bool {
+  func hasSameTimingParameters<U>(as other: KeyframeGroup<U>) -> Bool {
     guard keyframes.count == other.keyframes.count else {
       return false
     }
@@ -276,7 +276,7 @@ extension KeyframeGroup {
 extension Keyframe {
   /// Whether or not this keyframe has the same timing parameters as the given keyframe,
   /// excluding `spatialInTangent` and `spatialOutTangent`.
-  fileprivate func hasSameTimingParameters<T>(as other: Keyframe<T>) -> Bool {
+  fileprivate func hasSameTimingParameters<U>(as other: Keyframe<U>) -> Bool {
     time == other.time
       && isHold == other.isHold
       && inTangent == other.inTangent


### PR DESCRIPTION
There is now a new warning produced by these functions since the type and the function both declare a generic with the same name.

```
lottie-ios/Sources/Private/CoreAnimation/Extensions/Keyframes+combined.swift:265:32: warning: generic parameter 'T' shadows generic parameter from outer scope with the same name; this is an error in Swift 6
  func hasSameTimingParameters<T>(as other: KeyframeGroup<T>) -> Bool {
lottie-ios/Sources/Private/Model/Keyframes/KeyframeGroup.swift:18:27: note: 'T' previously declared here
final class KeyframeGroup<T> {
```