### PR TITLE
Fix default `ReducedMotionOption`

### DIFF
--- a/Sources/Public/Configuration/LottieConfiguration.swift
+++ b/Sources/Public/Configuration/LottieConfiguration.swift
@@ -12,7 +12,7 @@ public struct LottieConfiguration: Hashable {
     renderingEngine: RenderingEngineOption = .automatic,
     decodingStrategy: DecodingStrategy = .dictionaryBased,
     colorSpace: CGColorSpace = CGColorSpaceCreateDeviceRGB(),
-    reducedMotionOption: ReducedMotionOption = .reducedMotion)
+    reducedMotionOption: ReducedMotionOption = .systemReducedMotionToggle)
   {
     self.renderingEngine = renderingEngine
     self.decodingStrategy = decodingStrategy


### PR DESCRIPTION
#2110 accidentally set the default `ReducedMotionOption` to `.reducedMotion`. I must have updated this while debugging and forgotten to change it back.

This PR updates the default to the expected `.systemReducedMotionToggle` value.