### PR TITLE
Marks animation as optional in initializer.

### DIFF
--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -14,7 +14,7 @@ public struct LottieView: UIViewConfiguringSwiftUIView {
   // MARK: Lifecycle
 
   public init(
-    animation: LottieAnimation,
+    animation: LottieAnimation?,
     imageProvider: AnimationImageProvider? = nil,
     textProvider: AnimationTextProvider? = nil,
     fontProvider: AnimationFontProvider? = nil,


### PR DESCRIPTION
This marks the animation of the newly introduced `LottieView` for SwiftUI as optional. 

The main motivation for this change was to align it with the initializer of the `LottieAnimationView`. Another reason is probably that a common way to create an animation is via `LottieAnimation.named` and this function returns an optional result.
