### PR TITLE
Add SwiftUI APIs to get and set current progress / current frame

### DIFF
--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example (iOS).xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1430"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Example/AnimationListView.swift
+++ b/Example/Example/AnimationListView.swift
@@ -18,11 +18,8 @@ struct AnimationListView: View {
           case .animation(let animationName, _):
             HStack {
               LottieView(animation: .named(animationName, subdirectory: directory))
-<<<<<<< HEAD
-                .imageProvider(.exampleAppSampleImages)
-=======
                 .currentProgress(0.5)
->>>>>>> 2c79aa77 (Add APIs to get and set current progress / current frame)
+                .imageProvider(.exampleAppSampleImages)
                 .frame(width: 50, height: 50)
                 .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
 

--- a/Example/Example/AnimationListView.swift
+++ b/Example/Example/AnimationListView.swift
@@ -18,7 +18,11 @@ struct AnimationListView: View {
           case .animation(let animationName, _):
             HStack {
               LottieView(animation: .named(animationName, subdirectory: directory))
+<<<<<<< HEAD
                 .imageProvider(.exampleAppSampleImages)
+=======
+                .currentProgress(0.5)
+>>>>>>> 2c79aa77 (Add APIs to get and set current progress / current frame)
                 .frame(width: 50, height: 50)
                 .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
 

--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 /// TODO: Implement functionality from UIKit `AnimationPreviewViewController`
 struct AnimationPreviewView: View {
 
+  // MARK: Internal
+
   let animationName: String
-  @State private var animationPlaying: Bool = true
-  @State private var sliderValue: AnimationProgressTime = 0
 
   var body: some View {
     VStack {
@@ -35,6 +35,11 @@ struct AnimationPreviewView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.secondaryBackground)
   }
+
+  // MARK: Private
+
+  @State private var animationPlaying = true
+  @State private var sliderValue: AnimationProgressTime = 0
 
 }
 

--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -19,17 +19,19 @@ struct AnimationPreviewView: View {
         .imageProvider(.exampleAppSampleImages)
         .resizable()
         .looping()
-        .currentProgress(sliderValue)
+        .currentProgress(animationPlaying ? nil : sliderValue)
         .getRealtimeAnimationProgress(animationPlaying ? $sliderValue : nil)
 
       Spacer()
 
+      #if !os(tvOS)
       Slider(value: $sliderValue, in: 0...1, onEditingChanged: { editing in
         if animationPlaying, editing {
           animationPlaying = false
         }
       })
       .padding(.all, 16)
+      #endif
     }
     .navigationTitle(animationName.components(separatedBy: "/").last!)
     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct AnimationPreviewView: View {
 
   let animationName: String
+  @State private var animationPlaying: Bool = true
+  @State private var sliderValue: AnimationProgressTime = 0
 
   var body: some View {
     VStack {
@@ -17,6 +19,17 @@ struct AnimationPreviewView: View {
         .imageProvider(.exampleAppSampleImages)
         .resizable()
         .looping()
+        .currentProgress(sliderValue)
+        .getRealtimeAnimationProgress(animationPlaying ? $sliderValue : nil)
+
+      Spacer()
+
+      Slider(value: $sliderValue, in: 0...1, onEditingChanged: { editing in
+        if animationPlaying, editing {
+          animationPlaying = false
+        }
+      })
+      .padding(.all, 16)
     }
     .navigationTitle(animationName.components(separatedBy: "/").last!)
     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -3274,7 +3274,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
@@ -3308,7 +3308,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -2114,7 +2114,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					2E80409927A0725D006E74CB = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -3153,12 +3153,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3169,6 +3171,8 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SKIP_INSTALL = YES;
@@ -3182,12 +3186,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3198,6 +3204,8 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SKIP_INSTALL = YES;
@@ -3252,10 +3260,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3264,8 +3274,10 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SDKROOT = macosx;
@@ -3282,10 +3294,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3294,8 +3308,10 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SDKROOT = macosx;
@@ -3309,12 +3325,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3324,6 +3342,8 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SDKROOT = appletvos;
@@ -3339,12 +3359,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3354,6 +3376,8 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SDKROOT = appletvos;

--- a/Lottie.xcodeproj/xcshareddata/xcschemes/Lottie (iOS).xcscheme
+++ b/Lottie.xcodeproj/xcshareddata/xcschemes/Lottie (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lottie.xcodeproj/xcshareddata/xcschemes/Lottie (macOS).xcscheme
+++ b/Lottie.xcodeproj/xcshareddata/xcschemes/Lottie (macOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -58,7 +58,7 @@ public struct LottieView: UIViewConfiguringSwiftUIView {
     return copy
   }
 
-  /// Returns a copy of this animation view that loops its animation whenever visible by playing
+  /// Returns a copy of this view that loops its animation whenever visible by playing
   /// whenever it is updated with a `loopMode` of `.loop` if not already playing.
   public func looping() -> Self {
     configure { view in
@@ -68,8 +68,7 @@ public struct LottieView: UIViewConfiguringSwiftUIView {
     }
   }
 
-  /// Returns a copy of this animation view with its `AnimationView` updated to have the provided
-  /// background behavior.
+  /// Returns a copy of this view updated to have the provided background behavior.
   public func backgroundBehavior(_ value: LottieBackgroundBehavior) -> Self {
     configure { view in
       view.backgroundBehavior = value
@@ -158,6 +157,94 @@ public struct LottieView: UIViewConfiguringSwiftUIView {
     configure { view in
       if (view.valueProviders[keypath] as? ValueProvider) != valueProvider {
         view.setValueProvider(valueProvider, keypath: keypath)
+      }
+    }
+  }
+
+  /// Returns a copy of this view updated to display the given `AnimationProgressTime`.
+  ///  - If the `currentProgress` value is provided, the `currentProgress` of the
+  ///    underlying `LottieAnimationView` is updated. This will pause any existing animations.
+  ///  - If the `animationProgress` is `nil`, no changes will be made and any existing animations
+  ///    will continue playing uninterrupted.
+  public func currentProgress(_ currentProgress: AnimationProgressTime?) -> Self {
+    configure { view in
+      if
+        let currentProgress = currentProgress,
+        view.currentProgress != currentProgress
+      {
+        view.currentProgress = currentProgress
+      }
+    }
+  }
+
+  /// Returns a copy of this view updated to display the given `AnimationFrameTime`.
+  ///  - If the `currentFrame` value is provided, the `currentFrame` of the
+  ///    underlying `LottieAnimationView` is updated. This will pause any existing animations.
+  ///  - If the `currentFrame` is `nil`, no changes will be made and any existing animations
+  ///    will continue playing uninterrupted.
+  public func currentFrame(_ currentFrame: AnimationFrameTime?) -> Self {
+    configure { view in
+      if
+        let currentFrame = currentFrame,
+        view.currentFrame != currentFrame
+      {
+        view.currentFrame = currentFrame
+      }
+    }
+  }
+
+  /// Returns a copy of this view updated to display the given time value.
+  ///  - If the `currentTime` value is provided, the `currentTime` of the
+  ///    underlying `LottieAnimationView` is updated. This will pause any existing animations.
+  ///  - If the `currentTime` is `nil`, no changes will be made and any existing animations
+  ///    will continue playing uninterrupted.
+  public func currentTime(_ currentTime: TimeInterval?) -> Self {
+    configure { view in
+      if
+        let currentTime = currentTime,
+        view.currentTime != currentTime
+      {
+        view.currentTime = currentTime
+      }
+    }
+  }
+
+  /// Returns a view that updates the given binding each frame with the animation's `realtimeAnimationProgress`.
+  /// The `LottieView` is wrapped in a `TimelineView` with the `.animation` schedule.
+  ///  - This is a one-way binding. Its value is updated but never read.
+  ///  - If provided, the binding will be updated each frame with the `realtimeAnimationProgress`
+  ///    of the underlying `LottieAnimationView`. This is potentially expensive since it triggers
+  ///    a state update every frame.
+  ///  - If the binding is `nil`, the `TimelineView` will be paused and no updates will occur to the binding.
+  @available(iOS 15.0, tvOS 15.0, macOS 12.0, *)
+  public func getRealtimeAnimationProgress(_ realtimeAnimationProgress: Binding<AnimationProgressTime>?) -> some View {
+    TimelineView(.animation(paused: realtimeAnimationProgress == nil)) { _ in
+      configure { view in
+        if let realtimeAnimationProgress = realtimeAnimationProgress {
+          DispatchQueue.main.async {
+            realtimeAnimationProgress.wrappedValue = view.realtimeAnimationProgress
+          }
+        }
+      }
+    }
+  }
+
+  /// Returns a view that updates the given binding each frame with the animation's `realtimeAnimationProgress`.
+  /// The `LottieView` is wrapped in a `TimelineView` with the `.animation` schedule.
+  ///  - This is a one-way binding. Its value is updated but never read.
+  ///  - If provided, the binding will be updated each frame with the `realtimeAnimationProgress`
+  ///    of the underlying `LottieAnimationView`. This is potentially expensive since it triggers
+  ///    a state update every frame.
+  ///  - If the binding is `nil`, the `TimelineView` will be paused and no updates will occur to the binding.
+  @available(iOS 15.0, tvOS 15.0, macOS 12.0, *)
+  public func getRealtimeAnimationFrame(_ realtimeAnimationFrame: Binding<AnimationProgressTime>?) -> some View {
+    TimelineView(.animation(paused: realtimeAnimationFrame == nil)) { _ in
+      configure { view in
+        if let realtimeAnimationFrame = realtimeAnimationFrame {
+          DispatchQueue.main.async {
+            realtimeAnimationFrame.wrappedValue = view.realtimeAnimationFrame
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR adds SwiftUI `LottieView` APIs to get and set the `currentProgress` and `currentFrame` of the animation.

The `currentProgress` / `currentFrame` APIs let you do things like:

```swift
// The animation is paused at 50% progress
LottieView(animation: .named(animationName))
  .currentProgress(0.5)
```

```swift
// The animation always displays the frame of the slider
@State private var sliderValue: AnimationProgressTime = 0

// ...

LottieView(animation: .named(animationName))
  .currentProgress(sliderValue)

Slider(value: $sliderValue, in: 0...1)
```

This PR also includes APIs for accessing the `realtimeAnimationProgress` / `realtimeAnimationFrame` and assigning that value to a binding. You'd use this to update other pieces of UI to match the state of the animation, like a progress bar. This is a bit more niche, but since I was writing the functionality for the Example anyway I figured we may as well add it as a public API. 

For example, here's usage in the Example app where the slider displays the live-updating `realtimeAnimationProgress` until you manually start dragging the slider:

```swift
@State private var animationPlaying: Bool = true
@State private var sliderValue: AnimationProgressTime = 0

var body: some View {
  VStack {
    LottieView(animation: .named(animationName))
      .looping()
      .currentProgress(animationPlaying ? nil : sliderValue)
      .getRealtimeAnimationProgress(animationPlaying ? $sliderValue : nil)

    Slider(value: $sliderValue, in: 0...1, onEditingChanged: { editing in
      if animationPlaying, editing {
        animationPlaying = false
      }
    })
  }
}
```

<img src="https://github.com/airbnb/lottie-ios/assets/1811727/c7cb2ecc-5223-4376-bf0f-a8763cd1cc63" width=450>
