### PR TITLE
Fix breaking API changes from #2073

### DIFF
--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -308,7 +308,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   /// Value Providers that have been registered using `setValueProvider(_:keypath:)`
-  public var valueProviders = [AnimationKeypath: AnyValueProvider]() {
+  public var valueProviders: [AnimationKeypath: AnyValueProvider] {
     lottieAnimationLayer.valueProviders
   }
 

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -302,8 +302,15 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   // MARK: Public
 
+  /// The configuration that this `LottieAnimationView` uses when playing its animation
+  public var configuration: LottieConfiguration {
+    lottieAnimationLayer.configuration
+  }
+
   /// Value Providers that have been registered using `setValueProvider(_:keypath:)`
-  public private(set) var valueProviders = [AnimationKeypath: AnyValueProvider]()
+  public var valueProviders = [AnimationKeypath: AnyValueProvider]() {
+    lottieAnimationLayer.valueProviders
+  }
 
   /// Describes the behavior of an AnimationView when the app is moved to the background.
   ///


### PR DESCRIPTION
I noticed #2073 accidentally removed the `LottieAnimationView.configuration` property. This PR adds it back, as a passthrough to the underlying `LottieAnimationLayer.configuration`.