### PR TITLE
Add a public interface to display Lottie Animations directly from a CALayer

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -666,6 +666,9 @@
 		7E48BF582860CECF00A39198 /* UnitBezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E48BF572860CECF00A39198 /* UnitBezier.swift */; };
 		7E48BF592860CECF00A39198 /* UnitBezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E48BF572860CECF00A39198 /* UnitBezier.swift */; };
 		7E48BF5A2860CECF00A39198 /* UnitBezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E48BF572860CECF00A39198 /* UnitBezier.swift */; };
+		82A552752A2FD44B00E47AC8 /* LottieAnimationLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A552742A2FD44B00E47AC8 /* LottieAnimationLayer.swift */; };
+		82A552762A2FD44B00E47AC8 /* LottieAnimationLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A552742A2FD44B00E47AC8 /* LottieAnimationLayer.swift */; };
+		82A552772A2FD44B00E47AC8 /* LottieAnimationLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A552742A2FD44B00E47AC8 /* LottieAnimationLayer.swift */; };
 		A1D5BAAC27C731A500777D06 /* DataURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D5BAAB27C731A500777D06 /* DataURLTests.swift */; };
 		A40460592832C52B00ACFEDC /* BlendMode+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40460582832C52B00ACFEDC /* BlendMode+Filter.swift */; };
 		A404605A2832C52B00ACFEDC /* BlendMode+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40460582832C52B00ACFEDC /* BlendMode+Filter.swift */; };
@@ -925,6 +928,7 @@
 		6DB3BDBF28245A6A002A276D /* ParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingTests.swift; sourceTree = "<group>"; };
 		6DEF696D2824A76C007D640F /* BundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleTests.swift; sourceTree = "<group>"; };
 		7E48BF572860CECF00A39198 /* UnitBezier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitBezier.swift; sourceTree = "<group>"; };
+		82A552742A2FD44B00E47AC8 /* LottieAnimationLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieAnimationLayer.swift; sourceTree = "<group>"; };
 		A1D5BAAB27C731A500777D06 /* DataURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataURLTests.swift; sourceTree = "<group>"; };
 		A40460582832C52B00ACFEDC /* BlendMode+Filter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BlendMode+Filter.swift"; sourceTree = "<group>"; };
 		D453D8AA28FE6EE300D3F49C /* LottieAnimationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieAnimationCache.swift; sourceTree = "<group>"; };
@@ -1507,6 +1511,7 @@
 			isa = PBXGroup;
 			children = (
 				0887346E28F0CBDE00458627 /* LottieAnimation.swift */,
+				82A552742A2FD44B00E47AC8 /* LottieAnimationLayer.swift */,
 				0887347228F0CCDD00458627 /* LottieAnimationHelpers.swift */,
 				0887347428F0CCDD00458627 /* LottieAnimationView.swift */,
 				0887347328F0CCDD00458627 /* LottieAnimationViewInitializers.swift */,
@@ -1891,6 +1896,7 @@
 				2E9C96F62822F43100677516 /* ShapeLayer.swift in Sources */,
 				6C48784728FF20140005AF07 /* DotLottieManifest.swift in Sources */,
 				2E9C95D62822F43100677516 /* Ellipse.swift in Sources */,
+				82A552752A2FD44B00E47AC8 /* LottieAnimationLayer.swift in Sources */,
 				2E9C97442822F43100677516 /* AnimatorNodeDebugging.swift in Sources */,
 				2E9C96D82822F43100677516 /* AnimatorNode.swift in Sources */,
 				2E9C96212822F43100677516 /* Bundle.swift in Sources */,
@@ -2138,6 +2144,7 @@
 				2E9C96F72822F43100677516 /* ShapeLayer.swift in Sources */,
 				6C48784828FF20140005AF07 /* DotLottieManifest.swift in Sources */,
 				2E9C95D72822F43100677516 /* Ellipse.swift in Sources */,
+				82A552762A2FD44B00E47AC8 /* LottieAnimationLayer.swift in Sources */,
 				2E9C97452822F43100677516 /* AnimatorNodeDebugging.swift in Sources */,
 				2E9C96D92822F43100677516 /* AnimatorNode.swift in Sources */,
 				2E9C96222822F43100677516 /* Bundle.swift in Sources */,
@@ -2361,6 +2368,7 @@
 				2E9C96F82822F43100677516 /* ShapeLayer.swift in Sources */,
 				6C48784928FF20140005AF07 /* DotLottieManifest.swift in Sources */,
 				2E9C95D82822F43100677516 /* Ellipse.swift in Sources */,
+				82A552772A2FD44B00E47AC8 /* LottieAnimationLayer.swift in Sources */,
 				2E9C97462822F43100677516 /* AnimatorNodeDebugging.swift in Sources */,
 				2E9C96DA2822F43100677516 /* AnimatorNode.swift in Sources */,
 				2E9C96232822F43100677516 /* Bundle.swift in Sources */,

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -79,23 +79,23 @@ public class LottieAnimationLayer: CALayer {
   }
 
   /// Called by CoreAnimation to create a shadow copy of this layer
-   /// More details: https://developer.apple.com/documentation/quartzcore/calayer/1410842-init
-   override init(layer: Any) {
-     guard let typedLayer = layer as? Self else {
-       fatalError("\(Self.self).init(layer:) incorrectly called with \(type(of: layer))")
-     }
+  /// More details: https://developer.apple.com/documentation/quartzcore/calayer/1410842-init
+  override init(layer: Any) {
+    guard let typedLayer = layer as? Self else {
+      fatalError("\(Self.self).init(layer:) incorrectly called with \(type(of: layer))")
+    }
 
-     animation = typedLayer.animation
-     imageProvider = typedLayer.imageProvider
-     textProvider = typedLayer.textProvider
-     fontProvider = typedLayer.fontProvider
-     logger = typedLayer.logger
-     screenScale = typedLayer.screenScale
-     configuration = typedLayer.configuration
-     super.init(layer: typedLayer)
-   }
+    animation = typedLayer.animation
+    imageProvider = typedLayer.imageProvider
+    textProvider = typedLayer.textProvider
+    fontProvider = typedLayer.fontProvider
+    logger = typedLayer.logger
+    screenScale = typedLayer.screenScale
+    configuration = typedLayer.configuration
+    super.init(layer: typedLayer)
+  }
 
