### PR TITLE
Improve SwiftUI APIs for configuring value providers, image providers, etc

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -430,7 +430,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -460,7 +460,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = iOS/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/Example/AnimationListView.swift
+++ b/Example/Example/AnimationListView.swift
@@ -18,6 +18,7 @@ struct AnimationListView: View {
           case .animation(let animationName, _):
             HStack {
               LottieView(animation: .named(animationName, subdirectory: directory))
+                .imageProvider(.exampleAppSampleImages)
                 .frame(width: 50, height: 50)
                 .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
 

--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -14,6 +14,7 @@ struct AnimationPreviewView: View {
   var body: some View {
     VStack {
       LottieView(animation: .named(animationName))
+        .imageProvider(.exampleAppSampleImages)
         .resizable()
         .looping()
     }
@@ -31,5 +32,11 @@ extension Color {
     #else
       .clear
     #endif
+  }
+}
+
+extension AnimationImageProvider where Self == FilepathImageProvider {
+  static var exampleAppSampleImages: FilepathImageProvider {
+    FilepathImageProvider(filepath: Bundle.main.resourceURL!.appending(path: "Samples/Images"))
   }
 }

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -296,15 +296,21 @@ public class LottieAnimationLayer: CALayer {
 
   // MARK: Public
 
-  /// The configuration that this `LottieAnimationView` uses when playing its animation
-  public let configuration: LottieConfiguration
-
   /// Value Providers that have been registered using `setValueProvider(_:keypath:)`
   public private(set) var valueProviders = [AnimationKeypath: AnyValueProvider]()
 
   /// A closure called when the animation layer has been loaded.
   /// Will inform the receiver the type of rendering engine that is used for the layer.
   public var animationLayerDidLoad:((_ animationLayer: LottieAnimationLayer, _ renderingEngine: RenderingEngineOption) -> Void)?
+
+  /// The configuration that this `LottieAnimationView` uses when playing its animation
+  public var configuration: LottieConfiguration {
+    didSet {
+      if configuration.renderingEngine != oldValue.renderingEngine {
+        makeAnimationLayer(usingEngine: configuration.renderingEngine)
+      }
+    }
+  }
 
   /// The underlying CALayer created to display the content.
   /// Use this property to change CALayer props like the content's transform, anchor point, etc.

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -304,7 +304,8 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   /// The configuration that this `LottieAnimationView` uses when playing its animation
   public var configuration: LottieConfiguration {
-    lottieAnimationLayer.configuration
+    get { lottieAnimationLayer.configuration }
+    set { lottieAnimationLayer.configuration = newValue }
   }
 
   /// Value Providers that have been registered using `setValueProvider(_:keypath:)`

--- a/Sources/Public/DynamicProperties/ValueProviders/ColorValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/ColorValueProvider.swift
@@ -8,6 +8,8 @@
 import CoreGraphics
 import Foundation
 
+// MARK: - ColorValueProvider
+
 /// A `ValueProvider` that returns a CGColor Value
 public final class ColorValueProvider: ValueProvider {
 
@@ -18,6 +20,7 @@ public final class ColorValueProvider: ValueProvider {
     self.block = block
     color = LottieColor(r: 0, g: 0, b: 0, a: 1)
     keyframes = nil
+    identity = UUID()
   }
 
   /// Initializes with a single color.
@@ -26,6 +29,7 @@ public final class ColorValueProvider: ValueProvider {
     block = nil
     keyframes = nil
     hasUpdate = true
+    identity = color
   }
 
   /// Initializes with multiple colors, with timing information
@@ -34,6 +38,7 @@ public final class ColorValueProvider: ValueProvider {
     color = LottieColor(r: 0, g: 0, b: 0, a: 1)
     block = nil
     hasUpdate = true
+    identity = keyframes
   }
 
   // MARK: Public
@@ -81,4 +86,13 @@ public final class ColorValueProvider: ValueProvider {
 
   private var block: ColorValueBlock?
   private var keyframes: [Keyframe<LottieColor>]?
+  private var identity: AnyHashable
+}
+
+// MARK: Equatable
+
+extension ColorValueProvider: Equatable {
+  public static func ==(_ lhs: ColorValueProvider, _ rhs: ColorValueProvider) -> Bool {
+    lhs.identity == rhs.identity
+  }
 }

--- a/Sources/Public/DynamicProperties/ValueProviders/FloatValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/FloatValueProvider.swift
@@ -8,6 +8,8 @@
 import CoreGraphics
 import Foundation
 
+// MARK: - FloatValueProvider
+
 /// A `ValueProvider` that returns a CGFloat Value
 public final class FloatValueProvider: ValueProvider {
 
@@ -17,6 +19,7 @@ public final class FloatValueProvider: ValueProvider {
   public init(block: @escaping CGFloatValueBlock) {
     self.block = block
     float = 0
+    identity = UUID()
   }
 
   /// Initializes with a single float.
@@ -24,6 +27,7 @@ public final class FloatValueProvider: ValueProvider {
     self.float = float
     block = nil
     hasUpdate = true
+    identity = float
   }
 
   // MARK: Public
@@ -67,4 +71,13 @@ public final class FloatValueProvider: ValueProvider {
   private var hasUpdate = true
 
   private var block: CGFloatValueBlock?
+  private var identity: AnyHashable
+}
+
+// MARK: Equatable
+
+extension FloatValueProvider: Equatable {
+  public static func ==(_ lhs: FloatValueProvider, _ rhs: FloatValueProvider) -> Bool {
+    lhs.identity == rhs.identity
+  }
 }

--- a/Sources/Public/DynamicProperties/ValueProviders/GradientValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/GradientValueProvider.swift
@@ -8,6 +8,8 @@
 import CoreGraphics
 import Foundation
 
+// MARK: - GradientValueProvider
+
 /// A `ValueProvider` that returns a Gradient Color Value.
 public final class GradientValueProvider: ValueProvider {
 
@@ -22,6 +24,7 @@ public final class GradientValueProvider: ValueProvider {
     locationsBlock = locations
     colors = []
     self.locations = []
+    identity = UUID()
   }
 
   /// Initializes with an array of colors.
@@ -31,6 +34,7 @@ public final class GradientValueProvider: ValueProvider {
   {
     self.colors = colors
     self.locations = locations
+    identity = [AnyHashable(colors), AnyHashable(locations)]
     updateValueArray()
     hasUpdate = true
   }
@@ -93,6 +97,8 @@ public final class GradientValueProvider: ValueProvider {
   private var locationsBlock: ColorLocationsBlock?
   private var value: [Double] = []
 
+  private let identity: AnyHashable
+
   private func value(from colors: [LottieColor], locations: [Double]) -> [Double] {
     var colorValues = [Double]()
     var alphaValues = [Double]()
@@ -119,5 +125,12 @@ public final class GradientValueProvider: ValueProvider {
 
   private func updateValueArray() {
     value = value(from: colors, locations: locations)
+  }
+
+}
+
+extension GradientValueProvider {
+  public static func ==(_ lhs: GradientValueProvider, _ rhs: GradientValueProvider) -> Bool {
+    lhs.identity == rhs.identity
   }
 }

--- a/Sources/Public/DynamicProperties/ValueProviders/PointValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/PointValueProvider.swift
@@ -7,6 +7,9 @@
 
 import CoreGraphics
 import Foundation
+
+// MARK: - PointValueProvider
+
 /// A `ValueProvider` that returns a CGPoint Value
 public final class PointValueProvider: ValueProvider {
 
@@ -16,6 +19,7 @@ public final class PointValueProvider: ValueProvider {
   public init(block: @escaping PointValueBlock) {
     self.block = block
     point = .zero
+    identity = UUID()
   }
 
   /// Initializes with a single point.
@@ -23,6 +27,7 @@ public final class PointValueProvider: ValueProvider {
     self.point = point
     block = nil
     hasUpdate = true
+    identity = [point.x, point.y]
   }
 
   // MARK: Public
@@ -66,4 +71,11 @@ public final class PointValueProvider: ValueProvider {
   private var hasUpdate = true
 
   private var block: PointValueBlock?
+  private let identity: AnyHashable
+}
+
+extension PointValueProvider {
+  public static func ==(_ lhs: PointValueProvider, _ rhs: PointValueProvider) -> Bool {
+    lhs.identity == rhs.identity
+  }
 }

--- a/Sources/Public/DynamicProperties/ValueProviders/SizeValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/SizeValueProvider.swift
@@ -8,6 +8,8 @@
 import CoreGraphics
 import Foundation
 
+// MARK: - SizeValueProvider
+
 /// A `ValueProvider` that returns a CGSize Value
 public final class SizeValueProvider: ValueProvider {
 
@@ -17,6 +19,7 @@ public final class SizeValueProvider: ValueProvider {
   public init(block: @escaping SizeValueBlock) {
     self.block = block
     size = .zero
+    identity = UUID()
   }
 
   /// Initializes with a single size.
@@ -24,6 +27,7 @@ public final class SizeValueProvider: ValueProvider {
     self.size = size
     block = nil
     hasUpdate = true
+    identity = [size.width, size.height]
   }
 
   // MARK: Public
@@ -67,4 +71,11 @@ public final class SizeValueProvider: ValueProvider {
   private var hasUpdate = true
 
   private var block: SizeValueBlock?
+  private let identity: AnyHashable
+}
+
+extension SizeValueProvider {
+  public static func ==(_ lhs: SizeValueProvider, _ rhs: SizeValueProvider) -> Bool {
+    lhs.identity == rhs.identity
+  }
 }

--- a/Sources/Public/FontProvider/AnimationFontProvider.swift
+++ b/Sources/Public/FontProvider/AnimationFontProvider.swift
@@ -33,3 +33,11 @@ public final class DefaultFontProvider: AnimationFontProvider {
     CTFontCreateWithName(family as CFString, size, nil)
   }
 }
+
+// MARK: Equatable
+
+extension DefaultFontProvider: Equatable {
+  public static func ==(_: DefaultFontProvider, _: DefaultFontProvider) -> Bool {
+    true
+  }
+}

--- a/Sources/Public/TextProvider/AnimationTextProvider.swift
+++ b/Sources/Public/TextProvider/AnimationTextProvider.swift
@@ -36,6 +36,14 @@ public final class DictionaryTextProvider: AnimationTextProvider {
   let values: [String: String]
 }
 
+// MARK: Equatable
+
+extension DictionaryTextProvider: Equatable {
+  public static func ==(_ lhs: DictionaryTextProvider, _ rhs: DictionaryTextProvider) -> Bool {
+    lhs.values == rhs.values
+  }
+}
+
 // MARK: - DefaultTextProvider
 
 /// Default text provider. Uses text in the animation file
@@ -49,5 +57,13 @@ public final class DefaultTextProvider: AnimationTextProvider {
 
   public func textFor(keypathName _: String, sourceText: String) -> String {
     sourceText
+  }
+}
+
+// MARK: Equatable
+
+extension DefaultTextProvider: Equatable {
+  public static func ==(_: DefaultTextProvider, _: DefaultTextProvider) -> Bool {
+    true
   }
 }

--- a/Sources/Public/iOS/BundleImageProvider.swift
+++ b/Sources/Public/iOS/BundleImageProvider.swift
@@ -86,4 +86,11 @@ public class BundleImageProvider: AnimationImageProvider {
   let bundle: Bundle
   let searchPath: String?
 }
+
+extension BundleImageProvider: Equatable {
+  public static func ==(_ lhs: BundleImageProvider, _ rhs: BundleImageProvider) -> Bool {
+    lhs.bundle == rhs.bundle
+      && lhs.searchPath == rhs.searchPath
+  }
+}
 #endif

--- a/Sources/Public/iOS/FilepathImageProvider.swift
+++ b/Sources/Public/iOS/FilepathImageProvider.swift
@@ -56,4 +56,10 @@ public class FilepathImageProvider: AnimationImageProvider {
 
   let filepath: URL
 }
+
+extension FilepathImageProvider: Equatable {
+  public static func ==(_ lhs: FilepathImageProvider, _ rhs: FilepathImageProvider) -> Bool {
+    lhs.filepath == rhs.filepath
+  }
+}
 #endif

--- a/Sources/Public/macOS/BundleImageProvider.macOS.swift
+++ b/Sources/Public/macOS/BundleImageProvider.macOS.swift
@@ -76,4 +76,11 @@ public class BundleImageProvider: AnimationImageProvider {
   let searchPath: String?
 }
 
+extension BundleImageProvider: Equatable {
+  public static func ==(_ lhs: BundleImageProvider, _ rhs: BundleImageProvider) -> Bool {
+    lhs.bundle == rhs.bundle
+      && lhs.searchPath == rhs.searchPath
+  }
+}
+
 #endif

--- a/Sources/Public/macOS/FilepathImageProvider.macOS.swift
+++ b/Sources/Public/macOS/FilepathImageProvider.macOS.swift
@@ -56,6 +56,12 @@ public class FilepathImageProvider: AnimationImageProvider {
   let filepath: URL
 }
 
+extension FilepathImageProvider: Equatable {
+  public static func ==(_ lhs: FilepathImageProvider, _ rhs: FilepathImageProvider) -> Bool {
+    lhs.filepath == rhs.filepath
+  }
+}
+
 extension NSImage {
   @nonobjc
   var lottie_CGImage: CGImage? {


### PR DESCRIPTION
This PR improves the SwiftUI `LottieView` APIs for configuring:
 - value providers
 - image providers
 - font providers
 - text providers
 - accessibility labels
 - `LottieConfiguration`

All of these now have a builder-style method like `.imageProvider(MyImageProvider())`, and supported being updated at any time using equality checks.

For types like `AnimationImageProvider` that aren't `Equatable`, the builder methods use an `& Equatable` constraint. This PR adds an `Equatable` conformance to all of the first-party value provider implementations.