### PR TITLE
Restructure `ValueProviderStore` to not accumulate multiple values for the same key

### DIFF
--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -100,7 +100,7 @@ final class ValueProviderStore {
   private func valueProvider(for keypath: AnimationKeypath) -> AnyValueProvider? {
     // Find the last keypath matching the given keypath,
     // so we return the value provider that was registered most-recently
-    valueProviders.reversed().first(where: { registeredKeypath, _ in
+    valueProviders.last(where: { registeredKeypath, _ in
       keypath.matches(registeredKeypath)
     })?.valueProvider
   }

--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -36,9 +36,8 @@ final class ValueProviderStore {
       properties. Supported properties are: \(supportedProperties.joined(separator: ", ")).
       """)
 
-    orderedKeyPaths.remove(keypath)
-    orderedKeyPaths.insert(keypath, at: orderedKeyPaths.count)
-    valueProviders[keypath] = valueProvider
+    valueProviders.removeAll(where: { $0.keypath == keypath })
+    valueProviders.append((keypath: keypath, valueProvider: valueProvider))
   }
 
   // Retrieves the custom value keyframes for the given property,
@@ -95,19 +94,15 @@ final class ValueProviderStore {
   // MARK: Private
 
   private let logger: LottieLogger
-  private var valueProviders = [AnimationKeypath: AnyValueProvider]()
-  private var orderedKeyPaths = NSMutableOrderedSet()
+  private var valueProviders = [(keypath: AnimationKeypath, valueProvider: AnyValueProvider)]()
 
   /// Retrieves the most-recently-registered Value Provider that matches the given keypath.
   private func valueProvider(for keypath: AnimationKeypath) -> AnyValueProvider? {
     // Find the last keypath matching the given keypath,
     // so we return the value provider that was registered most-recently
-    guard
-      let matchingPath = orderedKeyPaths.reversed.first(where: { element in
-        guard let registeredKeypath = (element as? AnimationKeypath) else { return false }
-        return keypath.matches(registeredKeypath)
-      }) as? AnimationKeypath else { return nil }
-    return valueProviders[matchingPath]
+    valueProviders.reversed().first(where: { registeredKeypath, _ in
+      keypath.matches(registeredKeypath)
+    })?.valueProvider
   }
 
 }

--- a/Tests/SnapshotConfiguration.swift
+++ b/Tests/SnapshotConfiguration.swift
@@ -186,5 +186,6 @@ extension SnapshotConfiguration {
 extension LottieColor {
   static let black = LottieColor(r: 0, g: 0, b: 0, a: 1)
   static let red = LottieColor(r: 1, g: 0, b: 0, a: 1)
+  static let blue = LottieColor(r: 0, g: 0, b: 1, a: 1)
 }
 #endif

--- a/Tests/ValueProvidersTests.swift
+++ b/Tests/ValueProvidersTests.swift
@@ -5,8 +5,8 @@
 //  Created by Marcelo Fabri on 5/5/22.
 //
 
-import Lottie
 import XCTest
+@testable import Lottie
 
 @MainActor
 final class ValueProvidersTests: XCTestCase {
@@ -27,4 +27,53 @@ final class ValueProvidersTests: XCTestCase {
     XCTAssertEqual(originalColor, LottieColor(r: 0.4, g: 0.16, b: 0.7, a: 1))
   }
 
+  func testValueProviderStore() async throws {
+    let optionalAnimationView = await SnapshotConfiguration.makeAnimationView(
+      for: "HamburgerArrow",
+      configuration: .init(renderingEngine: .mainThread))
+    let animation = try XCTUnwrap(optionalAnimationView?.animation)
+
+    let store = ValueProviderStore(logger: .printToConsole)
+    let animationContext = LayerAnimationContext(
+      animation: animation,
+      timingConfiguration: .init(),
+      startFrame: 0,
+      endFrame: 100,
+      valueProviderStore: store,
+      compatibilityTracker: .init(mode: .track, logger: .printToConsole),
+      logger: .printToConsole,
+      currentKeypath: .init(keys: []),
+      textProvider: DictionaryTextProvider([:]))
+
+    // Test that the store returns the expected value for the provider.
+    store.setValueProvider(ColorValueProvider(.red), keypath: "**.Color")
+    let keyFramesQuery1 = try store.customKeyframes(
+      of: .color,
+      for: "Layer.Shape Group.Stroke 1.Color",
+      context: animationContext)
+    XCTAssertEqual(keyFramesQuery1?.keyframes.map(\.value.components), [[1, 0, 0, 1]])
+
+    // Test a different provider/keypath.
+    store.setValueProvider(ColorValueProvider(.blue), keypath: "A1.Shape 1.Stroke 1.Color")
+    let keyFramesQuery2 = try store.customKeyframes(
+      of: .color,
+      for: "A1.Shape 1.Stroke 1.Color",
+      context: animationContext)
+    XCTAssertEqual(keyFramesQuery2?.keyframes.map(\.value.components), [[0, 0, 1, 1]])
+
+    // Test that adding a different keypath didn't disrupt the original one.
+    let keyFramesQuery3 = try store.customKeyframes(
+      of: .color,
+      for: "Layer.Shape Group.Stroke 1.Color",
+      context: animationContext)
+    XCTAssertEqual(keyFramesQuery3?.keyframes.map(\.value.components), [[1, 0, 0, 1]])
+
+    // Test overriding the original keypath with a new provider stores the new provider.
+    store.setValueProvider(ColorValueProvider(.black), keypath: "**.Color")
+    let keyFramesQuery4 = try store.customKeyframes(
+      of: .color,
+      for: "Layer.Shape Group.Stroke 1.Color",
+      context: animationContext)
+    XCTAssertEqual(keyFramesQuery4?.keyframes.map(\.value.components), [[0, 0, 0, 1]])
+  }
 }


### PR DESCRIPTION
In our app we update value providers on animation views at various times throughout the view's lifecycle. This happens as the user changes their color theme preferences in our app.

Currently `ValueProviderStore` accumulates multiple providers for the same key, which leads to provider value resolution becoming more expensive over time.

This PR restructures `ValueProviderStore` so that it only keeps the most recent value provider for any given key. The updated class maintains the "last added" provider logic added in #1494.