-  required init?(coder: NSCoder) {
+  required init?(coder _: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
 
@@ -536,10 +536,6 @@ public class LottieAnimationLayer: CALayer {
     get { animationLayer?.animationView }
   }
 
-  var hasAnimationContext: Bool {
-    animationContext != nil
-  }
-
   /// Sets the lottie file backing the animation layer. Setting this will clear the
   /// layer's contents, completion blocks and current state. The new animation will
   /// be loaded up and set to the beginning of its timeline.
@@ -774,6 +770,15 @@ public class LottieAnimationLayer: CALayer {
 
   var animationLayer: RootAnimationLayer? = nil
 
+  /// Context describing the animation that is currently playing in this `LottieAnimationView`
+  ///  - When non-nil, an animation is currently playing in this layer. Otherwise,
+  ///    the layer is paused on a specific frame.
+  fileprivate(set) var animationContext: AnimationContext?
+
+  var hasAnimationContext: Bool {
+    animationContext != nil
+  }
+
   /// Set animation name from Interface Builder
   var animationName: String? {
     didSet {
@@ -842,10 +847,6 @@ public class LottieAnimationLayer: CALayer {
 
   // MARK: Fileprivate
 
-  /// Context describing the animation that is currently playing in this `LottieAnimationView`
-  ///  - When non-nil, an animation is currently playing in this layer. Otherwise,
-  ///    the layer is paused on a specific frame.
-  fileprivate(set) var animationContext: AnimationContext?
   fileprivate var _activeAnimationName: String = LottieAnimationLayer.animationName
   fileprivate var animationID = 0
 

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -267,9 +267,9 @@ public class LottieAnimationLayer: CALayer {
   /// Value Providers that have been registered using `setValueProvider(_:keypath:)`
   public private(set) var valueProviders = [AnimationKeypath: AnyValueProvider]()
 
-  /// A closure called when the animation layer will be loaded.
+  /// A closure called when the animation layer has been loaded.
   /// Will inform the receiver the type of rendering engine that is used for the layer.
-  public var animationLayerWillLoad:((_ animationLayer: LottieAnimationLayer, _ renderingEngine: RenderingEngineOption) -> Void)?
+  public var animationLayerDidLoad:((_ animationLayer: LottieAnimationLayer, _ renderingEngine: RenderingEngineOption) -> Void)?
 
   public var screenScale: CGFloat {
     didSet {
@@ -892,7 +892,7 @@ public class LottieAnimationLayer: CALayer {
       return
     }
 
-    animationLayerWillLoad?(self, renderingEngine)
+    animationLayerDidLoad?(self, renderingEngine)
 
     animationLayer.renderScale = screenScale
 

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1,0 +1,1292 @@
+//
+//  LottieAnimationLayer.swift
+//  Lottie
+//
+
+import Foundation
+import QuartzCore
+
+// MARK: - LottieBackgroundBehavior
+
+/// Describes the behavior of an AnimationView when the app is moved to the background.
+public enum LottieBackgroundBehavior {
+  /// Stop the animation and reset it to the beginning of its current play time. The completion block is called.
+  case stop
+
+  /// Pause the animation in its current state. The completion block is called.
+  case pause
+
+  /// Pause the animation and restart it when the application moves to the foreground.
+  /// The completion block is stored and called when the animation completes.
+  ///  - This is the default when using the Main Thread rendering engine.
+  case pauseAndRestore
+
+  /// Stops the animation and sets it to the end of its current play time. The completion block is called.
+  case forceFinish
+
+  /// The animation continues playing in the background.
+  ///  - This is the default when using the Core Animation rendering engine.
+  ///    Playing an animation using the Core Animation engine doesn't come with any CPU overhead,
+  ///    so using `.continuePlaying` avoids the need to stop and then resume the animation
+  ///    (which does come with some CPU overhead).
+  ///  - This mode should not be used with the Main Thread rendering engine.
+  case continuePlaying
+
+  // MARK: Public
+
+  /// The default background behavior, based on the rendering engine being used to play the animation.
+  ///  - Playing an animation using the Main Thread rendering engine comes with CPU overhead,
+  ///    so the animation should be paused or stopped when the `LottieAnimationView` is not visible.
+  ///  - Playing an animation using the Core Animation rendering engine does not come with any
+  ///    CPU overhead, so these animations do not need to be paused in the background.
+  public static func `default`(for renderingEngine: RenderingEngine) -> LottieBackgroundBehavior {
+    switch renderingEngine {
+    case .mainThread:
+      return .pauseAndRestore
+    case .coreAnimation:
+      return .continuePlaying
+    }
+  }
+}
+
+// MARK: - LottieLoopMode
+
+/// Defines animation loop behavior
+public enum LottieLoopMode {
+  /// Animation is played once then stops.
+  case playOnce
+  /// Animation will loop from beginning to end until stopped.
+  case loop
+  /// Animation will play forward, then backwards and loop until stopped.
+  case autoReverse
+  /// Animation will loop from beginning to end up to defined amount of times.
+  case `repeat`(Float)
+  /// Animation will play forward, then backwards a defined amount of times.
+  case repeatBackwards(Float)
+}
+
+// MARK: Equatable
+
+extension LottieLoopMode: Equatable {
+  public static func == (lhs: LottieLoopMode, rhs: LottieLoopMode) -> Bool {
+    switch (lhs, rhs) {
+    case (.repeat(let lhsAmount), .repeat(let rhsAmount)),
+      (.repeatBackwards(let lhsAmount), .repeatBackwards(let rhsAmount)):
+      return lhsAmount == rhsAmount
+    case (.playOnce, .playOnce),
+      (.loop, .loop),
+      (.autoReverse, .autoReverse):
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+// MARK: - LottieAnimationLayer
+
+/// This class will serve as an intermediate layer between a CoreAnimationLayer
+/// and a LottieAnimationView. The motivation behind creating this class is to
+/// have all the functionality of a LottieAnimationView on a CALayer-backed object.
+
+public class LottieAnimationLayer: CALayer {
+
+  // MARK: Lifecycle
+
+  // MARK: - Public (Initializers)
+
+  /// Initializes an AnimationView with an animation.
+  public init(
+    animation: LottieAnimation?,
+    imageProvider: AnimationImageProvider? = nil,
+    textProvider: AnimationTextProvider = DefaultTextProvider(),
+    fontProvider: AnimationFontProvider = DefaultFontProvider(),
+    configuration: LottieConfiguration = .shared,
+    logger: LottieLogger = .shared)
+  {
+    self.animation = animation
+    self.imageProvider = imageProvider ?? BundleImageProvider(bundle: Bundle.main, searchPath: nil)
+    self.textProvider = textProvider
+    self.fontProvider = fontProvider
+    self.configuration = configuration
+    self.screenScale = 1
+    self.logger = logger
+    super.init()
+    makeAnimationLayer(usingEngine: configuration.renderingEngine)
+    if let animation = animation {
+      frame = animation.bounds
+    }
+  }
+
+  /// Initializes an AnimationView with a .lottie file.
+  public init(
+    dotLottie: DotLottieFile?,
+    animationId: String? = nil,
+    textProvider: AnimationTextProvider = DefaultTextProvider(),
+    fontProvider: AnimationFontProvider = DefaultFontProvider(),
+    configuration: LottieConfiguration = .shared,
+    logger: LottieLogger = .shared)
+  {
+    let dotLottieAnimation = dotLottie?.animation(for: animationId)
+    animation = dotLottieAnimation?.animation
+    imageProvider = dotLottie?.imageProvider ?? BundleImageProvider(bundle: Bundle.main, searchPath: nil)
+    self.textProvider = textProvider
+    self.fontProvider = fontProvider
+    self.configuration = configuration
+    self.screenScale = 1
+    self.logger = logger
+    super.init()
+    loopMode = dotLottieAnimation?.configuration.loopMode ?? .playOnce
+    animationSpeed = CGFloat(dotLottieAnimation?.configuration.speed ?? 1)
+    makeAnimationLayer(usingEngine: configuration.renderingEngine)
+    if let animation = animation {
+      frame = animation.bounds
+    }
+  }
+
+  public init(
+    configuration: LottieConfiguration = .shared,
+    logger: LottieLogger = .shared)
+  {
+    animation = nil
+    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
+    textProvider = DefaultTextProvider()
+    fontProvider = DefaultFontProvider()
+    self.configuration = configuration
+    self.screenScale = 1
+    self.logger = logger
+    super.init()
+  }
+
+  required public override init(layer: Any) {
+    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
+    textProvider = DefaultTextProvider()
+    fontProvider = DefaultFontProvider()
+    configuration = .shared
+    screenScale = 1
+    logger = .shared
+    super.init(layer: layer)
+  }
+
+  required init?(coder: NSCoder) {
+    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
+    textProvider = DefaultTextProvider()
+    fontProvider = DefaultFontProvider()
+    configuration = .shared
+    screenScale = 1
+    logger = .shared
+    super.init(coder: coder)
+  }
+
+  // MARK: Open
+
+  /// Plays the animation from its current state to the end.
+  ///
+  /// - Parameter completion: An optional completion closure to be called when the animation completes playing.
+  open func play(completion: LottieCompletionBlock? = nil) {
+    guard let animation = animation else {
+      return
+    }
+
+    /// Build a context for the animation.
+    let context = AnimationContext(
+      playFrom: CGFloat(animation.startFrame),
+      playTo: CGFloat(animation.endFrame),
+      closure: completion)
+    removeCurrentAnimationIfNecessary()
+    addNewAnimationForContext(context)
+  }
+
+  /// Plays the animation from a progress (0-1) to a progress (0-1).
+  ///
+  /// - Parameter fromProgress: The start progress of the animation. If `nil` the animation will start at the current progress.
+  /// - Parameter toProgress: The end progress of the animation.
+  /// - Parameter loopMode: The loop behavior of the animation. If `nil` the view's `loopMode` property will be used.
+  /// - Parameter completion: An optional completion closure to be called when the animation stops.
+  open func play(
+    fromProgress: AnimationProgressTime? = nil,
+    toProgress: AnimationProgressTime,
+    loopMode: LottieLoopMode? = nil,
+    completion: LottieCompletionBlock? = nil)
+  {
+    guard let animation = animation else {
+      return
+    }
+
+    removeCurrentAnimationIfNecessary()
+    if let loopMode = loopMode {
+      /// Set the loop mode, if one was supplied
+      self.loopMode = loopMode
+    }
+    let context = AnimationContext(
+      playFrom: animation.frameTime(forProgress: fromProgress ?? currentProgress),
+      playTo: animation.frameTime(forProgress: toProgress),
+      closure: completion)
+    addNewAnimationForContext(context)
+  }
+
+  /// Plays the animation from a start frame to an end frame in the animation's framerate.
+  ///
+  /// - Parameter fromFrame: The start frame of the animation. If `nil` the animation will start at the current frame.
+  /// - Parameter toFrame: The end frame of the animation.
+  /// - Parameter loopMode: The loop behavior of the animation. If `nil` the view's `loopMode` property will be used.
+  /// - Parameter completion: An optional completion closure to be called when the animation stops.
+  open func play(
+    fromFrame: AnimationFrameTime? = nil,
+    toFrame: AnimationFrameTime,
+    loopMode: LottieLoopMode? = nil,
+    completion: LottieCompletionBlock? = nil)
+  {
+    removeCurrentAnimationIfNecessary()
+    if let loopMode = loopMode {
+      /// Set the loop mode, if one was supplied
+      self.loopMode = loopMode
+    }
+
+    let context = AnimationContext(
+      playFrom: fromFrame ?? currentFrame,
+      playTo: toFrame,
+      closure: completion)
+    addNewAnimationForContext(context)
+  }
+
+  /// Plays the animation from a named marker to another marker.
+  ///
+  /// Markers are point in time that are encoded into the Animation data and assigned
+  /// a name.
+  ///
+  /// NOTE: If markers are not found the play command will exit.
+  ///
+  /// - Parameter fromMarker: The start marker for the animation playback. If `nil` the
+  /// animation will start at the current progress.
+  /// - Parameter toMarker: The end marker for the animation playback.
+  /// - Parameter playEndMarkerFrame: A flag to determine whether or not to play the frame of the end marker. If the
+  /// end marker represents the end of the section to play, it should be to true. If the provided end marker
+  /// represents the beginning of the next section, it should be false.
+  /// - Parameter loopMode: The loop behavior of the animation. If `nil` the view's `loopMode` property will be used.
+  /// - Parameter completion: An optional completion closure to be called when the animation stops.
+  open func play(
+    fromMarker: String? = nil,
+    toMarker: String,
+    playEndMarkerFrame: Bool = true,
+    loopMode: LottieLoopMode? = nil,
+    completion: LottieCompletionBlock? = nil)
+  {
+    guard let animation = animation, let markers = animation.markerMap, let to = markers[toMarker] else {
+      return
+    }
+
+    removeCurrentAnimationIfNecessary()
+    if let loopMode = loopMode {
+      /// Set the loop mode, if one was supplied
+      self.loopMode = loopMode
+    }
+
+    let fromTime: CGFloat
+    if let fromName = fromMarker, let from = markers[fromName] {
+      fromTime = CGFloat(from.frameTime)
+    } else {
+      fromTime = currentFrame
+    }
+
+    let playTo = playEndMarkerFrame ? CGFloat(to.frameTime) : CGFloat(to.frameTime) - 1
+    let context = AnimationContext(
+      playFrom: fromTime,
+      playTo: playTo,
+      closure: completion)
+    addNewAnimationForContext(context)
+  }
+
+  /// Plays the animation from a named marker to the end of the marker's duration.
+  ///
+  /// A marker is a point in time with an associated duration that is encoded into the
+  /// animation data and assigned a name.
+  ///
+  /// NOTE: If marker is not found the play command will exit.
+  ///
+  /// - Parameter marker: The start marker for the animation playback.
+  /// - Parameter loopMode: The loop behavior of the animation. If `nil` the view's `loopMode` property will be used.
+  /// - Parameter completion: An optional completion closure to be called when the animation stops.
+  open func play(
+    marker: String,
+    loopMode: LottieLoopMode? = nil,
+    completion: LottieCompletionBlock? = nil)
+  {
+    guard let from = animation?.markerMap?[marker] else {
+      return
+    }
+
+    play(
+      fromFrame: from.frameTime,
+      toFrame: from.frameTime + from.durationFrameTime,
+      loopMode: loopMode,
+      completion: completion)
+  }
+
+  /// Stops the animation and resets the view to its start frame.
+  ///
+  /// The completion closure will be called with `false`
+  open func stop() {
+    removeCurrentAnimation()
+    currentFrame = 0
+  }
+
+  /// Pauses the animation in its current state.
+  ///
+  /// The completion closure will be called with `false`
+  open func pause() {
+    removeCurrentAnimation()
+  }
+
+  // MARK: Public
+
+  /// The configuration that this `LottieAnimationView` uses when playing its animation
+  public let configuration: LottieConfiguration
+
+  public var screenScale: CGFloat {
+    didSet {
+      animationLayer?.renderScale = screenScale
+    }
+  }
+
+  /// Value Providers that have been registered using `setValueProvider(_:keypath:)`
+  public private(set) var valueProviders = [AnimationKeypath: AnyValueProvider]()
+
+  /// Describes the behavior of an AnimationView when the app is moved to the background.
+  ///
+  /// The default for the Main Thread animation engine is `pause`,
+  /// which pauses the animation when the application moves to
+  /// the background. This prevents the animation from consuming CPU
+  /// resources when not on-screen. The completion block is called with
+  /// `false` for completed.
+  ///
+  /// The default for the Core Animation engine is `continuePlaying`,
+  /// since the Core Animation engine does not have any CPU overhead.
+  public var backgroundBehavior: LottieBackgroundBehavior {
+    get {
+      let currentBackgroundBehavior = _backgroundBehavior ?? .default(for: currentRenderingEngine ?? .mainThread)
+
+      if
+        currentRenderingEngine == .mainThread,
+        _backgroundBehavior == .continuePlaying
+      {
+        logger.assertionFailure("""
+          `LottieBackgroundBehavior.continuePlaying` should not be used with the Main Thread
+          rendering engine, since this would waste CPU resources on playing an animation
+          that is not visible. Consider using a different background mode, or switching to
+          the Core Animation rendering engine (which does not have any CPU overhead).
+          """)
+      }
+
+      return currentBackgroundBehavior
+    }
+    set {
+      _backgroundBehavior = newValue
+    }
+  }
+
+  /// Sets the animation backing the animation view. Setting this will clear the
+  /// view's contents, completion blocks and current state. The new animation will
+  /// be loaded up and set to the beginning of its timeline.
+  public var animation: LottieAnimation? {
+    didSet {
+      makeAnimationLayer(usingEngine: configuration.renderingEngine)
+
+      if let animation = animation {
+        animationLoaded?(self, animation)
+      }
+    }
+  }
+
+  /// A closure that is called when `self.animation` is loaded. When setting this closure,
+  /// it is called immediately if `self.animation` is non-nil.
+  ///
+  /// When initializing a `LottieAnimationView`, the animation will either be loaded
+  /// synchronously (when loading a `LottieAnimation` from a .json file on disk)
+  /// or asynchronously (when loading a `DotLottieFile` from disk, or downloading
+  /// an animation from a URL). This closure is called in both cases once the
+  /// animation is loaded and applied, so can be a useful way to configure this
+  /// `LottieAnimationView` regardless of which initializer was used. For example:
+  ///
+  /// ```
+  /// let animationView: LottieAnimationView
+  ///
+  /// if loadDotLottieFile {
+  ///   // Loads the .lottie file asynchronously
+  ///   animationView = LottieAnimationView(dotLottieName: "animation")
+  /// } else {
+  ///   // Loads the .json file synchronously
+  ///   animationView = LottieAnimationView(name: "animation")
+  /// }
+  ///
+  /// animationView.animationLoaded = { animationView, animation in
+  ///   // If using a .lottie file, this is called once the file finishes loading.
+  ///   // If using a .json file, this is called immediately (since the animation is loaded synchronously).
+  ///   animationView.play()
+  /// }
+  /// ```
+  public var animationLoaded: ((_ animationLayer: LottieAnimationLayer, _ animation: LottieAnimation) -> Void)? {
+    didSet {
+      if let animation = animation {
+        animationLoaded?(self, animation)
+      }
+    }
+  }
+
+  /// A closure called when the animation layer will be loaded.
+  /// Will inform the receiver the type of rendering engine that is used for the layer.
+  public var animationLayerWillLoad:((_ animationLayer: LottieAnimationLayer, _ renderingEngine: RenderingEngineOption) -> Void)?
+
+  /// Sets the image provider for the animation view. An image provider provides the
+  /// animation with its required image data.
+  ///
+  /// Setting this will cause the animation to reload its image contents.
+  public var imageProvider: AnimationImageProvider {
+    didSet {
+      animationLayer?.imageProvider = imageProvider.cachedImageProvider
+      reloadImages()
+    }
+  }
+
+  /// Sets the text provider for animation view. A text provider provides the
+  /// animation with values for text layers
+  public var textProvider: AnimationTextProvider {
+    didSet {
+      animationLayer?.textProvider = textProvider
+    }
+  }
+
+  /// Sets the text provider for animation view. A text provider provides the
+  /// animation with values for text layers
+  public var fontProvider: AnimationFontProvider {
+    didSet {
+      animationLayer?.fontProvider = fontProvider
+    }
+  }
+
+  /// Whether or not the animation is masked to the bounds. Defaults to true.
+  public var maskAnimationToBounds = true {
+    didSet {
+      animationLayer?.masksToBounds = maskAnimationToBounds
+    }
+  }
+
+  /// Returns `true` if the animation is currently playing.
+  public var isAnimationPlaying: Bool {
+    guard let animationLayer = animationLayer else {
+      return false
+    }
+
+    if let valueFromLayer = animationLayer.isAnimationPlaying {
+      return valueFromLayer
+    } else {
+      return animationLayer.animation(forKey: activeAnimationName) != nil
+    }
+  }
+
+  /// Sets the loop behavior for `play` calls. Defaults to `playOnce`
+  public var loopMode: LottieLoopMode = .playOnce {
+    didSet {
+      updateInFlightAnimation()
+    }
+  }
+
+  /// When `true` the animation view will rasterize its contents when not animating.
+  /// Rasterizing will improve performance of static animations.
+  ///
+  /// Note: this will not produce crisp results at resolutions above the animations natural resolution.
+  ///
+  /// Defaults to `false`
+  public var shouldRasterizeWhenIdle = false {
+    didSet {
+      updateRasterizationState()
+    }
+  }
+
+  /// Sets the current animation time with a Progress Time
+  ///
+  /// Note: Setting this will stop the current animation, if any.
+  /// Note 2: If `animation` is nil, setting this will fallback to 0
+  public var currentProgress: AnimationProgressTime {
+    set {
+      if let animation = animation {
+        currentFrame = animation.frameTime(forProgress: newValue)
+      } else {
+        currentFrame = 0
+      }
+    }
+    get {
+      if let animation = animation {
+        return animation.progressTime(forFrame: currentFrame)
+      } else {
+        return 0
+      }
+    }
+  }
+
+  /// Sets the current animation time with a time in seconds.
+  ///
+  /// Note: Setting this will stop the current animation, if any.
+  /// Note 2: If `animation` is nil, setting this will fallback to 0
+  public var currentTime: TimeInterval {
+    set {
+      if let animation = animation {
+        currentFrame = animation.frameTime(forTime: newValue)
+      } else {
+        currentFrame = 0
+      }
+    }
+    get {
+      if let animation = animation {
+        return animation.time(forFrame: currentFrame)
+      } else {
+        return 0
+      }
+    }
+  }
+
+  /// Sets the current animation time with a frame in the animations framerate.
+  ///
+  /// Note: Setting this will stop the current animation, if any.
+  public var currentFrame: AnimationFrameTime {
+    set {
+      removeCurrentAnimationIfNecessary()
+      updateAnimationFrame(newValue)
+    }
+    get {
+      animationLayer?.currentFrame ?? 0
+    }
+  }
+
+  /// Returns the current animation frame while an animation is playing.
+  public var realtimeAnimationFrame: AnimationFrameTime {
+    isAnimationPlaying ? animationLayer?.presentation()?.currentFrame ?? currentFrame : currentFrame
+  }
+
+  /// Returns the current animation frame while an animation is playing.
+  public var realtimeAnimationProgress: AnimationProgressTime {
+    if let animation = animation {
+      return animation.progressTime(forFrame: realtimeAnimationFrame)
+    }
+    return 0
+  }
+
+  /// Sets the speed of the animation playback. Defaults to 1
+  public var animationSpeed: CGFloat = 1 {
+    didSet {
+      updateInFlightAnimation()
+    }
+  }
+
+  /// When `true` the animation will play back at the framerate encoded in the
+  /// `LottieAnimation` model. When `false` the animation will play at the framerate
+  /// of the device.
+  ///
+  /// Defaults to false
+  public var respectAnimationFrameRate = false {
+    didSet {
+      animationLayer?.respectAnimationFrameRate = respectAnimationFrameRate
+    }
+  }
+
+  /// The rendering engine currently being used by this view.
+  ///  - This will only be `nil` in cases where the configuration is `automatic`
+  ///    but a `RootAnimationLayer` hasn't been constructed yet
+  public var currentRenderingEngine: RenderingEngine? {
+    switch configuration.renderingEngine {
+    case .specific(let engine):
+      return engine
+
+    case .automatic:
+      guard let animationLayer = animationLayer else {
+        return nil
+      }
+
+      if animationLayer is CoreAnimationLayer {
+        return .coreAnimation
+      } else {
+        return .mainThread
+      }
+    }
+  }
+
+  public var animationView: LottieAnimationView? {
+    set (newValue) {
+      animationLayer?.animationView = newValue
+    }
+    get {
+      animationLayer?.animationView
+    }
+  }
+
+  /// Sets the lottie file backing the animation view. Setting this will clear the
+  /// view's contents, completion blocks and current state. The new animation will
+  /// be loaded up and set to the beginning of its timeline.
+  /// The loopMode, animationSpeed and imageProvider will be set according
+  /// to lottie file settings
+  /// - Parameters:
+  ///   - animationId: Internal animation id to play. Optional
+  ///   Defaults to play first animation in file.
+  ///   - dotLottieFile: Lottie file to play
+  public func loadAnimation(
+    _ animationId: String? = nil,
+    from dotLottieFile: DotLottieFile)
+  {
+    guard let dotLottieAnimation = dotLottieFile.animation(for: animationId) else { return }
+
+    loopMode = dotLottieAnimation.configuration.loopMode
+    animationSpeed = CGFloat(dotLottieAnimation.configuration.speed)
+
+    if let imageProvider = dotLottieAnimation.configuration.imageProvider {
+      self.imageProvider = imageProvider
+    }
+
+    animation = dotLottieAnimation.animation
+  }
+
+  /// Reloads the images supplied to the animation from the `imageProvider`
+  public func reloadImages() {
+    animationLayer?.reloadImages()
+  }
+
+  /// Forces the LottieAnimationView to redraw its contents.
+  public func forceDisplayUpdate() {
+    animationLayer?.forceDisplayUpdate()
+  }
+
+  /// Sets a ValueProvider for the specified keypath. The value provider will be set
+  /// on all properties that match the keypath.
+  ///
+  /// Nearly all properties of a Lottie animation can be changed at runtime using a
+  /// combination of `Animation Keypaths` and `Value Providers`.
+  /// Setting a ValueProvider on a keypath will cause the animation to update its
+  /// contents and read the new Value Provider.
+  ///
+  /// A value provider provides a typed value on a frame by frame basis.
+  ///
+  /// - Parameter valueProvider: The new value provider for the properties.
+  /// - Parameter keypath: The keypath used to search for properties.
+  ///
+  /// Example:
+  /// ```
+  /// /// A keypath that finds the color value for all `Fill 1` nodes.
+  /// let fillKeypath = AnimationKeypath(keypath: "**.Fill 1.Color")
+  /// /// A Color Value provider that returns a reddish color.
+  /// let redValueProvider = ColorValueProvider(Color(r: 1, g: 0.2, b: 0.3, a: 1))
+  /// /// Set the provider on the animationView.
+  /// animationView.setValueProvider(redValueProvider, keypath: fillKeypath)
+  /// ```
+  public func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath) {
+    guard let animationLayer = animationLayer else { return }
+
+    valueProviders[keypath] = valueProvider
+    animationLayer.setValueProvider(valueProvider, keypath: keypath)
+  }
+
+  /// Reads the value of a property specified by the Keypath.
+  /// Returns nil if no property is found.
+  ///
+  /// - Parameter for: The keypath used to search for the property.
+  /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.
+  public func getValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any? {
+    animationLayer?.getValue(for: keypath, atFrame: atFrame)
+  }
+
+  /// Reads the original value of a property specified by the Keypath.
+  /// This will ignore any value providers and can be useful when implementing a value providers that makes change to the original value from the animation.
+  /// Returns nil if no property is found.
+  ///
+  /// - Parameter for: The keypath used to search for the property.
+  /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.
+  public func getOriginalValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any? {
+    animationLayer?.getOriginalValue(for: keypath, atFrame: atFrame)
+  }
+
+  /// Logs all child keypaths.
+  public func logHierarchyKeypaths() {
+    animationLayer?.logHierarchyKeypaths()
+  }
+
+  /// Computes and returns a list of all child keypaths in the current animation.
+  /// The returned list is the same as the log output of `logHierarchyKeypaths()`
+  public func allHierarchyKeypaths() -> [String] {
+    animationLayer?.allHierarchyKeypaths() ?? []
+  }
+
+  /// Converts a CGRect from the LottieAnimationView's coordinate space into the
+  /// coordinate space of the layer found at Keypath.
+  ///
+  /// If no layer is found, nil is returned
+  ///
+  /// - Parameter rect: The CGRect to convert.
+  /// - Parameter toLayerAt: The keypath used to find the layer.
+  public func convert(_ rect: CGRect, toLayerAt keypath: AnimationKeypath?) -> CGRect? {
+    guard let animationLayer = animationLayer else { return nil }
+    guard let keypath = keypath else {
+      return self.convert(rect, to: animationLayer)
+    }
+    guard let sublayer = animationLayer.layer(for: keypath) else {
+      return nil
+    }
+    setNeedsLayout()
+    layoutIfNeeded()
+    forceDisplayUpdate()
+    return animationLayer.convert(rect, to: sublayer)
+  }
+
+  /// Converts a CGPoint from the LottieAnimationView's coordinate space into the
+  /// coordinate space of the layer found at Keypath.
+  ///
+  /// If no layer is found, nil is returned
+  ///
+  /// - Parameter point: The CGPoint to convert.
+  /// - Parameter toLayerAt: The keypath used to find the layer.
+  public func convert(_ point: CGPoint, toLayerAt keypath: AnimationKeypath?) -> CGPoint? {
+    guard let animationLayer = animationLayer else { return nil }
+    guard let keypath = keypath else {
+      return self.convert(point, to: animationLayer)
+    }
+    guard let sublayer = animationLayer.layer(for: keypath) else {
+      return nil
+    }
+    setNeedsLayout()
+    layoutIfNeeded()
+    forceDisplayUpdate()
+    return animationLayer.convert(point, to: sublayer)
+  }
+
+  /// Sets the enabled state of all animator nodes found with the keypath search.
+  /// This can be used to interactively enable / disable parts of the animation.
+  ///
+  /// - Parameter isEnabled: When true the animator nodes affect the rendering tree. When false the node is removed from the tree.
+  /// - Parameter keypath: The keypath used to find the node(s).
+  public func setNodeIsEnabled(isEnabled: Bool, keypath: AnimationKeypath) {
+    guard let animationLayer = animationLayer else { return }
+    let nodes = animationLayer.animatorNodes(for: keypath)
+    if let nodes = nodes {
+      for node in nodes {
+        node.isEnabled = isEnabled
+      }
+      forceDisplayUpdate()
+    }
+  }
+
+  /// Markers are a way to describe a point in time by a key name.
+  ///
+  /// Markers are encoded into animation JSON. By using markers a designer can mark
+  /// playback points for a developer to use without having to worry about keeping
+  /// track of animation frames. If the animation file is updated, the developer
+  /// does not need to update playback code.
+  ///
+  /// Returns the Progress Time for the marker named. Returns nil if no marker found.
+  public func progressTime(forMarker named: String) -> AnimationProgressTime? {
+    guard let animation = animation else {
+      return nil
+    }
+    return animation.progressTime(forMarker: named)
+  }
+
+  /// Markers are a way to describe a point in time by a key name.
+  ///
+  /// Markers are encoded into animation JSON. By using markers a designer can mark
+  /// playback points for a developer to use without having to worry about keeping
+  /// track of animation frames. If the animation file is updated, the developer
+  /// does not need to update playback code.
+  ///
+  /// Returns the Frame Time for the marker named. Returns nil if no marker found.
+  public func frameTime(forMarker named: String) -> AnimationFrameTime? {
+    guard let animation = animation else {
+      return nil
+    }
+    return animation.frameTime(forMarker: named)
+  }
+
+  /// Markers are a way to describe a point in time and a duration by a key name.
+  ///
+  /// Markers are encoded into animation JSON. By using markers a designer can mark
+  /// playback points for a developer to use without having to worry about keeping
+  /// track of animation frames. If the animation file is updated, the developer
+  /// does not need to update playback code.
+  ///
+  /// - Returns: The duration frame time for the marker, or `nil` if no marker found.
+  public func durationFrameTime(forMarker named: String) -> AnimationFrameTime? {
+    guard let animation = animation else {
+      return nil
+    }
+    return animation.durationFrameTime(forMarker: named)
+  }
+
+  public func updateAnimationForBackgroundState() {
+    if let currentContext = animationContext {
+      switch backgroundBehavior {
+      case .stop:
+        removeCurrentAnimation()
+        updateAnimationFrame(currentContext.playFrom)
+      case .pause:
+        removeCurrentAnimation()
+      case .pauseAndRestore:
+        currentContext.closure.ignoreDelegate = true
+        removeCurrentAnimation()
+        /// Keep the stale context around for when the app enters the foreground.
+        animationContext = currentContext
+      case .forceFinish:
+        removeCurrentAnimation()
+        updateAnimationFrame(currentContext.playTo)
+      case .continuePlaying:
+        break
+      }
+    }
+  }
+
+  public func updateAnimationForForegroundState(wasWaitingToPlayAnimation: Bool) {
+    if let currentContext = animationContext {
+      if wasWaitingToPlayAnimation {
+        addNewAnimationForContext(currentContext)
+      } else if backgroundBehavior == .pauseAndRestore {
+        /// Restore animation from saved state
+        updateInFlightAnimation()
+      }
+    }
+  }
+
+  // MARK: Internal
+
+  var animationLayer: RootAnimationLayer? = nil
+
+  /// Set animation name from Interface Builder
+  var animationName: String? {
+    didSet {
+      self.animation = animationName.flatMap {
+        LottieAnimation.named($0, animationCache: nil)
+      }
+    }
+  }
+
+  func updateRasterizationState() {
+    if isAnimationPlaying {
+      animationLayer?.shouldRasterize = false
+    } else {
+      animationLayer?.shouldRasterize = shouldRasterizeWhenIdle
+    }
+  }
+
+  /// Updates the animation frame. Does not affect any current animations
+  func updateAnimationFrame(_ newFrame: CGFloat) {
+    // In performance tests, we have to wrap the animation view setup
+    // in a `CATransaction` in order for the layers to be deallocated at
+    // the correct time. The `CATransaction`s in this method interfere
+    // with the ones managed by the performance test, and aren't actually
+    // necessary in a headless environment, so we disable them.
+    if TestHelpers.performanceTestsAreRunning {
+      animationLayer?.currentFrame = newFrame
+      animationLayer?.forceDisplayUpdate()
+      return
+    }
+
+    CATransaction.begin()
+    CATransaction.setCompletionBlock {
+      self.animationLayer?.forceDisplayUpdate()
+    }
+    CATransaction.setDisableActions(true)
+    animationLayer?.currentFrame = newFrame
+    CATransaction.commit()
+  }
+
+  /// Updates an in flight animation.
+  func updateInFlightAnimation() {
+    guard let animationContext = animationContext else { return }
+
+    guard animationContext.closure.animationState != .complete else {
+      // Tried to re-add an already completed animation. Cancel.
+      self.animationContext = nil
+      return
+    }
+
+    /// Tell existing context to ignore its closure
+    animationContext.closure.ignoreDelegate = true
+
+    /// Make a new context, stealing the completion block from the previous.
+    let newContext = AnimationContext(
+      playFrom: animationContext.playFrom,
+      playTo: animationContext.playTo,
+      closure: animationContext.closure.completionBlock)
+
+    /// Remove current animation, and freeze the current frame.
+    let pauseFrame = realtimeAnimationFrame
+    animationLayer?.removeAnimation(forKey: activeAnimationName)
+    animationLayer?.currentFrame = pauseFrame
+
+    addNewAnimationForContext(newContext)
+  }
+
+  // MARK: Fileprivate
+
+  /// Stops the current in flight animation and freezes the animation in its current state.
+  fileprivate func removeCurrentAnimation() {
+    guard animationContext != nil else { return }
+    let pauseFrame = realtimeAnimationFrame
+    animationLayer?.removeAnimation(forKey: activeAnimationName)
+    updateAnimationFrame(pauseFrame)
+    animationContext = nil
+  }
+
+  /// Context describing the animation that is currently playing in this `LottieAnimationView`
+  ///  - When non-nil, an animation is currently playing in this view. Otherwise,
+  ///    the view is paused on a specific frame.
+  fileprivate var animationContext: AnimationContext?
+  public var hasAnimationContext: Bool {
+    self.animationContext != nil
+  }
+
+  fileprivate var _activeAnimationName: String = LottieAnimationLayer.animationName
+  fileprivate var animationID = 0
+
+  fileprivate var activeAnimationName: String {
+    switch animationLayer?.primaryAnimationKey {
+    case .specific(let animationKey):
+      return animationKey
+    case .managed, nil:
+      return _activeAnimationName
+    }
+  }
+
+  fileprivate func makeAnimationLayer(usingEngine renderingEngine: RenderingEngineOption) {
+    /// Remove current animation if any
+    removeCurrentAnimation()
+
+    if let oldAnimation = animationLayer {
+      oldAnimation.removeFromSuperlayer()
+    }
+
+    guard let animation = animation else {
+      return
+    }
+    let rootAnimationLayer: RootAnimationLayer?
+    switch renderingEngine {
+    case .automatic:
+      rootAnimationLayer = makeAutomaticEngineLayer(for: animation)
+    case .specific(.coreAnimation):
+      rootAnimationLayer = makeCoreAnimationLayer(for: animation)
+    case .specific(.mainThread):
+      rootAnimationLayer = makeMainThreadAnimationLayer(for: animation)
+    }
+
+    guard let animationLayer = rootAnimationLayer else {
+      return
+    }
+
+    animationLayerWillLoad?(self, renderingEngine)
+
+    animationLayer.renderScale = screenScale
+
+    self.addSublayer(animationLayer)
+    self.animationLayer = animationLayer
+    reloadImages()
+    animationLayer.setNeedsDisplay()
+    setNeedsLayout()
+    currentFrame = CGFloat(animation.startFrame)
+  }
+
+  fileprivate func makeMainThreadAnimationLayer(for animation: LottieAnimation) -> MainThreadAnimationLayer {
+    MainThreadAnimationLayer(
+      animation: animation,
+      imageProvider: imageProvider.cachedImageProvider,
+      textProvider: textProvider,
+      fontProvider: fontProvider,
+      maskAnimationToBounds: maskAnimationToBounds,
+      logger: logger)
+  }
+
+  fileprivate func makeCoreAnimationLayer(for animation: LottieAnimation) -> CoreAnimationLayer? {
+    do {
+      let coreAnimationLayer = try CoreAnimationLayer(
+        animation: animation,
+        imageProvider: imageProvider.cachedImageProvider,
+        textProvider: textProvider,
+        fontProvider: fontProvider,
+        maskAnimationToBounds: maskAnimationToBounds,
+        compatibilityTrackerMode: .track,
+        logger: logger)
+
+      coreAnimationLayer.didSetUpAnimation = { [logger] compatibilityIssues in
+        logger.assert(
+          compatibilityIssues.isEmpty,
+          "Encountered Core Animation compatibility issues while setting up animation:\n"
+          + compatibilityIssues.map { $0.description }.joined(separator: "\n") + "\n\n"
+          + """
+              This animation cannot be rendered correctly by the Core Animation engine.
+              To resolve this issue, you can use `RenderingEngineOption.automatic`, which automatically falls back
+              to the Main Thread rendering engine when necessary, or just use `RenderingEngineOption.mainThread`.
+
+              """)
+      }
+
+      return coreAnimationLayer
+    } catch {
+      // This should never happen, because we initialize the `CoreAnimationLayer` with
+      // `CompatibilityTracker.Mode.track` (which reports errors in `didSetUpAnimation`,
+      // not by throwing).
+      logger.assertionFailure("Encountered unexpected error \(error)")
+      return nil
+    }
+  }
+
+  fileprivate func makeAutomaticEngineLayer(for animation: LottieAnimation) -> CoreAnimationLayer? {
+    do {
+      // Attempt to set up the Core Animation layer. This can either throw immediately in `init`,
+      // or throw an error later in `CALayer.display()` that will be reported in `didSetUpAnimation`.
+      let coreAnimationLayer = try CoreAnimationLayer(
+        animation: animation,
+        imageProvider: imageProvider.cachedImageProvider,
+        textProvider: textProvider,
+        fontProvider: fontProvider,
+        maskAnimationToBounds: maskAnimationToBounds,
+        compatibilityTrackerMode: .abort,
+        logger: logger)
+
+      coreAnimationLayer.didSetUpAnimation = { [weak self] issues in
+        self?.automaticEngineLayerDidSetUpAnimation(issues)
+      }
+
+      return coreAnimationLayer
+    } catch {
+      if case CompatibilityTracker.Error.encounteredCompatibilityIssue(let compatibilityIssue) = error {
+        automaticEngineLayerDidSetUpAnimation([compatibilityIssue])
+      } else {
+        // This should never happen, because we expect `CoreAnimationLayer` to only throw
+        // `CompatibilityTracker.Error.encounteredCompatibilityIssue` errors.
+        logger.assertionFailure("Encountered unexpected error \(error)")
+        automaticEngineLayerDidSetUpAnimation([])
+      }
+
+      return nil
+    }
+  }
+
+  // Handles any compatibility issues with the Core Animation engine
+  // by falling back to the Main Thread engine
+  fileprivate func automaticEngineLayerDidSetUpAnimation(_ compatibilityIssues: [CompatibilityIssue]) {
+    // If there weren't any compatibility issues, then there's nothing else to do
+    if compatibilityIssues.isEmpty {
+      return
+    }
+
+    logger.warn(
+      "Encountered Core Animation compatibility issue while setting up animation:\n"
+      + compatibilityIssues.map { $0.description }.joined(separator: "\n") + "\n"
+      + """
+          This animation may have additional compatibility issues, but animation setup was cancelled early to avoid wasted work.
+
+          Automatically falling back to Main Thread rendering engine. This fallback comes with some additional performance
+          overhead, which can be reduced by manually specifying that this animation should always use the Main Thread engine.
+
+          """)
+
+    let animationContext = animationContext
+    let currentFrame = currentFrame
+
+    // Disable the completion handler delegate before tearing down the `CoreAnimationLayer`
+    // and building the `MainThreadAnimationLayer`. Otherwise deinitializing the
+    // `CoreAnimationLayer` would trigger the animation completion handler even though
+    // the animation hasn't even started playing yet.
+    animationContext?.closure.ignoreDelegate = true
+
+    makeAnimationLayer(usingEngine: .mainThread)
+
+    // Set up the Main Thread animation layer using the same configuration that
+    // was being used by the previous Core Animation layer
+    self.currentFrame = currentFrame
+
+    if let animationContext = animationContext {
+      // `AnimationContext.closure` (`AnimationCompletionDelegate`) is a reference type
+      // that is the animation layer's `CAAnimationDelegate`, and holds a reference to
+      // the animation layer. Reusing a single instance across different animation layers
+      // can cause the animation setup to fail, so we create a copy of the `animationContext`:
+      addNewAnimationForContext(AnimationContext(
+        playFrom: animationContext.playFrom,
+        playTo: animationContext.playTo,
+        closure: animationContext.closure.completionBlock))
+    }
+  }
+
+  /// Removes the current animation and pauses the animation at the current frame
+  /// if necessary before setting up a new animation.
+  ///  - This is not necessary with the Core Animation engine, and skipping
+  ///    this step lets us avoid building the animations twice (once paused
+  ///    and once again playing)
+  ///  - This method should only be called immediately before setting up another
+  ///    animation -- otherwise this LottieAnimationView could be put in an inconsistent state.
+  fileprivate func removeCurrentAnimationIfNecessary() {
+    switch currentRenderingEngine {
+    case .mainThread:
+      removeCurrentAnimation()
+    case .coreAnimation, nil:
+      // We still need to remove the `animationContext`, since it should only be present
+      // when an animation is actually playing. Without this calling `removeCurrentAnimationIfNecessary()`
+      // and then setting the animation to a specific paused frame would put this
+      // `LottieAnimationView` in an inconsistent state.
+      animationContext = nil
+    }
+  }
+
+  /// Adds animation to animation layer and sets the delegate. If animation layer or animation are nil, exits.
+  fileprivate func addNewAnimationForContext(_ animationContext: AnimationContext) {
+    guard let animationlayer = animationLayer, let animation = animation else {
+      return
+    }
+
+    self.animationContext = animationContext
+
+    switch currentRenderingEngine {
+    case .mainThread:
+      // On the CALayer side, just play all animations immediately. The UIView side
+      // will handle queueing animations.
+      break
+
+    case .coreAnimation, nil:
+      // The Core Animation engine automatically batches animation setup to happen
+      // in `CALayer.display()`, which won't be called until the layer is on-screen,
+      // so we don't need to defer animation setup at this layer.
+      break
+    }
+
+    animationID = animationID + 1
+    _activeAnimationName = LottieAnimationLayer.animationName + String(animationID)
+
+    if let coreAnimationLayer = animationlayer as? CoreAnimationLayer {
+      var animationContext = animationContext
+
+      // Core Animation doesn't natively support negative speed values,
+      // so instead we can swap `playFrom` / `playTo`
+      if animationSpeed < 0 {
+        let temp = animationContext.playFrom
+        animationContext.playFrom = animationContext.playTo
+        animationContext.playTo = temp
+      }
+
+      var timingConfiguration = CoreAnimationLayer.CAMediaTimingConfiguration(
+        autoreverses: loopMode.caAnimationConfiguration.autoreverses,
+        repeatCount: loopMode.caAnimationConfiguration.repeatCount,
+        speed: abs(Float(animationSpeed)))
+
+      // The animation should start playing from the `currentFrame`,
+      // if `currentFrame` is included in the time range being played.
+      let lowerBoundTime = min(animationContext.playFrom, animationContext.playTo)
+      let upperBoundTime = max(animationContext.playFrom, animationContext.playTo)
+      if (lowerBoundTime ..< upperBoundTime).contains(round(currentFrame)) {
+        // We have to configure this differently depending on the loop mode:
+        switch loopMode {
+          // When playing exactly once (and not looping), we can just set the
+          // `playFrom` time to be the `currentFrame`. Since the animation duration
+          // is based on `playFrom` and `playTo`, this automatically truncates the
+          // duration (so the animation stops playing at `playFrom`).
+          //  - Don't do this if the animation is already at that frame
+          //    (e.g. playing from 100% to 0% when the animation is already at 0%)
+          //    since that would cause the animation to not play at all.
+        case .playOnce:
+          if animationContext.playTo != currentFrame {
+            animationContext.playFrom = currentFrame
+          }
+
+          // When looping, we specifically _don't_ want to affect the duration of the animation,
+          // since that would affect the duration of all subsequent loops. We just want to adjust
+          // the duration of the _first_ loop. Instead of setting `playFrom`, we just add a `timeOffset`
+          // so the first loop begins at `currentTime` but all subsequent loops are the standard duration.
+        default:
+          if animationSpeed < 0 {
+            timingConfiguration.timeOffset = animation.time(forFrame: animationContext.playFrom) - currentTime
+          } else {
+            timingConfiguration.timeOffset = currentTime - animation.time(forFrame: animationContext.playFrom)
+          }
+        }
+      }
+
+      // If attempting to play a zero-duration animation, just pause on that single frame instead
+      if animationContext.playFrom == animationContext.playTo {
+        currentFrame = animationContext.playTo
+        animationContext.closure.completionBlock?(true)
+        return
+      }
+
+      coreAnimationLayer.playAnimation(configuration: .init(
+        animationContext: animationContext,
+        timingConfiguration: timingConfiguration))
+
+      return
+    }
+
+    /// At this point there is no animation on animationLayer and its state is set.
+
+    let framerate = animation.framerate
+
+    let playFrom = animationContext.playFrom.clamp(animation.startFrame, animation.endFrame)
+    let playTo = animationContext.playTo.clamp(animation.startFrame, animation.endFrame)
+
+    let duration = ((max(playFrom, playTo) - min(playFrom, playTo)) / CGFloat(framerate))
+
+    let playingForward: Bool =
+    (
+      (animationSpeed > 0 && playFrom < playTo) ||
+      (animationSpeed < 0 && playTo < playFrom))
+
+    var startFrame = currentFrame.clamp(min(playFrom, playTo), max(playFrom, playTo))
+    if startFrame == playTo {
+      startFrame = playFrom
+    }
+
+    let timeOffset: TimeInterval = playingForward
+    ? Double(startFrame - min(playFrom, playTo)) / framerate
+    : Double(max(playFrom, playTo) - startFrame) / framerate
+
+    let layerAnimation = CABasicAnimation(keyPath: "currentFrame")
+    layerAnimation.fromValue = playFrom
+    layerAnimation.toValue = playTo
+    layerAnimation.speed = Float(animationSpeed)
+    layerAnimation.duration = TimeInterval(duration)
+    layerAnimation.fillMode = CAMediaTimingFillMode.both
+    layerAnimation.repeatCount = loopMode.caAnimationConfiguration.repeatCount
+    layerAnimation.autoreverses = loopMode.caAnimationConfiguration.autoreverses
+
+    layerAnimation.isRemovedOnCompletion = false
+    if timeOffset != 0 {
+      let currentLayerTime = self.convertTime(CACurrentMediaTime(), from: nil)
+      layerAnimation.beginTime = currentLayerTime - (timeOffset * 1 / Double(abs(animationSpeed)))
+    }
+    layerAnimation.delegate = animationContext.closure
+    animationContext.closure.animationLayer = animationlayer
+    animationContext.closure.animationKey = activeAnimationName
+
+    animationlayer.add(layerAnimation, forKey: activeAnimationName)
+    updateRasterizationState()
+  }
+
+  // MARK: Private
+
+  static private let animationName = "Lottie"
+
+  private let logger: LottieLogger
+
+  /// The `LottieBackgroundBehavior` that was specified manually by setting `self.backgroundBehavior`
+  private var _backgroundBehavior: LottieBackgroundBehavior?
+
+}
+
+// MARK: - LottieLoopMode + caAnimationConfiguration
+
+extension LottieLoopMode {
+  /// The `CAAnimation` configuration that reflects this mode
+  var caAnimationConfiguration: (repeatCount: Float, autoreverses: Bool) {
+    switch self {
+    case .playOnce:
+      return (repeatCount: 1, autoreverses: false)
+    case .loop:
+      return (repeatCount: .greatestFiniteMagnitude, autoreverses: false)
+    case .autoReverse:
+      return (repeatCount: .greatestFiniteMagnitude, autoreverses: true)
+    case .repeat(let amount):
+      return (repeatCount: amount, autoreverses: false)
+    case .repeatBackwards(let amount):
+      return (repeatCount: amount, autoreverses: true)
+    }
+  }
+}

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -10,7 +10,6 @@ import QuartzCore
 
 /// A CALayer subclass for rendering Lottie animations.
 /// All functionality is also available in a UIView as `LottieAnimationView`.
-
 public class LottieAnimationLayer: CALayer {
 
   // MARK: Lifecycle

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -89,7 +89,6 @@ extension LottieLoopMode: Equatable {
 
 /// A UIView subclass for rendering Lottie animations.
 /// All functionality is also available in a CALayer as `LottieAnimationLayer`.
-
 @IBDesignable
 open class LottieAnimationView: LottieAnimationViewBase {
 

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -26,14 +26,20 @@ open class LottieAnimationView: LottieAnimationViewBase {
     configuration: LottieConfiguration = .shared,
     logger: LottieLogger = .shared)
   {
-    self.lottieAnimationLayer = LottieAnimationLayer(animation: animation, imageProvider: imageProvider, textProvider: textProvider, fontProvider: fontProvider, configuration: configuration, logger: logger)
+    lottieAnimationLayer = LottieAnimationLayer(
+      animation: animation,
+      imageProvider: imageProvider,
+      textProvider: textProvider,
+      fontProvider: fontProvider,
+      configuration: configuration,
+      logger: logger)
     self.logger = logger
     super.init(frame: .zero)
     commonInit()
     if let animation = animation {
       frame = animation.bounds
     }
-    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    viewLayer?.addSublayer(lottieAnimationLayer)
     setNeedsLayout()
   }
 
@@ -46,14 +52,20 @@ open class LottieAnimationView: LottieAnimationViewBase {
     configuration: LottieConfiguration = .shared,
     logger: LottieLogger = .shared)
   {
-    self.lottieAnimationLayer = LottieAnimationLayer(dotLottie: dotLottie, animationId: animationId, textProvider: textProvider, fontProvider: fontProvider, configuration: configuration, logger: logger)
+    lottieAnimationLayer = LottieAnimationLayer(
+      dotLottie: dotLottie,
+      animationId: animationId,
+      textProvider: textProvider,
+      fontProvider: fontProvider,
+      configuration: configuration,
+      logger: logger)
     self.logger = logger
     super.init(frame: .zero)
     commonInit()
     if let animation = animation {
       frame = animation.bounds
     }
-    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    viewLayer?.addSublayer(lottieAnimationLayer)
     setNeedsLayout()
   }
 
@@ -61,49 +73,42 @@ open class LottieAnimationView: LottieAnimationViewBase {
     configuration: LottieConfiguration = .shared,
     logger: LottieLogger = .shared)
   {
-    self.lottieAnimationLayer = LottieAnimationLayer(configuration: configuration, logger: logger)
+    lottieAnimationLayer = LottieAnimationLayer(configuration: configuration, logger: logger)
     self.logger = logger
     super.init(frame: .zero)
     commonInit()
-    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    viewLayer?.addSublayer(lottieAnimationLayer)
     setNeedsLayout()
   }
 
   public override init(frame: CGRect) {
-    self.lottieAnimationLayer = LottieAnimationLayer(animation: nil, imageProvider: BundleImageProvider(bundle: Bundle.main, searchPath: nil), textProvider: DefaultTextProvider(), fontProvider: DefaultFontProvider(), configuration: .shared, logger: .shared)
-    self.logger = .shared
+    lottieAnimationLayer = LottieAnimationLayer(
+      animation: nil,
+      imageProvider: BundleImageProvider(bundle: Bundle.main, searchPath: nil),
+      textProvider: DefaultTextProvider(),
+      fontProvider: DefaultFontProvider(),
+      configuration: .shared,
+      logger: .shared)
+    logger = .shared
     super.init(frame: frame)
     commonInit()
-    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    viewLayer?.addSublayer(lottieAnimationLayer)
     setNeedsLayout()
   }
 
   required public init?(coder aDecoder: NSCoder) {
-    self.lottieAnimationLayer = LottieAnimationLayer(animation: nil, imageProvider: BundleImageProvider(bundle: Bundle.main, searchPath: nil), textProvider: DefaultTextProvider(), fontProvider: DefaultFontProvider(), configuration: .shared, logger: .shared)
-    self.logger = .shared
+    lottieAnimationLayer = LottieAnimationLayer(
+      animation: nil,
+      imageProvider: BundleImageProvider(bundle: Bundle.main, searchPath: nil),
+      textProvider: DefaultTextProvider(),
+      fontProvider: DefaultFontProvider(),
+      configuration: .shared,
+      logger: .shared)
+    logger = .shared
     super.init(coder: aDecoder)
     commonInit()
-    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    viewLayer?.addSublayer(lottieAnimationLayer)
     setNeedsLayout()
-  }
-
-  override func commonInit() {
-    super.commonInit()
-    self.lottieAnimationLayer.screenScale = self.screenScale
-
-    self.lottieAnimationLayer.animationLoaded = {[weak self] _, animation in
-      guard let self = self else { return }
-      self.animationLoaded?(self, animation)
-      self.invalidateIntrinsicContentSize()
-      self.setNeedsLayout()
-    }
-
-    self.lottieAnimationLayer.animationLayerWillLoad = {[weak self] lottieAnimationLayer, _ in
-      guard let self = self else { return }
-      self.invalidateIntrinsicContentSize()
-      self.setNeedsLayout()
-      lottieAnimationLayer.animationView = self
-    }
   }
 
   // MARK: Open
@@ -112,7 +117,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// - Parameter completion: An optional completion closure to be called when the animation completes playing.
   open func play(completion: LottieCompletionBlock? = nil) {
-    self.lottieAnimationLayer.play(completion: completion)
+    lottieAnimationLayer.play(completion: completion)
   }
 
   /// Plays the animation from a progress (0-1) to a progress (0-1).
@@ -127,7 +132,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    self.lottieAnimationLayer.play(fromProgress: fromProgress, toProgress: toProgress, loopMode: loopMode, completion: completion)
+    lottieAnimationLayer.play(fromProgress: fromProgress, toProgress: toProgress, loopMode: loopMode, completion: completion)
   }
 
   /// Plays the animation from a start frame to an end frame in the animation's framerate.
@@ -142,7 +147,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    self.lottieAnimationLayer.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: loopMode, completion: completion)
+    lottieAnimationLayer.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: loopMode, completion: completion)
   }
 
   /// Plays the animation from a named marker to another marker.
@@ -167,7 +172,12 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    self.lottieAnimationLayer.play(fromMarker: fromMarker, toMarker: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode, completion: completion)
+    lottieAnimationLayer.play(
+      fromMarker: fromMarker,
+      toMarker: toMarker,
+      playEndMarkerFrame: playEndMarkerFrame,
+      loopMode: loopMode,
+      completion: completion)
   }
 
   /// Plays the animation from a named marker to the end of the marker's duration.
@@ -185,21 +195,21 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    self.lottieAnimationLayer.play(marker: marker, loopMode: loopMode, completion: completion)
+    lottieAnimationLayer.play(marker: marker, loopMode: loopMode, completion: completion)
   }
 
   /// Stops the animation and resets the view to its start frame.
   ///
   /// The completion closure will be called with `false`
   open func stop() {
-    self.lottieAnimationLayer.stop()
+    lottieAnimationLayer.stop()
   }
 
   /// Pauses the animation in its current state.
   ///
   /// The completion closure will be called with `false`
   open func pause() {
-    self.lottieAnimationLayer.pause()
+    lottieAnimationLayer.pause()
   }
 
   // MARK: Public
@@ -222,9 +232,9 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// since the Core Animation engine does not have any CPU overhead.
   public var backgroundBehavior: LottieBackgroundBehavior {
     get {
-      return lottieAnimationLayer.backgroundBehavior
+      lottieAnimationLayer.backgroundBehavior
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.backgroundBehavior = newValue
     }
   }
@@ -234,9 +244,9 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// be loaded up and set to the beginning of its timeline.
   public var animation: LottieAnimation? {
     get {
-      return lottieAnimationLayer.animation
+      lottieAnimationLayer.animation
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.animation = newValue
     }
   }
@@ -282,9 +292,9 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Setting this will cause the animation to reload its image contents.
   public var imageProvider: AnimationImageProvider {
     get {
-      return lottieAnimationLayer.imageProvider
+      lottieAnimationLayer.imageProvider
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.imageProvider = newValue
     }
   }
@@ -293,9 +303,9 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// animation with values for text layers
   public var textProvider: AnimationTextProvider {
     get {
-      return lottieAnimationLayer.textProvider
+      lottieAnimationLayer.textProvider
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.textProvider = newValue
     }
   }
@@ -304,41 +314,39 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// animation with values for text layers
   public var fontProvider: AnimationFontProvider {
     get {
-      return lottieAnimationLayer.fontProvider
+      lottieAnimationLayer.fontProvider
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.fontProvider = newValue
     }
   }
 
   /// Whether or not the animation is masked to the bounds. Defaults to true.
-  public var maskAnimationToBounds:Bool {
+  public var maskAnimationToBounds: Bool {
     get {
-      return lottieAnimationLayer.maskAnimationToBounds
+      lottieAnimationLayer.maskAnimationToBounds
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.maskAnimationToBounds = newValue
     }
   }
 
   /// Returns `true` if the animation is currently playing.
   public var isAnimationPlaying: Bool {
-    get {
-      return lottieAnimationLayer.isAnimationPlaying
-    }
+    lottieAnimationLayer.isAnimationPlaying
   }
 
   /// Returns `true` if the animation will start playing when this view is added to a window.
   public var isAnimationQueued: Bool {
-    self.lottieAnimationLayer.hasAnimationContext && waitingToPlayAnimation
+    lottieAnimationLayer.hasAnimationContext && waitingToPlayAnimation
   }
 
   /// Sets the loop behavior for `play` calls. Defaults to `playOnce`
   public var loopMode: LottieLoopMode {
     get {
-      return lottieAnimationLayer.loopMode
+      lottieAnimationLayer.loopMode
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.loopMode = newValue
     }
   }
@@ -351,9 +359,9 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Defaults to `false`
   public var shouldRasterizeWhenIdle: Bool {
     get {
-      return lottieAnimationLayer.shouldRasterizeWhenIdle
+      lottieAnimationLayer.shouldRasterizeWhenIdle
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.shouldRasterizeWhenIdle = newValue
     }
   }
@@ -364,9 +372,9 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Note 2: If `animation` is nil, setting this will fallback to 0
   public var currentProgress: AnimationProgressTime {
     get {
-      return lottieAnimationLayer.currentProgress
+      lottieAnimationLayer.currentProgress
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.currentProgress = newValue
     }
   }
@@ -377,9 +385,9 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Note 2: If `animation` is nil, setting this will fallback to 0
   public var currentTime: TimeInterval {
     get {
-      return lottieAnimationLayer.currentTime
+      lottieAnimationLayer.currentTime
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.currentTime = newValue
     }
   }
@@ -389,33 +397,29 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Note: Setting this will stop the current animation, if any.
   public var currentFrame: AnimationFrameTime {
     get {
-      return lottieAnimationLayer.currentFrame
+      lottieAnimationLayer.currentFrame
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.currentFrame = newValue
     }
   }
 
   /// Returns the current animation frame while an animation is playing.
   public var realtimeAnimationFrame: AnimationFrameTime {
-    get {
-      return lottieAnimationLayer.realtimeAnimationFrame
-    }
+    lottieAnimationLayer.realtimeAnimationFrame
   }
 
   /// Returns the current animation frame while an animation is playing.
   public var realtimeAnimationProgress: AnimationProgressTime {
-    get {
-      return lottieAnimationLayer.realtimeAnimationProgress
-    }
+    lottieAnimationLayer.realtimeAnimationProgress
   }
 
   /// Sets the speed of the animation playback. Defaults to 1
   public var animationSpeed: CGFloat {
     get {
-      return lottieAnimationLayer.animationSpeed
+      lottieAnimationLayer.animationSpeed
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.animationSpeed = newValue
     }
   }
@@ -427,9 +431,9 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Defaults to false
   public var respectAnimationFrameRate: Bool {
     get {
-      return lottieAnimationLayer.respectAnimationFrameRate
+      lottieAnimationLayer.respectAnimationFrameRate
     }
-    set (newValue) {
+    set(newValue) {
       lottieAnimationLayer.respectAnimationFrameRate = newValue
     }
   }
@@ -457,7 +461,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   override public var intrinsicContentSize: CGSize {
-    if let animation = self.lottieAnimationLayer.animation {
+    if let animation = lottieAnimationLayer.animation {
       return animation.bounds.size
     }
     return .zero
@@ -467,9 +471,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///  - This will only be `nil` in cases where the configuration is `automatic`
   ///    but a `RootAnimationLayer` hasn't been constructed yet
   public var currentRenderingEngine: RenderingEngine? {
-    get {
-      return lottieAnimationLayer.currentRenderingEngine
-    }
+    lottieAnimationLayer.currentRenderingEngine
   }
 
   /// Sets the lottie file backing the animation view. Setting this will clear the
@@ -485,17 +487,17 @@ open class LottieAnimationView: LottieAnimationViewBase {
     _ animationId: String? = nil,
     from dotLottieFile: DotLottieFile)
   {
-    self.lottieAnimationLayer.loadAnimation(animationId, from: dotLottieFile)
+    lottieAnimationLayer.loadAnimation(animationId, from: dotLottieFile)
   }
 
   /// Reloads the images supplied to the animation from the `imageProvider`
   public func reloadImages() {
-    self.lottieAnimationLayer.reloadImages()
+    lottieAnimationLayer.reloadImages()
   }
 
   /// Forces the LottieAnimationView to redraw its contents.
   public func forceDisplayUpdate() {
-    self.lottieAnimationLayer.forceDisplayUpdate()
+    lottieAnimationLayer.forceDisplayUpdate()
   }
 
   /// Sets a ValueProvider for the specified keypath. The value provider will be set
@@ -521,7 +523,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// animationView.setValueProvider(redValueProvider, keypath: fillKeypath)
   /// ```
   public func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath) {
-    self.lottieAnimationLayer.setValueProvider(valueProvider, keypath: keypath)
+    lottieAnimationLayer.setValueProvider(valueProvider, keypath: keypath)
   }
 
   /// Reads the value of a property specified by the Keypath.
@@ -530,7 +532,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter for: The keypath used to search for the property.
   /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.
   public func getValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any? {
-    self.lottieAnimationLayer.getValue(for: keypath, atFrame: atFrame)
+    lottieAnimationLayer.getValue(for: keypath, atFrame: atFrame)
   }
 
   /// Reads the original value of a property specified by the Keypath.
@@ -540,19 +542,19 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter for: The keypath used to search for the property.
   /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.
   public func getOriginalValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any? {
-    self.lottieAnimationLayer.getOriginalValue(for: keypath, atFrame: atFrame)
+    lottieAnimationLayer.getOriginalValue(for: keypath, atFrame: atFrame)
   }
 
   /// Logs all child keypaths.
   /// Logs the result of `allHierarchyKeypaths()` to the `LottieLogger`.
   public func logHierarchyKeypaths() {
-    self.lottieAnimationLayer.logHierarchyKeypaths()
+    lottieAnimationLayer.logHierarchyKeypaths()
   }
 
   /// Computes and returns a list of all child keypaths in the current animation.
   /// The returned list is the same as the log output of `logHierarchyKeypaths()`
   public func allHierarchyKeypaths() -> [String] {
-    self.lottieAnimationLayer.allHierarchyKeypaths()
+    lottieAnimationLayer.allHierarchyKeypaths()
   }
 
   /// Searches for the nearest child layer to the first Keypath and adds the subview
@@ -577,12 +579,12 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// animationView.addSubview(subview, forLayerAt: layerKeypath)
   /// ```
   public func addSubview(_ subview: AnimationSubview, forLayerAt keypath: AnimationKeypath) {
-    guard let sublayer = self.lottieAnimationLayer.animationLayer?.layer(for: keypath) else {
+    guard let sublayer = lottieAnimationLayer.animationLayer?.layer(for: keypath) else {
       return
     }
     setNeedsLayout()
     layoutIfNeeded()
-    self.lottieAnimationLayer.forceDisplayUpdate()
+    lottieAnimationLayer.forceDisplayUpdate()
     addSubview(subview)
     if let subViewLayer = subview.viewLayer {
       sublayer.addSublayer(subViewLayer)
@@ -597,7 +599,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter rect: The CGRect to convert.
   /// - Parameter toLayerAt: The keypath used to find the layer.
   public func convert(_ rect: CGRect, toLayerAt keypath: AnimationKeypath?) -> CGRect? {
-    let convertedRect = self.lottieAnimationLayer.convert(rect, toLayerAt: keypath)
+    let convertedRect = lottieAnimationLayer.convert(rect, toLayerAt: keypath)
     setNeedsLayout()
     layoutIfNeeded()
     return convertedRect
@@ -611,7 +613,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter point: The CGPoint to convert.
   /// - Parameter toLayerAt: The keypath used to find the layer.
   public func convert(_ point: CGPoint, toLayerAt keypath: AnimationKeypath?) -> CGPoint? {
-    let convertedRect = self.lottieAnimationLayer.convert(point, toLayerAt: keypath)
+    let convertedRect = lottieAnimationLayer.convert(point, toLayerAt: keypath)
     setNeedsLayout()
     layoutIfNeeded()
     return convertedRect
@@ -623,7 +625,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter isEnabled: When true the animator nodes affect the rendering tree. When false the node is removed from the tree.
   /// - Parameter keypath: The keypath used to find the node(s).
   public func setNodeIsEnabled(isEnabled: Bool, keypath: AnimationKeypath) {
-    self.lottieAnimationLayer.setNodeIsEnabled(isEnabled: isEnabled, keypath: keypath)
+    lottieAnimationLayer.setNodeIsEnabled(isEnabled: isEnabled, keypath: keypath)
   }
 
   /// Markers are a way to describe a point in time by a key name.
@@ -635,7 +637,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Returns the Progress Time for the marker named. Returns nil if no marker found.
   public func progressTime(forMarker named: String) -> AnimationProgressTime? {
-    return self.lottieAnimationLayer.progressTime(forMarker: named)
+    lottieAnimationLayer.progressTime(forMarker: named)
   }
 
   /// Markers are a way to describe a point in time by a key name.
@@ -647,7 +649,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Returns the Frame Time for the marker named. Returns nil if no marker found.
   public func frameTime(forMarker named: String) -> AnimationFrameTime? {
-    return self.lottieAnimationLayer.frameTime(forMarker: named)
+    lottieAnimationLayer.frameTime(forMarker: named)
   }
 
   /// Markers are a way to describe a point in time and a duration by a key name.
@@ -659,34 +661,51 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// - Returns: The duration frame time for the marker, or `nil` if no marker found.
   public func durationFrameTime(forMarker named: String) -> AnimationFrameTime? {
-    return self.lottieAnimationLayer.durationFrameTime(forMarker: named)
+    lottieAnimationLayer.durationFrameTime(forMarker: named)
   }
 
   // MARK: Internal
 
   var animationLayer: RootAnimationLayer? {
-    get {
-      return lottieAnimationLayer.animationLayer
-    }
+    lottieAnimationLayer.animationLayer
   }
 
   /// Set animation name from Interface Builder
   @IBInspectable var animationName: String? {
     didSet {
-      self.lottieAnimationLayer.animation = animationName.flatMap {        LottieAnimation.named($0, animationCache: nil)
+      self.lottieAnimationLayer.animation = animationName.flatMap { LottieAnimation.named($0, animationCache: nil)
       }
     }
   }
 
+  override func commonInit() {
+    super.commonInit()
+    lottieAnimationLayer.screenScale = screenScale
+
+    lottieAnimationLayer.animationLoaded = { [weak self] _, animation in
+      guard let self = self else { return }
+      self.animationLoaded?(self, animation)
+      self.invalidateIntrinsicContentSize()
+      self.setNeedsLayout()
+    }
+
+    lottieAnimationLayer.animationLayerWillLoad = { [weak self] lottieAnimationLayer, _ in
+      guard let self = self else { return }
+      self.invalidateIntrinsicContentSize()
+      self.setNeedsLayout()
+      lottieAnimationLayer.animationView = self
+    }
+  }
+
   override func layoutAnimation() {
-    guard let animation = self.lottieAnimationLayer.animation, let animationLayer = self.lottieAnimationLayer.animationLayer else { return }
+    guard let animation = lottieAnimationLayer.animation, let animationLayer = lottieAnimationLayer.animationLayer else { return }
 
     var position = animation.bounds.center
     let xform: CATransform3D
     var shouldForceUpdates = false
 
-    if let viewportFrame = self.viewportFrame {
-      self.setNeedsLayout()
+    if let viewportFrame = viewportFrame {
+      setNeedsLayout()
       shouldForceUpdates = contentMode == .redraw
 
       let compAspect = viewportFrame.size.width / viewportFrame.size.height
@@ -756,11 +775,11 @@ open class LottieAnimationView: LottieAnimationViewBase {
         position.y = bounds.maxY - animation.bounds.midY
         xform = CATransform3DIdentity
 
-#if os(iOS) || os(tvOS)
+      #if os(iOS) || os(tvOS)
       @unknown default:
         logger.assertionFailure("unsupported contentMode: \(contentMode.rawValue)")
         xform = CATransform3DIdentity
-#endif
+      #endif
       }
     }
 
@@ -770,7 +789,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     // If layout is changed without animation, explicitly set animation duration to 0.0
     // inside CATransaction to avoid unwanted artifacts.
     /// Check if any animation exist on the view's layer, and match it.
-    if let key = self.lottieAnimationLayer.animationKeys()?.first, let animation = self.lottieAnimationLayer.animation(forKey: key) {
+    if let key = lottieAnimationLayer.animationKeys()?.first, let animation = lottieAnimationLayer.animation(forKey: key) {
       // The layout is happening within an animation block. Grab the animation data.
 
       let positionKey = "LayoutPositionAnimation"
@@ -794,7 +813,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
       animationLayer.position = position
       animationLayer.transform = xform
-      animationLayer.anchorPoint = self.lottieAnimationLayer.anchorPoint
+      animationLayer.anchorPoint = lottieAnimationLayer.anchorPoint
       animationLayer.add(positionAnimation, forKey: positionKey)
       animationLayer.add(xformAnimation, forKey: transformKey)
     } else {
@@ -818,21 +837,21 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
     if shouldForceUpdates {
       animationLayer.forceDisplayUpdate()
-      self.lottieAnimationLayer.forceDisplayUpdate();
+      lottieAnimationLayer.forceDisplayUpdate();
     }
   }
 
   func updateRasterizationState() {
-    if self.lottieAnimationLayer.isAnimationPlaying {
-      self.lottieAnimationLayer.animationLayer?.shouldRasterize = false
+    if lottieAnimationLayer.isAnimationPlaying {
+      lottieAnimationLayer.animationLayer?.shouldRasterize = false
     } else {
-      self.lottieAnimationLayer.animationLayer?.shouldRasterize = self.lottieAnimationLayer.shouldRasterizeWhenIdle
+      lottieAnimationLayer.animationLayer?.shouldRasterize = lottieAnimationLayer.shouldRasterizeWhenIdle
     }
   }
 
   /// Updates the animation frame. Does not affect any current animations
   func updateAnimationFrame(_ newFrame: CGFloat) {
-    self.lottieAnimationLayer.updateAnimationFrame(newFrame)
+    lottieAnimationLayer.updateAnimationFrame(newFrame)
   }
 
   @objc
@@ -858,7 +877,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   func updateInFlightAnimation() {
-    self.lottieAnimationLayer.updateInFlightAnimation()
+    lottieAnimationLayer.updateInFlightAnimation()
   }
 
   // MARK: Fileprivate
@@ -866,7 +885,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   fileprivate var waitingToPlayAnimation = false
 
   fileprivate func updateAnimationForBackgroundState() {
-    self.lottieAnimationLayer.updateAnimationForBackgroundState()
+    lottieAnimationLayer.updateAnimationForBackgroundState()
   }
 
   fileprivate func updateAnimationForForegroundState() {
@@ -874,7 +893,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     if waitingToPlayAnimation {
       waitingToPlayAnimation = false;
     }
-    self.lottieAnimationLayer.updateAnimationForForegroundState(wasWaitingToPlayAnimation: wasWaitingToPlayAnimation)
+    lottieAnimationLayer.updateAnimationForForegroundState(wasWaitingToPlayAnimation: wasWaitingToPlayAnimation)
   }
 
   // MARK: Private

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -8,83 +8,6 @@
 import Foundation
 import QuartzCore
 
-// MARK: - LottieBackgroundBehavior
-
-/// Describes the behavior of an AnimationView when the app is moved to the background.
-public enum LottieBackgroundBehavior {
-  /// Stop the animation and reset it to the beginning of its current play time. The completion block is called.
-  case stop
-
-  /// Pause the animation in its current state. The completion block is called.
-  case pause
-
-  /// Pause the animation and restart it when the application moves to the foreground.
-  /// The completion block is stored and called when the animation completes.
-  ///  - This is the default when using the Main Thread rendering engine.
-  case pauseAndRestore
-
-  /// Stops the animation and sets it to the end of its current play time. The completion block is called.
-  case forceFinish
-
-  /// The animation continues playing in the background.
-  ///  - This is the default when using the Core Animation rendering engine.
-  ///    Playing an animation using the Core Animation engine doesn't come with any CPU overhead,
-  ///    so using `.continuePlaying` avoids the need to stop and then resume the animation
-  ///    (which does come with some CPU overhead).
-  ///  - This mode should not be used with the Main Thread rendering engine.
-  case continuePlaying
-
-  // MARK: Public
-
-  /// The default background behavior, based on the rendering engine being used to play the animation.
-  ///  - Playing an animation using the Main Thread rendering engine comes with CPU overhead,
-  ///    so the animation should be paused or stopped when the `LottieAnimationView` is not visible.
-  ///  - Playing an animation using the Core Animation rendering engine does not come with any
-  ///    CPU overhead, so these animations do not need to be paused in the background.
-  public static func `default`(for renderingEngine: RenderingEngine) -> LottieBackgroundBehavior {
-    switch renderingEngine {
-    case .mainThread:
-      return .pauseAndRestore
-    case .coreAnimation:
-      return .continuePlaying
-    }
-  }
-}
-
-// MARK: - LottieLoopMode
-
-/// Defines animation loop behavior
-public enum LottieLoopMode {
-  /// Animation is played once then stops.
-  case playOnce
-  /// Animation will loop from beginning to end until stopped.
-  case loop
-  /// Animation will play forward, then backwards and loop until stopped.
-  case autoReverse
-  /// Animation will loop from beginning to end up to defined amount of times.
-  case `repeat`(Float)
-  /// Animation will play forward, then backwards a defined amount of times.
-  case repeatBackwards(Float)
-}
-
-// MARK: Equatable
-
-extension LottieLoopMode: Equatable {
-  public static func == (lhs: LottieLoopMode, rhs: LottieLoopMode) -> Bool {
-    switch (lhs, rhs) {
-    case (.repeat(let lhsAmount), .repeat(let rhsAmount)),
-         (.repeatBackwards(let lhsAmount), .repeatBackwards(let rhsAmount)):
-      return lhsAmount == rhsAmount
-    case (.playOnce, .playOnce),
-         (.loop, .loop),
-         (.autoReverse, .autoReverse):
-      return true
-    default:
-      return false
-    }
-  }
-}
-
 // MARK: - LottieAnimationView
 
 @IBDesignable
@@ -103,18 +26,15 @@ open class LottieAnimationView: LottieAnimationViewBase {
     configuration: LottieConfiguration = .shared,
     logger: LottieLogger = .shared)
   {
-    self.animation = animation
-    self.imageProvider = imageProvider ?? BundleImageProvider(bundle: Bundle.main, searchPath: nil)
-    self.textProvider = textProvider
-    self.fontProvider = fontProvider
-    self.configuration = configuration
+    self.lottieAnimationLayer = LottieAnimationLayer(animation: animation, imageProvider: imageProvider, textProvider: textProvider, fontProvider: fontProvider, configuration: configuration, logger: logger)
     self.logger = logger
     super.init(frame: .zero)
     commonInit()
-    makeAnimationLayer(usingEngine: configuration.renderingEngine)
     if let animation = animation {
       frame = animation.bounds
     }
+    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    setNeedsLayout()
   }
 
   /// Initializes an AnimationView with a .lottie file.
@@ -126,56 +46,64 @@ open class LottieAnimationView: LottieAnimationViewBase {
     configuration: LottieConfiguration = .shared,
     logger: LottieLogger = .shared)
   {
-    let dotLottieAnimation = dotLottie?.animation(for: animationId)
-    animation = dotLottieAnimation?.animation
-    imageProvider = dotLottie?.imageProvider ?? BundleImageProvider(bundle: Bundle.main, searchPath: nil)
-    self.textProvider = textProvider
-    self.fontProvider = fontProvider
-    self.configuration = configuration
+    self.lottieAnimationLayer = LottieAnimationLayer(dotLottie: dotLottie, animationId: animationId, textProvider: textProvider, fontProvider: fontProvider, configuration: configuration, logger: logger)
     self.logger = logger
     super.init(frame: .zero)
     commonInit()
-    loopMode = dotLottieAnimation?.configuration.loopMode ?? .playOnce
-    animationSpeed = CGFloat(dotLottieAnimation?.configuration.speed ?? 1)
-    makeAnimationLayer(usingEngine: configuration.renderingEngine)
     if let animation = animation {
       frame = animation.bounds
     }
+    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    setNeedsLayout()
   }
 
   public init(
     configuration: LottieConfiguration = .shared,
     logger: LottieLogger = .shared)
   {
-    animation = nil
-    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
-    textProvider = DefaultTextProvider()
-    fontProvider = DefaultFontProvider()
-    self.configuration = configuration
+    self.lottieAnimationLayer = LottieAnimationLayer(configuration: configuration, logger: logger)
     self.logger = logger
     super.init(frame: .zero)
     commonInit()
+    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    setNeedsLayout()
   }
 
   public override init(frame: CGRect) {
-    animation = nil
-    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
-    textProvider = DefaultTextProvider()
-    fontProvider = DefaultFontProvider()
-    configuration = .shared
-    logger = .shared
+    self.lottieAnimationLayer = LottieAnimationLayer(animation: nil, imageProvider: BundleImageProvider(bundle: Bundle.main, searchPath: nil), textProvider: DefaultTextProvider(), fontProvider: DefaultFontProvider(), configuration: .shared, logger: .shared)
+    self.logger = .shared
     super.init(frame: frame)
     commonInit()
+    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    setNeedsLayout()
   }
 
   required public init?(coder aDecoder: NSCoder) {
-    imageProvider = BundleImageProvider(bundle: Bundle.main, searchPath: nil)
-    textProvider = DefaultTextProvider()
-    fontProvider = DefaultFontProvider()
-    configuration = .shared
-    logger = .shared
+    self.lottieAnimationLayer = LottieAnimationLayer(animation: nil, imageProvider: BundleImageProvider(bundle: Bundle.main, searchPath: nil), textProvider: DefaultTextProvider(), fontProvider: DefaultFontProvider(), configuration: .shared, logger: .shared)
+    self.logger = .shared
     super.init(coder: aDecoder)
     commonInit()
+    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    setNeedsLayout()
+  }
+
+  override func commonInit() {
+    super.commonInit()
+    self.lottieAnimationLayer.screenScale = self.screenScale
+
+    self.lottieAnimationLayer.animationLoaded = {[weak self] _, animation in
+      guard let self = self else { return }
+      self.animationLoaded?(self, animation)
+      self.invalidateIntrinsicContentSize()
+      self.setNeedsLayout()
+    }
+
+    self.lottieAnimationLayer.animationLayerWillLoad = {[weak self] lottieAnimationLayer, _ in
+      guard let self = self else { return }
+      self.invalidateIntrinsicContentSize()
+      self.setNeedsLayout()
+      lottieAnimationLayer.animationView = self
+    }
   }
 
   // MARK: Open
@@ -184,17 +112,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// - Parameter completion: An optional completion closure to be called when the animation completes playing.
   open func play(completion: LottieCompletionBlock? = nil) {
-    guard let animation = animation else {
-      return
-    }
-
-    /// Build a context for the animation.
-    let context = AnimationContext(
-      playFrom: CGFloat(animation.startFrame),
-      playTo: CGFloat(animation.endFrame),
-      closure: completion)
-    removeCurrentAnimationIfNecessary()
-    addNewAnimationForContext(context)
+    self.lottieAnimationLayer.play(completion: completion)
   }
 
   /// Plays the animation from a progress (0-1) to a progress (0-1).
@@ -209,20 +127,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    guard let animation = animation else {
-      return
-    }
-
-    removeCurrentAnimationIfNecessary()
-    if let loopMode = loopMode {
-      /// Set the loop mode, if one was supplied
-      self.loopMode = loopMode
-    }
-    let context = AnimationContext(
-      playFrom: animation.frameTime(forProgress: fromProgress ?? currentProgress),
-      playTo: animation.frameTime(forProgress: toProgress),
-      closure: completion)
-    addNewAnimationForContext(context)
+    self.lottieAnimationLayer.play(fromProgress: fromProgress, toProgress: toProgress, loopMode: loopMode, completion: completion)
   }
 
   /// Plays the animation from a start frame to an end frame in the animation's framerate.
@@ -237,17 +142,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    removeCurrentAnimationIfNecessary()
-    if let loopMode = loopMode {
-      /// Set the loop mode, if one was supplied
-      self.loopMode = loopMode
-    }
-
-    let context = AnimationContext(
-      playFrom: fromFrame ?? currentFrame,
-      playTo: toFrame,
-      closure: completion)
-    addNewAnimationForContext(context)
+    self.lottieAnimationLayer.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: loopMode, completion: completion)
   }
 
   /// Plays the animation from a named marker to another marker.
@@ -272,29 +167,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    guard let animation = animation, let markers = animation.markerMap, let to = markers[toMarker] else {
-      return
-    }
-
-    removeCurrentAnimationIfNecessary()
-    if let loopMode = loopMode {
-      /// Set the loop mode, if one was supplied
-      self.loopMode = loopMode
-    }
-
-    let fromTime: CGFloat
-    if let fromName = fromMarker, let from = markers[fromName] {
-      fromTime = CGFloat(from.frameTime)
-    } else {
-      fromTime = currentFrame
-    }
-
-    let playTo = playEndMarkerFrame ? CGFloat(to.frameTime) : CGFloat(to.frameTime) - 1
-    let context = AnimationContext(
-      playFrom: fromTime,
-      playTo: playTo,
-      closure: completion)
-    addNewAnimationForContext(context)
+    self.lottieAnimationLayer.play(fromMarker: fromMarker, toMarker: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode, completion: completion)
   }
 
   /// Plays the animation from a named marker to the end of the marker's duration.
@@ -312,36 +185,27 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    guard let from = animation?.markerMap?[marker] else {
-      return
-    }
-
-    play(
-      fromFrame: from.frameTime,
-      toFrame: from.frameTime + from.durationFrameTime,
-      loopMode: loopMode,
-      completion: completion)
+    self.lottieAnimationLayer.play(marker: marker, loopMode: loopMode, completion: completion)
   }
 
   /// Stops the animation and resets the view to its start frame.
   ///
   /// The completion closure will be called with `false`
   open func stop() {
-    removeCurrentAnimation()
-    currentFrame = 0
+    self.lottieAnimationLayer.stop()
   }
 
   /// Pauses the animation in its current state.
   ///
   /// The completion closure will be called with `false`
   open func pause() {
-    removeCurrentAnimation()
+    self.lottieAnimationLayer.pause()
   }
 
   // MARK: Public
 
-  /// The configuration that this `LottieAnimationView` uses when playing its animation
-  public let configuration: LottieConfiguration
+  // The backing CALayer for this animation view.
+  public var lottieAnimationLayer: LottieAnimationLayer;
 
   /// Value Providers that have been registered using `setValueProvider(_:keypath:)`
   public private(set) var valueProviders = [AnimationKeypath: AnyValueProvider]()
@@ -358,24 +222,10 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// since the Core Animation engine does not have any CPU overhead.
   public var backgroundBehavior: LottieBackgroundBehavior {
     get {
-      let currentBackgroundBehavior = _backgroundBehavior ?? .default(for: currentRenderingEngine ?? .mainThread)
-
-      if
-        currentRenderingEngine == .mainThread,
-        _backgroundBehavior == .continuePlaying
-      {
-        logger.assertionFailure("""
-          `LottieBackgroundBehavior.continuePlaying` should not be used with the Main Thread
-          rendering engine, since this would waste CPU resources on playing an animation
-          that is not visible. Consider using a different background mode, or switching to
-          the Core Animation rendering engine (which does not have any CPU overhead).
-          """)
-      }
-
-      return currentBackgroundBehavior
+      return lottieAnimationLayer.backgroundBehavior
     }
-    set {
-      _backgroundBehavior = newValue
+    set (newValue) {
+      lottieAnimationLayer.backgroundBehavior = newValue
     }
   }
 
@@ -383,12 +233,11 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// view's contents, completion blocks and current state. The new animation will
   /// be loaded up and set to the beginning of its timeline.
   public var animation: LottieAnimation? {
-    didSet {
-      makeAnimationLayer(usingEngine: configuration.renderingEngine)
-
-      if let animation = animation {
-        animationLoaded?(self, animation)
-      }
+    get {
+      return lottieAnimationLayer.animation
+    }
+    set (newValue) {
+      lottieAnimationLayer.animation = newValue
     }
   }
 
@@ -432,57 +281,65 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Setting this will cause the animation to reload its image contents.
   public var imageProvider: AnimationImageProvider {
-    didSet {
-      animationLayer?.imageProvider = imageProvider.cachedImageProvider
-      reloadImages()
+    get {
+      return lottieAnimationLayer.imageProvider
+    }
+    set (newValue) {
+      lottieAnimationLayer.imageProvider = newValue
     }
   }
 
   /// Sets the text provider for animation view. A text provider provides the
   /// animation with values for text layers
   public var textProvider: AnimationTextProvider {
-    didSet {
-      animationLayer?.textProvider = textProvider
+    get {
+      return lottieAnimationLayer.textProvider
+    }
+    set (newValue) {
+      lottieAnimationLayer.textProvider = newValue
     }
   }
 
   /// Sets the text provider for animation view. A text provider provides the
   /// animation with values for text layers
   public var fontProvider: AnimationFontProvider {
-    didSet {
-      animationLayer?.fontProvider = fontProvider
+    get {
+      return lottieAnimationLayer.fontProvider
+    }
+    set (newValue) {
+      lottieAnimationLayer.fontProvider = newValue
     }
   }
 
   /// Whether or not the animation is masked to the bounds. Defaults to true.
-  public var maskAnimationToBounds = true {
-    didSet {
-      animationLayer?.masksToBounds = maskAnimationToBounds
+  public var maskAnimationToBounds:Bool {
+    get {
+      return lottieAnimationLayer.maskAnimationToBounds
+    }
+    set (newValue) {
+      lottieAnimationLayer.maskAnimationToBounds = newValue
     }
   }
 
   /// Returns `true` if the animation is currently playing.
   public var isAnimationPlaying: Bool {
-    guard let animationLayer = animationLayer else {
-      return false
-    }
-
-    if let valueFromLayer = animationLayer.isAnimationPlaying {
-      return valueFromLayer
-    } else {
-      return animationLayer.animation(forKey: activeAnimationName) != nil
+    get {
+      return lottieAnimationLayer.isAnimationPlaying
     }
   }
 
   /// Returns `true` if the animation will start playing when this view is added to a window.
   public var isAnimationQueued: Bool {
-    animationContext != nil && waitingToPlayAnimation
+    self.lottieAnimationLayer.hasAnimationContext && waitingToPlayAnimation
   }
 
   /// Sets the loop behavior for `play` calls. Defaults to `playOnce`
-  public var loopMode: LottieLoopMode = .playOnce {
-    didSet {
-      updateInFlightAnimation()
+  public var loopMode: LottieLoopMode {
+    get {
+      return lottieAnimationLayer.loopMode
+    }
+    set (newValue) {
+      lottieAnimationLayer.loopMode = newValue
     }
   }
 
@@ -492,9 +349,12 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Note: this will not produce crisp results at resolutions above the animations natural resolution.
   ///
   /// Defaults to `false`
-  public var shouldRasterizeWhenIdle = false {
-    didSet {
-      updateRasterizationState()
+  public var shouldRasterizeWhenIdle: Bool {
+    get {
+      return lottieAnimationLayer.shouldRasterizeWhenIdle
+    }
+    set (newValue) {
+      lottieAnimationLayer.shouldRasterizeWhenIdle = newValue
     }
   }
 
@@ -503,19 +363,11 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Note: Setting this will stop the current animation, if any.
   /// Note 2: If `animation` is nil, setting this will fallback to 0
   public var currentProgress: AnimationProgressTime {
-    set {
-      if let animation = animation {
-        currentFrame = animation.frameTime(forProgress: newValue)
-      } else {
-        currentFrame = 0
-      }
-    }
     get {
-      if let animation = animation {
-        return animation.progressTime(forFrame: currentFrame)
-      } else {
-        return 0
-      }
+      return lottieAnimationLayer.currentProgress
+    }
+    set (newValue) {
+      lottieAnimationLayer.currentProgress = newValue
     }
   }
 
@@ -524,19 +376,11 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Note: Setting this will stop the current animation, if any.
   /// Note 2: If `animation` is nil, setting this will fallback to 0
   public var currentTime: TimeInterval {
-    set {
-      if let animation = animation {
-        currentFrame = animation.frameTime(forTime: newValue)
-      } else {
-        currentFrame = 0
-      }
-    }
     get {
-      if let animation = animation {
-        return animation.time(forFrame: currentFrame)
-      } else {
-        return 0
-      }
+      return lottieAnimationLayer.currentTime
+    }
+    set (newValue) {
+      lottieAnimationLayer.currentTime = newValue
     }
   }
 
@@ -544,32 +388,35 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Note: Setting this will stop the current animation, if any.
   public var currentFrame: AnimationFrameTime {
-    set {
-      removeCurrentAnimationIfNecessary()
-      updateAnimationFrame(newValue)
-    }
     get {
-      animationLayer?.currentFrame ?? 0
+      return lottieAnimationLayer.currentFrame
+    }
+    set (newValue) {
+      lottieAnimationLayer.currentFrame = newValue
     }
   }
 
   /// Returns the current animation frame while an animation is playing.
   public var realtimeAnimationFrame: AnimationFrameTime {
-    isAnimationPlaying ? animationLayer?.presentation()?.currentFrame ?? currentFrame : currentFrame
+    get {
+      return lottieAnimationLayer.realtimeAnimationFrame
+    }
   }
 
   /// Returns the current animation frame while an animation is playing.
   public var realtimeAnimationProgress: AnimationProgressTime {
-    if let animation = animation {
-      return animation.progressTime(forFrame: realtimeAnimationFrame)
+    get {
+      return lottieAnimationLayer.realtimeAnimationProgress
     }
-    return 0
   }
 
   /// Sets the speed of the animation playback. Defaults to 1
-  public var animationSpeed: CGFloat = 1 {
-    didSet {
-      updateInFlightAnimation()
+  public var animationSpeed: CGFloat {
+    get {
+      return lottieAnimationLayer.animationSpeed
+    }
+    set (newValue) {
+      lottieAnimationLayer.animationSpeed = newValue
     }
   }
 
@@ -578,9 +425,12 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// of the device.
   ///
   /// Defaults to false
-  public var respectAnimationFrameRate = false {
-    didSet {
-      animationLayer?.respectAnimationFrameRate = respectAnimationFrameRate
+  public var respectAnimationFrameRate: Bool {
+    get {
+      return lottieAnimationLayer.respectAnimationFrameRate
+    }
+    set (newValue) {
+      lottieAnimationLayer.respectAnimationFrameRate = newValue
     }
   }
 
@@ -589,7 +439,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// in the animation's coordinate space.
   ///
   /// Animatable.
-  public var viewportFrame: CGRect? = nil {
+  public var viewportFrame: CGRect? {
     didSet {
       // This is really ugly, but is needed to trigger a layout pass within an animation block.
       // Typically this happens automatically, when layout objects are UIView based.
@@ -607,7 +457,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   override public var intrinsicContentSize: CGSize {
-    if let animation = animation {
+    if let animation = self.lottieAnimationLayer.animation {
       return animation.bounds.size
     }
     return .zero
@@ -617,20 +467,8 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///  - This will only be `nil` in cases where the configuration is `automatic`
   ///    but a `RootAnimationLayer` hasn't been constructed yet
   public var currentRenderingEngine: RenderingEngine? {
-    switch configuration.renderingEngine {
-    case .specific(let engine):
-      return engine
-
-    case .automatic:
-      guard let animationLayer = animationLayer else {
-        return nil
-      }
-
-      if animationLayer is CoreAnimationLayer {
-        return .coreAnimation
-      } else {
-        return .mainThread
-      }
+    get {
+      return lottieAnimationLayer.currentRenderingEngine
     }
   }
 
@@ -647,26 +485,17 @@ open class LottieAnimationView: LottieAnimationViewBase {
     _ animationId: String? = nil,
     from dotLottieFile: DotLottieFile)
   {
-    guard let dotLottieAnimation = dotLottieFile.animation(for: animationId) else { return }
-
-    loopMode = dotLottieAnimation.configuration.loopMode
-    animationSpeed = CGFloat(dotLottieAnimation.configuration.speed)
-
-    if let imageProvider = dotLottieAnimation.configuration.imageProvider {
-      self.imageProvider = imageProvider
-    }
-
-    animation = dotLottieAnimation.animation
+    self.lottieAnimationLayer.loadAnimation(animationId, from: dotLottieFile)
   }
 
   /// Reloads the images supplied to the animation from the `imageProvider`
   public func reloadImages() {
-    animationLayer?.reloadImages()
+    self.lottieAnimationLayer.reloadImages()
   }
 
   /// Forces the LottieAnimationView to redraw its contents.
   public func forceDisplayUpdate() {
-    animationLayer?.forceDisplayUpdate()
+    self.lottieAnimationLayer.forceDisplayUpdate()
   }
 
   /// Sets a ValueProvider for the specified keypath. The value provider will be set
@@ -692,10 +521,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// animationView.setValueProvider(redValueProvider, keypath: fillKeypath)
   /// ```
   public func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath) {
-    guard let animationLayer = animationLayer else { return }
-
-    valueProviders[keypath] = valueProvider
-    animationLayer.setValueProvider(valueProvider, keypath: keypath)
+    self.lottieAnimationLayer.setValueProvider(valueProvider, keypath: keypath)
   }
 
   /// Reads the value of a property specified by the Keypath.
@@ -704,7 +530,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter for: The keypath used to search for the property.
   /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.
   public func getValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any? {
-    animationLayer?.getValue(for: keypath, atFrame: atFrame)
+    self.lottieAnimationLayer.getValue(for: keypath, atFrame: atFrame)
   }
 
   /// Reads the original value of a property specified by the Keypath.
@@ -714,19 +540,19 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter for: The keypath used to search for the property.
   /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.
   public func getOriginalValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any? {
-    animationLayer?.getOriginalValue(for: keypath, atFrame: atFrame)
+    self.lottieAnimationLayer.getOriginalValue(for: keypath, atFrame: atFrame)
   }
 
   /// Logs all child keypaths.
   /// Logs the result of `allHierarchyKeypaths()` to the `LottieLogger`.
   public func logHierarchyKeypaths() {
-    animationLayer?.logHierarchyKeypaths()
+    self.lottieAnimationLayer.logHierarchyKeypaths()
   }
 
   /// Computes and returns a list of all child keypaths in the current animation.
   /// The returned list is the same as the log output of `logHierarchyKeypaths()`
   public func allHierarchyKeypaths() -> [String] {
-    animationLayer?.allHierarchyKeypaths() ?? []
+    self.lottieAnimationLayer.allHierarchyKeypaths()
   }
 
   /// Searches for the nearest child layer to the first Keypath and adds the subview
@@ -751,12 +577,12 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// animationView.addSubview(subview, forLayerAt: layerKeypath)
   /// ```
   public func addSubview(_ subview: AnimationSubview, forLayerAt keypath: AnimationKeypath) {
-    guard let sublayer = animationLayer?.layer(for: keypath) else {
+    guard let sublayer = self.lottieAnimationLayer.animationLayer?.layer(for: keypath) else {
       return
     }
     setNeedsLayout()
     layoutIfNeeded()
-    forceDisplayUpdate()
+    self.lottieAnimationLayer.forceDisplayUpdate()
     addSubview(subview)
     if let subViewLayer = subview.viewLayer {
       sublayer.addSublayer(subViewLayer)
@@ -771,17 +597,10 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter rect: The CGRect to convert.
   /// - Parameter toLayerAt: The keypath used to find the layer.
   public func convert(_ rect: CGRect, toLayerAt keypath: AnimationKeypath?) -> CGRect? {
-    guard let animationLayer = animationLayer else { return nil }
-    guard let keypath = keypath else {
-      return viewLayer?.convert(rect, to: animationLayer)
-    }
-    guard let sublayer = animationLayer.layer(for: keypath) else {
-      return nil
-    }
+    let convertedRect = self.lottieAnimationLayer.convert(rect, toLayerAt: keypath)
     setNeedsLayout()
     layoutIfNeeded()
-    forceDisplayUpdate()
-    return animationLayer.convert(rect, to: sublayer)
+    return convertedRect
   }
 
   /// Converts a CGPoint from the LottieAnimationView's coordinate space into the
@@ -792,17 +611,10 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter point: The CGPoint to convert.
   /// - Parameter toLayerAt: The keypath used to find the layer.
   public func convert(_ point: CGPoint, toLayerAt keypath: AnimationKeypath?) -> CGPoint? {
-    guard let animationLayer = animationLayer else { return nil }
-    guard let keypath = keypath else {
-      return viewLayer?.convert(point, to: animationLayer)
-    }
-    guard let sublayer = animationLayer.layer(for: keypath) else {
-      return nil
-    }
+    let convertedRect = self.lottieAnimationLayer.convert(point, toLayerAt: keypath)
     setNeedsLayout()
     layoutIfNeeded()
-    forceDisplayUpdate()
-    return animationLayer.convert(point, to: sublayer)
+    return convertedRect
   }
 
   /// Sets the enabled state of all animator nodes found with the keypath search.
@@ -811,14 +623,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter isEnabled: When true the animator nodes affect the rendering tree. When false the node is removed from the tree.
   /// - Parameter keypath: The keypath used to find the node(s).
   public func setNodeIsEnabled(isEnabled: Bool, keypath: AnimationKeypath) {
-    guard let animationLayer = animationLayer else { return }
-    let nodes = animationLayer.animatorNodes(for: keypath)
-    if let nodes = nodes {
-      for node in nodes {
-        node.isEnabled = isEnabled
-      }
-      forceDisplayUpdate()
-    }
+    self.lottieAnimationLayer.setNodeIsEnabled(isEnabled: isEnabled, keypath: keypath)
   }
 
   /// Markers are a way to describe a point in time by a key name.
@@ -830,10 +635,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Returns the Progress Time for the marker named. Returns nil if no marker found.
   public func progressTime(forMarker named: String) -> AnimationProgressTime? {
-    guard let animation = animation else {
-      return nil
-    }
-    return animation.progressTime(forMarker: named)
+    return self.lottieAnimationLayer.progressTime(forMarker: named)
   }
 
   /// Markers are a way to describe a point in time by a key name.
@@ -845,10 +647,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Returns the Frame Time for the marker named. Returns nil if no marker found.
   public func frameTime(forMarker named: String) -> AnimationFrameTime? {
-    guard let animation = animation else {
-      return nil
-    }
-    return animation.frameTime(forMarker: named)
+    return self.lottieAnimationLayer.frameTime(forMarker: named)
   }
 
   /// Markers are a way to describe a point in time and a duration by a key name.
@@ -860,32 +659,34 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// - Returns: The duration frame time for the marker, or `nil` if no marker found.
   public func durationFrameTime(forMarker named: String) -> AnimationFrameTime? {
-    guard let animation = animation else {
-      return nil
-    }
-    return animation.durationFrameTime(forMarker: named)
+    return self.lottieAnimationLayer.durationFrameTime(forMarker: named)
   }
 
   // MARK: Internal
 
-  var animationLayer: RootAnimationLayer? = nil
+  var animationLayer: RootAnimationLayer? {
+    get {
+      return lottieAnimationLayer.animationLayer
+    }
+  }
 
   /// Set animation name from Interface Builder
   @IBInspectable var animationName: String? {
     didSet {
-      self.animation = animationName.flatMap {
-        LottieAnimation.named($0, animationCache: nil)
+      self.lottieAnimationLayer.animation = animationName.flatMap {        LottieAnimation.named($0, animationCache: nil)
       }
     }
   }
 
   override func layoutAnimation() {
-    guard let animation = animation, let animationLayer = animationLayer else { return }
+    guard let animation = self.lottieAnimationLayer.animation, let animationLayer = self.lottieAnimationLayer.animationLayer else { return }
+
     var position = animation.bounds.center
     let xform: CATransform3D
     var shouldForceUpdates = false
 
-    if let viewportFrame = viewportFrame {
+    if let viewportFrame = self.viewportFrame {
+      self.setNeedsLayout()
       shouldForceUpdates = contentMode == .redraw
 
       let compAspect = viewportFrame.size.width / viewportFrame.size.height
@@ -955,11 +756,11 @@ open class LottieAnimationView: LottieAnimationViewBase {
         position.y = bounds.maxY - animation.bounds.midY
         xform = CATransform3DIdentity
 
-      #if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS)
       @unknown default:
         logger.assertionFailure("unsupported contentMode: \(contentMode.rawValue)")
         xform = CATransform3DIdentity
-      #endif
+#endif
       }
     }
 
@@ -969,7 +770,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     // If layout is changed without animation, explicitly set animation duration to 0.0
     // inside CATransaction to avoid unwanted artifacts.
     /// Check if any animation exist on the view's layer, and match it.
-    if let key = viewLayer?.animationKeys()?.first, let animation = viewLayer?.animation(forKey: key) {
+    if let key = self.lottieAnimationLayer.animationKeys()?.first, let animation = self.lottieAnimationLayer.animation(forKey: key) {
       // The layout is happening within an animation block. Grab the animation data.
 
       let positionKey = "LayoutPositionAnimation"
@@ -993,11 +794,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
       animationLayer.position = position
       animationLayer.transform = xform
-      #if os(OSX)
-      animationLayer.anchorPoint = layer?.anchorPoint ?? CGPoint.zero
-      #else
-      animationLayer.anchorPoint = layer.anchorPoint
-      #endif
+      animationLayer.anchorPoint = self.lottieAnimationLayer.anchorPoint
       animationLayer.add(positionAnimation, forKey: positionKey)
       animationLayer.add(xformAnimation, forKey: transformKey)
     } else {
@@ -1021,37 +818,21 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
     if shouldForceUpdates {
       animationLayer.forceDisplayUpdate()
+      self.lottieAnimationLayer.forceDisplayUpdate();
     }
   }
 
   func updateRasterizationState() {
-    if isAnimationPlaying {
-      animationLayer?.shouldRasterize = false
+    if self.lottieAnimationLayer.isAnimationPlaying {
+      self.lottieAnimationLayer.animationLayer?.shouldRasterize = false
     } else {
-      animationLayer?.shouldRasterize = shouldRasterizeWhenIdle
+      self.lottieAnimationLayer.animationLayer?.shouldRasterize = self.lottieAnimationLayer.shouldRasterizeWhenIdle
     }
   }
 
   /// Updates the animation frame. Does not affect any current animations
   func updateAnimationFrame(_ newFrame: CGFloat) {
-    // In performance tests, we have to wrap the animation view setup
-    // in a `CATransaction` in order for the layers to be deallocated at
-    // the correct time. The `CATransaction`s in this method interfere
-    // with the ones managed by the performance test, and aren't actually
-    // necessary in a headless environment, so we disable them.
-    if TestHelpers.performanceTestsAreRunning {
-      animationLayer?.currentFrame = newFrame
-      animationLayer?.forceDisplayUpdate()
-      return
-    }
-
-    CATransaction.begin()
-    CATransaction.setCompletionBlock {
-      self.animationLayer?.forceDisplayUpdate()
-    }
-    CATransaction.setDisableActions(true)
-    animationLayer?.currentFrame = newFrame
-    CATransaction.commit()
+    self.lottieAnimationLayer.updateAnimationFrame(newFrame)
   }
 
   @objc
@@ -1076,438 +857,27 @@ open class LottieAnimationView: LottieAnimationViewBase {
     }
   }
 
-  /// Updates an in flight animation.
   func updateInFlightAnimation() {
-    guard let animationContext = animationContext else { return }
-
-    guard animationContext.closure.animationState != .complete else {
-      // Tried to re-add an already completed animation. Cancel.
-      self.animationContext = nil
-      return
-    }
-
-    /// Tell existing context to ignore its closure
-    animationContext.closure.ignoreDelegate = true
-
-    /// Make a new context, stealing the completion block from the previous.
-    let newContext = AnimationContext(
-      playFrom: animationContext.playFrom,
-      playTo: animationContext.playTo,
-      closure: animationContext.closure.completionBlock)
-
-    /// Remove current animation, and freeze the current frame.
-    let pauseFrame = realtimeAnimationFrame
-    animationLayer?.removeAnimation(forKey: activeAnimationName)
-    animationLayer?.currentFrame = pauseFrame
-
-    addNewAnimationForContext(newContext)
+    self.lottieAnimationLayer.updateInFlightAnimation()
   }
 
   // MARK: Fileprivate
 
-  /// Context describing the animation that is currently playing in this `LottieAnimationView`
-  ///  - When non-nil, an animation is currently playing in this view. Otherwise,
-  ///    the view is paused on a specific frame.
-  fileprivate var animationContext: AnimationContext?
-
-  fileprivate var _activeAnimationName: String = LottieAnimationView.animationName
-  fileprivate var animationID = 0
-
   fileprivate var waitingToPlayAnimation = false
 
-  fileprivate var activeAnimationName: String {
-    switch animationLayer?.primaryAnimationKey {
-    case .specific(let animationKey):
-      return animationKey
-    case .managed, nil:
-      return _activeAnimationName
-    }
-  }
-
-  fileprivate func makeAnimationLayer(usingEngine renderingEngine: RenderingEngineOption) {
-    /// Remove current animation if any
-    removeCurrentAnimation()
-
-    if let oldAnimation = animationLayer {
-      oldAnimation.removeFromSuperlayer()
-      animationLayer = nil
-    }
-
-    invalidateIntrinsicContentSize()
-
-    guard let animation = animation else {
-      return
-    }
-
-    let rootAnimationLayer: RootAnimationLayer?
-    switch renderingEngine {
-    case .automatic:
-      rootAnimationLayer = makeAutomaticEngineLayer(for: animation)
-    case .specific(.coreAnimation):
-      rootAnimationLayer = makeCoreAnimationLayer(for: animation)
-    case .specific(.mainThread):
-      rootAnimationLayer = makeMainThreadAnimationLayer(for: animation)
-    }
-
-    guard let animationLayer = rootAnimationLayer else {
-      return
-    }
-
-    animationLayer.animationView = self
-    animationLayer.renderScale = screenScale
-
-    viewLayer?.addSublayer(animationLayer)
-    self.animationLayer = animationLayer
-    reloadImages()
-    animationLayer.setNeedsDisplay()
-    setNeedsLayout()
-    currentFrame = CGFloat(animation.startFrame)
-  }
-
-  fileprivate func makeMainThreadAnimationLayer(for animation: LottieAnimation) -> MainThreadAnimationLayer {
-    MainThreadAnimationLayer(
-      animation: animation,
-      imageProvider: imageProvider.cachedImageProvider,
-      textProvider: textProvider,
-      fontProvider: fontProvider,
-      maskAnimationToBounds: maskAnimationToBounds,
-      logger: logger)
-  }
-
-  fileprivate func makeCoreAnimationLayer(for animation: LottieAnimation) -> CoreAnimationLayer? {
-    do {
-      let coreAnimationLayer = try CoreAnimationLayer(
-        animation: animation,
-        imageProvider: imageProvider.cachedImageProvider,
-        textProvider: textProvider,
-        fontProvider: fontProvider,
-        maskAnimationToBounds: maskAnimationToBounds,
-        compatibilityTrackerMode: .track,
-        logger: logger)
-
-      coreAnimationLayer.didSetUpAnimation = { [logger] compatibilityIssues in
-        logger.assert(
-          compatibilityIssues.isEmpty,
-          "Encountered Core Animation compatibility issues while setting up animation:\n"
-            + compatibilityIssues.map { $0.description }.joined(separator: "\n") + "\n\n"
-            + """
-              This animation cannot be rendered correctly by the Core Animation engine.
-              To resolve this issue, you can use `RenderingEngineOption.automatic`, which automatically falls back
-              to the Main Thread rendering engine when necessary, or just use `RenderingEngineOption.mainThread`.
-
-              """)
-      }
-
-      return coreAnimationLayer
-    } catch {
-      // This should never happen, because we initialize the `CoreAnimationLayer` with
-      // `CompatibilityTracker.Mode.track` (which reports errors in `didSetUpAnimation`,
-      // not by throwing).
-      logger.assertionFailure("Encountered unexpected error \(error)")
-      return nil
-    }
-  }
-
-  fileprivate func makeAutomaticEngineLayer(for animation: LottieAnimation) -> CoreAnimationLayer? {
-    do {
-      // Attempt to set up the Core Animation layer. This can either throw immediately in `init`,
-      // or throw an error later in `CALayer.display()` that will be reported in `didSetUpAnimation`.
-      let coreAnimationLayer = try CoreAnimationLayer(
-        animation: animation,
-        imageProvider: imageProvider.cachedImageProvider,
-        textProvider: textProvider,
-        fontProvider: fontProvider,
-        maskAnimationToBounds: maskAnimationToBounds,
-        compatibilityTrackerMode: .abort,
-        logger: logger)
-
-      coreAnimationLayer.didSetUpAnimation = { [weak self] issues in
-        self?.automaticEngineLayerDidSetUpAnimation(issues)
-      }
-
-      return coreAnimationLayer
-    } catch {
-      if case CompatibilityTracker.Error.encounteredCompatibilityIssue(let compatibilityIssue) = error {
-        automaticEngineLayerDidSetUpAnimation([compatibilityIssue])
-      } else {
-        // This should never happen, because we expect `CoreAnimationLayer` to only throw
-        // `CompatibilityTracker.Error.encounteredCompatibilityIssue` errors.
-        logger.assertionFailure("Encountered unexpected error \(error)")
-        automaticEngineLayerDidSetUpAnimation([])
-      }
-
-      return nil
-    }
-  }
-
-  // Handles any compatibility issues with the Core Animation engine
-  // by falling back to the Main Thread engine
-  fileprivate func automaticEngineLayerDidSetUpAnimation(_ compatibilityIssues: [CompatibilityIssue]) {
-    // If there weren't any compatibility issues, then there's nothing else to do
-    if compatibilityIssues.isEmpty {
-      return
-    }
-
-    logger.warn(
-      "Encountered Core Animation compatibility issue while setting up animation:\n"
-        + compatibilityIssues.map { $0.description }.joined(separator: "\n") + "\n"
-        + """
-          This animation may have additional compatibility issues, but animation setup was cancelled early to avoid wasted work.
-
-          Automatically falling back to Main Thread rendering engine. This fallback comes with some additional performance
-          overhead, which can be reduced by manually specifying that this animation should always use the Main Thread engine.
-
-          """)
-
-    let animationContext = animationContext
-    let currentFrame = currentFrame
-
-    // Disable the completion handler delegate before tearing down the `CoreAnimationLayer`
-    // and building the `MainThreadAnimationLayer`. Otherwise deinitializing the
-    // `CoreAnimationLayer` would trigger the animation completion handler even though
-    // the animation hasn't even started playing yet.
-    animationContext?.closure.ignoreDelegate = true
-
-    makeAnimationLayer(usingEngine: .mainThread)
-
-    // Set up the Main Thread animation layer using the same configuration that
-    // was being used by the previous Core Animation layer
-    self.currentFrame = currentFrame
-
-    if let animationContext = animationContext {
-      // `AnimationContext.closure` (`AnimationCompletionDelegate`) is a reference type
-      // that is the animation layer's `CAAnimationDelegate`, and holds a reference to
-      // the animation layer. Reusing a single instance across different animation layers
-      // can cause the animation setup to fail, so we create a copy of the `animationContext`:
-      addNewAnimationForContext(AnimationContext(
-        playFrom: animationContext.playFrom,
-        playTo: animationContext.playTo,
-        closure: animationContext.closure.completionBlock))
-    }
-  }
-
   fileprivate func updateAnimationForBackgroundState() {
-    if let currentContext = animationContext {
-      switch backgroundBehavior {
-      case .stop:
-        removeCurrentAnimation()
-        updateAnimationFrame(currentContext.playFrom)
-      case .pause:
-        removeCurrentAnimation()
-      case .pauseAndRestore:
-        currentContext.closure.ignoreDelegate = true
-        removeCurrentAnimation()
-        /// Keep the stale context around for when the app enters the foreground.
-        animationContext = currentContext
-      case .forceFinish:
-        removeCurrentAnimation()
-        updateAnimationFrame(currentContext.playTo)
-      case .continuePlaying:
-        break
-      }
-    }
+    self.lottieAnimationLayer.updateAnimationForBackgroundState()
   }
 
   fileprivate func updateAnimationForForegroundState() {
-    if let currentContext = animationContext {
-      if waitingToPlayAnimation {
-        waitingToPlayAnimation = false
-        addNewAnimationForContext(currentContext)
-      } else if backgroundBehavior == .pauseAndRestore {
-        /// Restore animation from saved state
-        updateInFlightAnimation()
-      }
+    let wasWaitingToPlayAnimation = waitingToPlayAnimation;
+    if waitingToPlayAnimation {
+      waitingToPlayAnimation = false;
     }
-  }
-
-  /// Removes the current animation and pauses the animation at the current frame
-  /// if necessary before setting up a new animation.
-  ///  - This is not necessary with the Core Animation engine, and skipping
-  ///    this step lets us avoid building the animations twice (once paused
-  ///    and once again playing)
-  ///  - This method should only be called immediately before setting up another
-  ///    animation -- otherwise this LottieAnimationView could be put in an inconsistent state.
-  fileprivate func removeCurrentAnimationIfNecessary() {
-    switch currentRenderingEngine {
-    case .mainThread:
-      removeCurrentAnimation()
-    case .coreAnimation, nil:
-      // We still need to remove the `animationContext`, since it should only be present
-      // when an animation is actually playing. Without this calling `removeCurrentAnimationIfNecessary()`
-      // and then setting the animation to a specific paused frame would put this
-      // `LottieAnimationView` in an inconsistent state.
-      animationContext = nil
-    }
-  }
-
-  /// Stops the current in flight animation and freezes the animation in its current state.
-  fileprivate func removeCurrentAnimation() {
-    guard animationContext != nil else { return }
-    let pauseFrame = realtimeAnimationFrame
-    animationLayer?.removeAnimation(forKey: activeAnimationName)
-    updateAnimationFrame(pauseFrame)
-    animationContext = nil
-  }
-
-  /// Adds animation to animation layer and sets the delegate. If animation layer or animation are nil, exits.
-  fileprivate func addNewAnimationForContext(_ animationContext: AnimationContext) {
-    guard let animationlayer = animationLayer, let animation = animation else {
-      return
-    }
-
-    self.animationContext = animationContext
-
-    switch currentRenderingEngine {
-    case .mainThread:
-      guard window != nil else {
-        waitingToPlayAnimation = true
-        return
-      }
-
-    case .coreAnimation, nil:
-      // The Core Animation engine automatically batches animation setup to happen
-      // in `CALayer.display()`, which won't be called until the layer is on-screen,
-      // so we don't need to defer animation setup at this layer.
-      break
-    }
-
-    animationID = animationID + 1
-    _activeAnimationName = LottieAnimationView.animationName + String(animationID)
-
-    if let coreAnimationLayer = animationlayer as? CoreAnimationLayer {
-      var animationContext = animationContext
-
-      // Core Animation doesn't natively support negative speed values,
-      // so instead we can swap `playFrom` / `playTo`
-      if animationSpeed < 0 {
-        let temp = animationContext.playFrom
-        animationContext.playFrom = animationContext.playTo
-        animationContext.playTo = temp
-      }
-
-      var timingConfiguration = CoreAnimationLayer.CAMediaTimingConfiguration(
-        autoreverses: loopMode.caAnimationConfiguration.autoreverses,
-        repeatCount: loopMode.caAnimationConfiguration.repeatCount,
-        speed: abs(Float(animationSpeed)))
-
-      // The animation should start playing from the `currentFrame`,
-      // if `currentFrame` is included in the time range being played.
-      let lowerBoundTime = min(animationContext.playFrom, animationContext.playTo)
-      let upperBoundTime = max(animationContext.playFrom, animationContext.playTo)
-      if (lowerBoundTime ..< upperBoundTime).contains(round(currentFrame)) {
-        // We have to configure this differently depending on the loop mode:
-        switch loopMode {
-        // When playing exactly once (and not looping), we can just set the
-        // `playFrom` time to be the `currentFrame`. Since the animation duration
-        // is based on `playFrom` and `playTo`, this automatically truncates the
-        // duration (so the animation stops playing at `playFrom`).
-        //  - Don't do this if the animation is already at that frame
-        //    (e.g. playing from 100% to 0% when the animation is already at 0%)
-        //    since that would cause the animation to not play at all.
-        case .playOnce:
-          if animationContext.playTo != currentFrame {
-            animationContext.playFrom = currentFrame
-          }
-
-        // When looping, we specifically _don't_ want to affect the duration of the animation,
-        // since that would affect the duration of all subsequent loops. We just want to adjust
-        // the duration of the _first_ loop. Instead of setting `playFrom`, we just add a `timeOffset`
-        // so the first loop begins at `currentTime` but all subsequent loops are the standard duration.
-        default:
-          if animationSpeed < 0 {
-            timingConfiguration.timeOffset = animation.time(forFrame: animationContext.playFrom) - currentTime
-          } else {
-            timingConfiguration.timeOffset = currentTime - animation.time(forFrame: animationContext.playFrom)
-          }
-        }
-      }
-
-      // If attempting to play a zero-duration animation, just pause on that single frame instead
-      if animationContext.playFrom == animationContext.playTo {
-        currentFrame = animationContext.playTo
-        animationContext.closure.completionBlock?(true)
-        return
-      }
-
-      coreAnimationLayer.playAnimation(configuration: .init(
-        animationContext: animationContext,
-        timingConfiguration: timingConfiguration))
-
-      return
-    }
-
-    /// At this point there is no animation on animationLayer and its state is set.
-
-    let framerate = animation.framerate
-
-    let playFrom = animationContext.playFrom.clamp(animation.startFrame, animation.endFrame)
-    let playTo = animationContext.playTo.clamp(animation.startFrame, animation.endFrame)
-
-    let duration = ((max(playFrom, playTo) - min(playFrom, playTo)) / CGFloat(framerate))
-
-    let playingForward: Bool =
-      (
-        (animationSpeed > 0 && playFrom < playTo) ||
-          (animationSpeed < 0 && playTo < playFrom))
-
-    var startFrame = currentFrame.clamp(min(playFrom, playTo), max(playFrom, playTo))
-    if startFrame == playTo {
-      startFrame = playFrom
-    }
-
-    let timeOffset: TimeInterval = playingForward
-      ? Double(startFrame - min(playFrom, playTo)) / framerate
-      : Double(max(playFrom, playTo) - startFrame) / framerate
-
-    let layerAnimation = CABasicAnimation(keyPath: "currentFrame")
-    layerAnimation.fromValue = playFrom
-    layerAnimation.toValue = playTo
-    layerAnimation.speed = Float(animationSpeed)
-    layerAnimation.duration = TimeInterval(duration)
-    layerAnimation.fillMode = CAMediaTimingFillMode.both
-    layerAnimation.repeatCount = loopMode.caAnimationConfiguration.repeatCount
-    layerAnimation.autoreverses = loopMode.caAnimationConfiguration.autoreverses
-
-    layerAnimation.isRemovedOnCompletion = false
-    if timeOffset != 0 {
-      let currentLayerTime = viewLayer?.convertTime(CACurrentMediaTime(), from: nil) ?? 0
-      layerAnimation.beginTime = currentLayerTime - (timeOffset * 1 / Double(abs(animationSpeed)))
-    }
-    layerAnimation.delegate = animationContext.closure
-    animationContext.closure.animationLayer = animationlayer
-    animationContext.closure.animationKey = activeAnimationName
-
-    animationlayer.add(layerAnimation, forKey: activeAnimationName)
-    updateRasterizationState()
+    self.lottieAnimationLayer.updateAnimationForForegroundState(wasWaitingToPlayAnimation: wasWaitingToPlayAnimation)
   }
 
   // MARK: Private
 
-  static private let animationName = "Lottie"
-
   private let logger: LottieLogger
-
-  /// The `LottieBackgroundBehavior` that was specified manually by setting `self.backgroundBehavior`
-  private var _backgroundBehavior: LottieBackgroundBehavior?
-
-}
-
-// MARK: - LottieLoopMode + caAnimationConfiguration
-
-extension LottieLoopMode {
-  /// The `CAAnimation` configuration that reflects this mode
-  var caAnimationConfiguration: (repeatCount: Float, autoreverses: Bool) {
-    switch self {
-    case .playOnce:
-      return (repeatCount: 1, autoreverses: false)
-    case .loop:
-      return (repeatCount: .greatestFiniteMagnitude, autoreverses: false)
-    case .autoReverse:
-      return (repeatCount: .greatestFiniteMagnitude, autoreverses: true)
-    case .repeat(let amount):
-      return (repeatCount: amount, autoreverses: false)
-    case .repeatBackwards(let amount):
-      return (repeatCount: amount, autoreverses: true)
-    }
-  }
 }

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -708,7 +708,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
       self.setNeedsLayout()
     }
 
-    lottieAnimationLayer.animationLayerWillLoad = { [weak self] lottieAnimationLayer, _ in
+    lottieAnimationLayer.animationLayerDidLoad = { [weak self] lottieAnimationLayer, _ in
       guard let self = self else { return }
       self.invalidateIntrinsicContentSize()
       self.setNeedsLayout()

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -187,7 +187,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// - Parameter completion: An optional completion closure to be called when the animation completes playing.
   open func play(completion: LottieCompletionBlock? = nil) {
-    self.lottieAnimationLayer.play(completion: completion)
+    lottieAnimationLayer.play(completion: completion)
   }
 
   /// Plays the animation from a progress (0-1) to a progress (0-1).
@@ -202,7 +202,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    self.lottieAnimationLayer.play(fromProgress: fromProgress, toProgress: toProgress, loopMode: loopMode, completion: completion)
+    lottieAnimationLayer.play(fromProgress: fromProgress, toProgress: toProgress, loopMode: loopMode, completion: completion)
   }
 
   /// Plays the animation from a start frame to an end frame in the animation's framerate.
@@ -217,7 +217,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    self.lottieAnimationLayer.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: loopMode, completion: completion)
+    lottieAnimationLayer.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: loopMode, completion: completion)
   }
 
   /// Plays the animation from a named marker to another marker.
@@ -242,7 +242,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    self.lottieAnimationLayer.play(
+    lottieAnimationLayer.play(
       fromMarker: fromMarker,
       toMarker: toMarker,
       playEndMarkerFrame: playEndMarkerFrame,
@@ -265,27 +265,24 @@ open class LottieAnimationView: LottieAnimationViewBase {
     loopMode: LottieLoopMode? = nil,
     completion: LottieCompletionBlock? = nil)
   {
-    self.lottieAnimationLayer.play(marker: marker, loopMode: loopMode, completion: completion)
+    lottieAnimationLayer.play(marker: marker, loopMode: loopMode, completion: completion)
   }
 
   /// Stops the animation and resets the view to its start frame.
   ///
   /// The completion closure will be called with `false`
   open func stop() {
-    self.lottieAnimationLayer.stop()
+    lottieAnimationLayer.stop()
   }
 
   /// Pauses the animation in its current state.
   ///
   /// The completion closure will be called with `false`
   open func pause() {
-    self.lottieAnimationLayer.pause()
+    lottieAnimationLayer.pause()
   }
 
   // MARK: Public
-
-  // The backing CALayer for this animation view.
-  private let lottieAnimationLayer: LottieAnimationLayer
 
   /// Value Providers that have been registered using `setValueProvider(_:keypath:)`
   public private(set) var valueProviders = [AnimationKeypath: AnyValueProvider]()
@@ -301,16 +298,16 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// The default for the Core Animation engine is `continuePlaying`,
   /// since the Core Animation engine does not have any CPU overhead.
   public var backgroundBehavior: LottieBackgroundBehavior {
-    get { self.lottieAnimationLayer.backgroundBehavior }
-    set { self.lottieAnimationLayer.backgroundBehavior = newValue }
+    get { lottieAnimationLayer.backgroundBehavior }
+    set { lottieAnimationLayer.backgroundBehavior = newValue }
   }
 
   /// Sets the animation backing the animation view. Setting this will clear the
   /// view's contents, completion blocks and current state. The new animation will
   /// be loaded up and set to the beginning of its timeline.
   public var animation: LottieAnimation? {
-    get { self.lottieAnimationLayer.animation }
-    set { self.lottieAnimationLayer.animation = newValue }
+    get { lottieAnimationLayer.animation }
+    set { lottieAnimationLayer.animation = newValue }
   }
 
   /// A closure that is called when `self.animation` is loaded. When setting this closure,
@@ -353,44 +350,44 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Setting this will cause the animation to reload its image contents.
   public var imageProvider: AnimationImageProvider {
-    get { self.lottieAnimationLayer.imageProvider }
-    set { self.lottieAnimationLayer.imageProvider = newValue }
+    get { lottieAnimationLayer.imageProvider }
+    set { lottieAnimationLayer.imageProvider = newValue }
   }
 
   /// Sets the text provider for animation view. A text provider provides the
   /// animation with values for text layers
   public var textProvider: AnimationTextProvider {
-    get { self.lottieAnimationLayer.textProvider }
-    set { self.lottieAnimationLayer.textProvider = newValue }
+    get { lottieAnimationLayer.textProvider }
+    set { lottieAnimationLayer.textProvider = newValue }
   }
 
   /// Sets the text provider for animation view. A text provider provides the
   /// animation with values for text layers
   public var fontProvider: AnimationFontProvider {
-    get { self.lottieAnimationLayer.fontProvider }
-    set { self.lottieAnimationLayer.fontProvider = newValue }
+    get { lottieAnimationLayer.fontProvider }
+    set { lottieAnimationLayer.fontProvider = newValue }
   }
 
   /// Whether or not the animation is masked to the bounds. Defaults to true.
   public var maskAnimationToBounds: Bool {
-    get { self.lottieAnimationLayer.maskAnimationToBounds }
-    set { self.lottieAnimationLayer.maskAnimationToBounds = newValue }
+    get { lottieAnimationLayer.maskAnimationToBounds }
+    set { lottieAnimationLayer.maskAnimationToBounds = newValue }
   }
 
   /// Returns `true` if the animation is currently playing.
   public var isAnimationPlaying: Bool {
-    self.lottieAnimationLayer.isAnimationPlaying
+    lottieAnimationLayer.isAnimationPlaying
   }
 
   /// Returns `true` if the animation will start playing when this view is added to a window.
   public var isAnimationQueued: Bool {
-    self.lottieAnimationLayer.hasAnimationContext && waitingToPlayAnimation
+    lottieAnimationLayer.hasAnimationContext && waitingToPlayAnimation
   }
 
   /// Sets the loop behavior for `play` calls. Defaults to `playOnce`
   public var loopMode: LottieLoopMode {
-    get { self.lottieAnimationLayer.loopMode }
-    set { self.lottieAnimationLayer.loopMode = newValue }
+    get { lottieAnimationLayer.loopMode }
+    set { lottieAnimationLayer.loopMode = newValue }
   }
 
   /// When `true` the animation view will rasterize its contents when not animating.
@@ -400,8 +397,8 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Defaults to `false`
   public var shouldRasterizeWhenIdle: Bool {
-    get { self.lottieAnimationLayer.shouldRasterizeWhenIdle }
-    set { self.lottieAnimationLayer.shouldRasterizeWhenIdle = newValue }
+    get { lottieAnimationLayer.shouldRasterizeWhenIdle }
+    set { lottieAnimationLayer.shouldRasterizeWhenIdle = newValue }
   }
 
   /// Sets the current animation time with a Progress Time
@@ -409,8 +406,8 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Note: Setting this will stop the current animation, if any.
   /// Note 2: If `animation` is nil, setting this will fallback to 0
   public var currentProgress: AnimationProgressTime {
-    get { self.lottieAnimationLayer.currentProgress }
-    set { self.lottieAnimationLayer.currentProgress = newValue }
+    get { lottieAnimationLayer.currentProgress }
+    set { lottieAnimationLayer.currentProgress = newValue }
   }
 
   /// Sets the current animation time with a time in seconds.
@@ -418,32 +415,32 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Note: Setting this will stop the current animation, if any.
   /// Note 2: If `animation` is nil, setting this will fallback to 0
   public var currentTime: TimeInterval {
-    get { self.lottieAnimationLayer.currentTime }
-    set { self.lottieAnimationLayer.currentTime = newValue }
+    get { lottieAnimationLayer.currentTime }
+    set { lottieAnimationLayer.currentTime = newValue }
   }
 
   /// Sets the current animation time with a frame in the animations framerate.
   ///
   /// Note: Setting this will stop the current animation, if any.
   public var currentFrame: AnimationFrameTime {
-    get { self.lottieAnimationLayer.currentFrame }
-    set { self.lottieAnimationLayer.currentFrame = newValue }
+    get { lottieAnimationLayer.currentFrame }
+    set { lottieAnimationLayer.currentFrame = newValue }
   }
 
   /// Returns the current animation frame while an animation is playing.
   public var realtimeAnimationFrame: AnimationFrameTime {
-    self.lottieAnimationLayer.realtimeAnimationFrame
+    lottieAnimationLayer.realtimeAnimationFrame
   }
 
   /// Returns the current animation frame while an animation is playing.
   public var realtimeAnimationProgress: AnimationProgressTime {
-    self.lottieAnimationLayer.realtimeAnimationProgress
+    lottieAnimationLayer.realtimeAnimationProgress
   }
 
   /// Sets the speed of the animation playback. Defaults to 1
   public var animationSpeed: CGFloat {
-    get { self.lottieAnimationLayer.animationSpeed }
-    set { self.lottieAnimationLayer.animationSpeed = newValue }
+    get { lottieAnimationLayer.animationSpeed }
+    set { lottieAnimationLayer.animationSpeed = newValue }
   }
 
   /// When `true` the animation will play back at the framerate encoded in the
@@ -452,8 +449,8 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Defaults to false
   public var respectAnimationFrameRate: Bool {
-    get { self.lottieAnimationLayer.respectAnimationFrameRate }
-    set { self.lottieAnimationLayer.respectAnimationFrameRate = newValue }
+    get { lottieAnimationLayer.respectAnimationFrameRate }
+    set { lottieAnimationLayer.respectAnimationFrameRate = newValue }
   }
 
   /// Controls the cropping of an Animation. Setting this property will crop the animation
@@ -489,7 +486,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///  - This will only be `nil` in cases where the configuration is `automatic`
   ///    but a `RootAnimationLayer` hasn't been constructed yet
   public var currentRenderingEngine: RenderingEngine? {
-    self.lottieAnimationLayer.currentRenderingEngine
+    lottieAnimationLayer.currentRenderingEngine
   }
 
   /// Sets the lottie file backing the animation view. Setting this will clear the
@@ -505,17 +502,17 @@ open class LottieAnimationView: LottieAnimationViewBase {
     _ animationId: String? = nil,
     from dotLottieFile: DotLottieFile)
   {
-    self.lottieAnimationLayer.loadAnimation(animationId, from: dotLottieFile)
+    lottieAnimationLayer.loadAnimation(animationId, from: dotLottieFile)
   }
 
   /// Reloads the images supplied to the animation from the `imageProvider`
   public func reloadImages() {
-    self.lottieAnimationLayer.reloadImages()
+    lottieAnimationLayer.reloadImages()
   }
 
   /// Forces the LottieAnimationView to redraw its contents.
   public func forceDisplayUpdate() {
-    self.lottieAnimationLayer.forceDisplayUpdate()
+    lottieAnimationLayer.forceDisplayUpdate()
   }
 
   /// Sets a ValueProvider for the specified keypath. The value provider will be set
@@ -541,7 +538,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// animationView.setValueProvider(redValueProvider, keypath: fillKeypath)
   /// ```
   public func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath) {
-    self.lottieAnimationLayer.setValueProvider(valueProvider, keypath: keypath)
+    lottieAnimationLayer.setValueProvider(valueProvider, keypath: keypath)
   }
 
   /// Reads the value of a property specified by the Keypath.
@@ -550,7 +547,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter for: The keypath used to search for the property.
   /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.
   public func getValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any? {
-    self.lottieAnimationLayer.getValue(for: keypath, atFrame: atFrame)
+    lottieAnimationLayer.getValue(for: keypath, atFrame: atFrame)
   }
 
   /// Reads the original value of a property specified by the Keypath.
@@ -560,19 +557,19 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter for: The keypath used to search for the property.
   /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.
   public func getOriginalValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any? {
-    self.lottieAnimationLayer.getOriginalValue(for: keypath, atFrame: atFrame)
+    lottieAnimationLayer.getOriginalValue(for: keypath, atFrame: atFrame)
   }
 
   /// Logs all child keypaths.
   /// Logs the result of `allHierarchyKeypaths()` to the `LottieLogger`.
   public func logHierarchyKeypaths() {
-    self.lottieAnimationLayer.logHierarchyKeypaths()
+    lottieAnimationLayer.logHierarchyKeypaths()
   }
 
   /// Computes and returns a list of all child keypaths in the current animation.
   /// The returned list is the same as the log output of `logHierarchyKeypaths()`
   public func allHierarchyKeypaths() -> [String] {
-    self.lottieAnimationLayer.allHierarchyKeypaths()
+    lottieAnimationLayer.allHierarchyKeypaths()
   }
 
   /// Searches for the nearest child layer to the first Keypath and adds the subview
@@ -602,7 +599,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
     }
     setNeedsLayout()
     layoutIfNeeded()
-    self.lottieAnimationLayer.forceDisplayUpdate()
+    lottieAnimationLayer.forceDisplayUpdate()
     addSubview(subview)
     if let subViewLayer = subview.viewLayer {
       sublayer.addSublayer(subViewLayer)
@@ -617,7 +614,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter rect: The CGRect to convert.
   /// - Parameter toLayerAt: The keypath used to find the layer.
   public func convert(_ rect: CGRect, toLayerAt keypath: AnimationKeypath?) -> CGRect? {
-    let convertedRect = self.lottieAnimationLayer.convert(rect, toLayerAt: keypath)
+    let convertedRect = lottieAnimationLayer.convert(rect, toLayerAt: keypath)
     setNeedsLayout()
     layoutIfNeeded()
     return convertedRect
@@ -631,7 +628,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter point: The CGPoint to convert.
   /// - Parameter toLayerAt: The keypath used to find the layer.
   public func convert(_ point: CGPoint, toLayerAt keypath: AnimationKeypath?) -> CGPoint? {
-    let convertedRect = self.lottieAnimationLayer.convert(point, toLayerAt: keypath)
+    let convertedRect = lottieAnimationLayer.convert(point, toLayerAt: keypath)
     setNeedsLayout()
     layoutIfNeeded()
     return convertedRect
@@ -643,7 +640,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// - Parameter isEnabled: When true the animator nodes affect the rendering tree. When false the node is removed from the tree.
   /// - Parameter keypath: The keypath used to find the node(s).
   public func setNodeIsEnabled(isEnabled: Bool, keypath: AnimationKeypath) {
-    self.lottieAnimationLayer.setNodeIsEnabled(isEnabled: isEnabled, keypath: keypath)
+    lottieAnimationLayer.setNodeIsEnabled(isEnabled: isEnabled, keypath: keypath)
   }
 
   /// Markers are a way to describe a point in time by a key name.
@@ -655,7 +652,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Returns the Progress Time for the marker named. Returns nil if no marker found.
   public func progressTime(forMarker named: String) -> AnimationProgressTime? {
-    self.lottieAnimationLayer.progressTime(forMarker: named)
+    lottieAnimationLayer.progressTime(forMarker: named)
   }
 
   /// Markers are a way to describe a point in time by a key name.
@@ -667,7 +664,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// Returns the Frame Time for the marker named. Returns nil if no marker found.
   public func frameTime(forMarker named: String) -> AnimationFrameTime? {
-    self.lottieAnimationLayer.frameTime(forMarker: named)
+    lottieAnimationLayer.frameTime(forMarker: named)
   }
 
   /// Markers are a way to describe a point in time and a duration by a key name.
@@ -679,13 +676,13 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///
   /// - Returns: The duration frame time for the marker, or `nil` if no marker found.
   public func durationFrameTime(forMarker named: String) -> AnimationFrameTime? {
-    self.lottieAnimationLayer.durationFrameTime(forMarker: named)
+    lottieAnimationLayer.durationFrameTime(forMarker: named)
   }
 
   // MARK: Internal
 
   var animationLayer: RootAnimationLayer? {
-    self.lottieAnimationLayer.animationLayer
+    lottieAnimationLayer.animationLayer
   }
 
   /// Set animation name from Interface Builder
@@ -698,8 +695,8 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   override func commonInit() {
     super.commonInit()
-    self.lottieAnimationLayer.screenScale = screenScale
-    self.viewLayer?.addSublayer(self.lottieAnimationLayer)
+    lottieAnimationLayer.screenScale = screenScale
+    viewLayer?.addSublayer(lottieAnimationLayer)
 
     lottieAnimationLayer.animationLoaded = { [weak self] _, animation in
       guard let self = self else { return }
@@ -856,21 +853,21 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
     if shouldForceUpdates {
       animationLayer.forceDisplayUpdate()
-      self.lottieAnimationLayer.forceDisplayUpdate()
+      lottieAnimationLayer.forceDisplayUpdate()
     }
   }
 
   func updateRasterizationState() {
-    if self.lottieAnimationLayer.isAnimationPlaying {
-      self.lottieAnimationLayer.animationLayer?.shouldRasterize = false
+    if lottieAnimationLayer.isAnimationPlaying {
+      lottieAnimationLayer.animationLayer?.shouldRasterize = false
     } else {
-      self.lottieAnimationLayer.animationLayer?.shouldRasterize = self.lottieAnimationLayer.shouldRasterizeWhenIdle
+      lottieAnimationLayer.animationLayer?.shouldRasterize = lottieAnimationLayer.shouldRasterizeWhenIdle
     }
   }
 
   /// Updates the animation frame. Does not affect any current animations
   func updateAnimationFrame(_ newFrame: CGFloat) {
-    self.lottieAnimationLayer.updateAnimationFrame(newFrame)
+    lottieAnimationLayer.updateAnimationFrame(newFrame)
   }
 
   @objc
@@ -896,7 +893,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   func updateInFlightAnimation() {
-    self.lottieAnimationLayer.updateInFlightAnimation()
+    lottieAnimationLayer.updateInFlightAnimation()
   }
 
   // MARK: Fileprivate
@@ -904,7 +901,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   fileprivate var waitingToPlayAnimation = false
 
   fileprivate func updateAnimationForBackgroundState() {
-    self.lottieAnimationLayer.updateAnimationForBackgroundState()
+    lottieAnimationLayer.updateAnimationForBackgroundState()
   }
 
   fileprivate func updateAnimationForForegroundState() {
@@ -912,10 +909,13 @@ open class LottieAnimationView: LottieAnimationViewBase {
     if waitingToPlayAnimation {
       waitingToPlayAnimation = false
     }
-    self.lottieAnimationLayer.updateAnimationForForegroundState(wasWaitingToPlayAnimation: wasWaitingToPlayAnimation)
+    lottieAnimationLayer.updateAnimationForForegroundState(wasWaitingToPlayAnimation: wasWaitingToPlayAnimation)
   }
 
   // MARK: Private
+
+  // The backing CALayer for this animation view.
+  private let lottieAnimationLayer: LottieAnimationLayer
 
   private let logger: LottieLogger
 }


### PR DESCRIPTION
https://origami.design/ wants to add support for Lottie Animations. However Origami works at CALayer level and because of that it cannot add directly a NSView/UIView. Internally Lottie also works with CALayers. This commit creates then a CALayer interface that mimics basically the same behavior/functionality of the LottieAnimationView and then LottieAnimationView also uses that layer internally.