### PR TITLE
Add SwiftUI APIs for controlling playback behavior using `LottiePlaybackMode`

### DIFF
--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -65,9 +65,9 @@ struct AnimationPreviewView: View {
             animationPlaying = false
           }
         })
-        #endif
 
         Spacer(minLength: 16)
+        #endif
 
         Button {
           animationPlaying.toggle()
@@ -116,6 +116,7 @@ struct AnimationPreviewView: View {
 
   @ViewBuilder
   private var optionsMenu: some View {
+    #if !os(tvOS)
     Menu {
       Menu {
         option("Automatic", keyPath: \.renderingEngine, value: .automatic)
@@ -155,6 +156,7 @@ struct AnimationPreviewView: View {
     } label: {
       Image(systemName: "gear")
     }
+    #endif
   }
 
   private func loadAnimation() async throws -> LottieAnimationSource? {

--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -53,26 +53,42 @@ struct AnimationPreviewView: View {
       .imageProvider(.exampleAppSampleImages)
       .resizable()
       .reloadAnimationTrigger(currentURLIndex, showPlaceholder: false)
-      .looping()
-      .currentProgress(animationPlaying ? nil : sliderValue)
+      .playbackMode(playbackMode)
       .getRealtimeAnimationProgress(animationPlaying ? $sliderValue : nil)
 
       Spacer()
 
-      #if !os(tvOS)
-      Slider(value: $sliderValue, in: 0...1, onEditingChanged: { editing in
-        if animationPlaying, editing {
-          animationPlaying = false
+      HStack {
+        #if !os(tvOS)
+        Slider(value: $sliderValue, in: 0...1, onEditingChanged: { editing in
+          if animationPlaying, editing {
+            animationPlaying = false
+          }
+        })
+        #endif
+
+        Spacer(minLength: 16)
+
+        Button {
+          animationPlaying.toggle()
+        } label: {
+          if animationPlaying {
+            Image(systemName: "pause.fill")
+          } else {
+            Image(systemName: "play.fill")
+          }
         }
-      })
+      }
       .padding(.all, 16)
-      #endif
     }
     .navigationTitle(animationSource.name.components(separatedBy: "/").last!)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.secondaryBackground)
     .onReceive(timer) { _ in
       updateIndex()
+    }
+    .toolbar {
+      optionsMenu
     }
   }
 
@@ -85,6 +101,61 @@ struct AnimationPreviewView: View {
   @State private var animationPlaying = true
   @State private var sliderValue: AnimationProgressTime = 0
   @State private var currentURLIndex: Int
+  @State private var renderingEngine: RenderingEngineOption = .automatic
+  @State private var loopMode: LottieLoopMode = .loop
+  @State private var playFromProgress: AnimationProgressTime = 0
+  @State private var playToProgress: AnimationProgressTime = 1
+
+  private var playbackMode: LottiePlaybackMode {
+    if animationPlaying {
+      return .fromProgress(playFromProgress, toProgress: playToProgress, loopMode: loopMode)
+    } else {
+      return .progress(sliderValue)
+    }
+  }
+
+  @ViewBuilder
+  private var optionsMenu: some View {
+    Menu {
+      Menu {
+        option("Automatic", keyPath: \.renderingEngine, value: .automatic)
+        option("Core Animaiton", keyPath: \.renderingEngine, value: .coreAnimation)
+        option("Main Thread", keyPath: \.renderingEngine, value: .mainThread)
+      } label: {
+        Text("Rendering Engine")
+      }
+
+      Menu {
+        option("Play Once", keyPath: \.loopMode, value: .playOnce)
+        option("Loop", keyPath: \.loopMode, value: .loop)
+        option("Autoreverse", keyPath: \.loopMode, value: .autoReverse)
+      } label: {
+        Text("Loop Mode")
+      }
+
+      Menu {
+        option("0%", keyPath: \.playFromProgress, value: 0)
+        option("25%", keyPath: \.playFromProgress, value: 0.25)
+        option("50%", keyPath: \.playFromProgress, value: 0.5)
+        option("75%", keyPath: \.playFromProgress, value: 0.75)
+        option("100%", keyPath: \.playFromProgress, value: 1.0)
+      } label: {
+        Text("Play from...")
+      }
+
+      Menu {
+        option("0%", keyPath: \.playToProgress, value: 0)
+        option("25%", keyPath: \.playToProgress, value: 0.25)
+        option("50%", keyPath: \.playToProgress, value: 0.5)
+        option("75%", keyPath: \.playToProgress, value: 0.75)
+        option("100%", keyPath: \.playToProgress, value: 1.0)
+      } label: {
+        Text("Play to...")
+      }
+    } label: {
+      Image(systemName: "gear")
+    }
+  }
 
   private func loadAnimation() async throws -> LottieAnimationSource? {
     switch animationSource {
@@ -104,6 +175,19 @@ struct AnimationPreviewView: View {
     let currentIndex = currentURLIndex
     let nextIndex = currentIndex == urls.index(before: urls.endIndex) ? urls.startIndex : currentIndex + 1
     currentURLIndex = nextIndex
+  }
+
+  /// A `Button` that controls the value of the given keypath
+  private func option<T: Equatable>(_ label: String, keyPath: ReferenceWritableKeyPath<Self, T>, value: T) -> some View {
+    Button {
+      self[keyPath: keyPath] = value
+    } label: {
+      if self[keyPath: keyPath] == value {
+        Text("✔ \(label)")
+      } else {
+        Text(label)
+      }
+    }
   }
 }
 

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -88,6 +88,9 @@
 		08C002F52A461D6A00AB54BA /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C002F42A461D6A00AB54BA /* LottieView.swift */; };
 		08C002F62A461D6A00AB54BA /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C002F42A461D6A00AB54BA /* LottieView.swift */; };
 		08CB2681291ED2B700B4F071 /* AnimationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB2680291ED2B700B4F071 /* AnimationViewTests.swift */; };
+		08CD109C2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CD109B2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift */; };
+		08CD109D2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CD109B2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift */; };
+		08CD109E2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CD109B2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift */; };
 		08E206DF2A56014E002DCE17 /* StyledView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E206AD2A56014E002DCE17 /* StyledView.swift */; };
 		08E206E02A56014E002DCE17 /* StyledView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E206AD2A56014E002DCE17 /* StyledView.swift */; };
 		08E206E12A56014E002DCE17 /* StyledView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E206AD2A56014E002DCE17 /* StyledView.swift */; };
@@ -876,6 +879,7 @@
 		08C002F32A461A7300AB54BA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		08C002F42A461D6A00AB54BA /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		08CB2680291ED2B700B4F071 /* AnimationViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationViewTests.swift; sourceTree = "<group>"; };
+		08CD109B2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottiePlaybackMode.swift; sourceTree = "<group>"; };
 		08E206AD2A56014E002DCE17 /* StyledView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyledView.swift; sourceTree = "<group>"; };
 		08E206AE2A56014E002DCE17 /* ViewType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewType.swift; sourceTree = "<group>"; };
 		08E206AF2A56014E002DCE17 /* ContentConfigurableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentConfigurableView.swift; sourceTree = "<group>"; };
@@ -1887,6 +1891,7 @@
 				0887347428F0CCDD00458627 /* LottieAnimationView.swift */,
 				0887347328F0CCDD00458627 /* LottieAnimationViewInitializers.swift */,
 				08C002F42A461D6A00AB54BA /* LottieView.swift */,
+				08CD109B2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift */,
 			);
 			path = Animation;
 			sourceTree = "<group>";
@@ -2332,6 +2337,7 @@
 				2E9C95D32822F43100677516 /* Fill.swift in Sources */,
 				6DB3BDB8282454A6002A276D /* DictionaryInitializable.swift in Sources */,
 				08E207002A56014E002DCE17 /* UIViewConfiguringSwiftUIView.swift in Sources */,
+				08CD109C2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift in Sources */,
 				2E9C96B72822F43100677516 /* NodePropertyMap.swift in Sources */,
 				2E9C97682822F43100677516 /* VectorsExtensions.swift in Sources */,
 				2E9C97232822F43100677516 /* RectangleAnimation.swift in Sources */,
@@ -2715,6 +2721,7 @@
 				2EAF5AF927A0798700E00531 /* FloatValueProvider.swift in Sources */,
 				2E9C968E2822F43100677516 /* PassThroughOutputNode.swift in Sources */,
 				08E207402A56014E002DCE17 /* SetBehaviorsProviding.swift in Sources */,
+				08CD109D2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift in Sources */,
 				2EAF5AB727A0798700E00531 /* CompatibleAnimationKeypath.swift in Sources */,
 				2E9C96882822F43100677516 /* GroupOutputNode.swift in Sources */,
 				2E9C966A2822F43100677516 /* InvertedMatteLayer.swift in Sources */,
@@ -2905,6 +2912,7 @@
 				2E9C96B92822F43100677516 /* NodePropertyMap.swift in Sources */,
 				2E9C976A2822F43100677516 /* VectorsExtensions.swift in Sources */,
 				08E207022A56014E002DCE17 /* UIViewConfiguringSwiftUIView.swift in Sources */,
+				08CD109E2A7C2D9F0043A1A9 /* LottiePlaybackMode.swift in Sources */,
 				2E9C97252822F43100677516 /* RectangleAnimation.swift in Sources */,
 				2E450DAE283415D500E56D19 /* OpacityAnimation.swift in Sources */,
 				2E9C96FE2822F43100677516 /* CALayer+setupLayerHierarchy.swift in Sources */,

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -54,7 +54,7 @@ public enum LottieBackgroundBehavior {
 // MARK: - LottieLoopMode
 
 /// Defines animation loop behavior
-public enum LottieLoopMode {
+public enum LottieLoopMode: Hashable {
   /// Animation is played once then stops.
   case playOnce
   /// Animation will loop from beginning to end until stopped.
@@ -337,6 +337,11 @@ open class LottieAnimationView: LottieAnimationViewBase {
     lottieAnimationLayer.pause()
   }
 
+  /// Applies the given `LottiePlaybackMode` to this layer.
+  open func play(_ playbackMode: LottiePlaybackMode) {
+    lottieAnimationLayer.play(playbackMode)
+  }
+
   // MARK: Public
 
   /// The configuration that this `LottieAnimationView` uses when playing its animation
@@ -550,6 +555,11 @@ open class LottieAnimationView: LottieAnimationViewBase {
   ///    but a `RootAnimationLayer` hasn't been constructed yet
   public var currentRenderingEngine: RenderingEngine? {
     lottieAnimationLayer.currentRenderingEngine
+  }
+
+  /// The current `LottiePlaybackMode` that is being used
+  public var currentPlaybackMode: LottiePlaybackMode? {
+    lottieAnimationLayer.currentPlaybackMode
   }
 
   /// Sets the lottie file backing the animation view. Setting this will clear the

--- a/Sources/Public/Animation/LottiePlaybackMode.swift
+++ b/Sources/Public/Animation/LottiePlaybackMode.swift
@@ -1,0 +1,117 @@
+// Created by Cal Stephens on 8/3/23.
+// Copyright © 2023 Airbnb Inc. All rights reserved.
+
+import Foundation
+
+// MARK: - LottiePlaybackMode
+
+/// Configuration for how a Lottie animation should be played
+public enum LottiePlaybackMode: Hashable {
+  /// The animation is paused at the given progress value,
+  /// a value between 0.0 (0% progress) and 1.0 (100% progress).
+  case progress(_ progress: AnimationProgressTime)
+
+  /// The animation is paused at the given frame of the animation.
+  case frame(_ frame: AnimationFrameTime)
+
+  /// The animation is paused at the given time value from the start of the animation.
+  case time(_ time: TimeInterval)
+
+  /// Any existing animation will be paused at the current frame.
+  case pause
+
+  /// Plays the animation from a progress (0-1) to a progress (0-1).
+  /// - Parameter fromProgress: The start progress of the animation. If `nil` the animation will start at the current progress.
+  /// - Parameter toProgress: The end progress of the animation.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  case fromProgress(_ fromProgress: AnimationProgressTime?, toProgress: AnimationProgressTime, loopMode: LottieLoopMode)
+
+  /// The animation plays from the given `fromFrame` to the given `toFrame`.
+  /// - Parameter fromFrame: The start frame of the animation. If `nil` the animation will start at the current frame.
+  /// - Parameter toFrame: The end frame of the animation.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  case fromFrame(_ fromFrame: AnimationFrameTime?, toFrame: AnimationFrameTime, loopMode: LottieLoopMode)
+
+  /// Plays the animation from a named marker to another marker.
+  ///
+  /// Markers are point in time that are encoded into the Animation data and assigned a name.
+  ///
+  /// NOTE: If markers are not found the play command will exit.
+  ///
+  /// - Parameter fromMarker: The start marker for the animation playback. If `nil` the
+  /// animation will start at the current progress.
+  /// - Parameter toMarker: The end marker for the animation playback.
+  /// - Parameter playEndMarkerFrame: A flag to determine whether or not to play the frame of the end marker. If the
+  /// end marker represents the end of the section to play, it should be to true. If the provided end marker
+  /// represents the beginning of the next section, it should be false.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  case fromMarker(
+    _ fromMarker: String?,
+    toMarker: String,
+    playEndMarkerFrame: Bool = true,
+    loopMode: LottieLoopMode)
+
+  /// Plays the animation from a named marker to the end of the marker's duration.
+  ///
+  /// A marker is a point in time with an associated duration that is encoded into the
+  /// animation data and assigned a name.
+  ///
+  /// NOTE: If marker is not found the play command will exit.
+  ///
+  /// - Parameter marker: The start marker for the animation playback.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  case marker(_ marker: String, loopMode: LottieLoopMode)
+
+  /// Plays the given markers sequentially in order.
+  ///
+  /// A marker is a point in time with an associated duration that is encoded into the
+  /// animation data and assigned a name. Multiple markers can be played sequentially
+  /// to create programmable animations.
+  ///
+  /// If a marker is not found, it will be skipped.
+  ///
+  /// If a marker doesn't have a duration value, it will play with a duration of 0
+  /// (effectively being skipped).
+  ///
+  /// If another animation is played (by calling any `play` method) while this
+  /// marker sequence is playing, the marker sequence will be cancelled.
+  ///
+  /// - Parameter markers: The list of markers to play sequentially.
+  case markers(_ markers: [String])
+}
+
+extension LottiePlaybackMode {
+  /// Plays the animation from the current progress to a progress value (0-1).
+  /// - Parameter toProgress: The end progress of the animation.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  public static func toProgress(_ toProgress: AnimationProgressTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
+    .fromProgress(nil, toProgress: toProgress, loopMode: loopMode)
+  }
+
+  // Plays the animation from the current frame to the given frame.
+  /// - Parameter toFrame: The end frame of the animation.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  public static func toFrame(_ toFrame: AnimationFrameTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
+    .fromFrame(nil, toFrame: toFrame, loopMode: loopMode)
+  }
+
+  /// Plays the animation from the current frame to some marker.
+  ///
+  /// Markers are point in time that are encoded into the Animation data and assigned a name.
+  ///
+  /// NOTE: If the marker isn't found the play command will exit.
+  ///
+  /// - Parameter toMarker: The end marker for the animation playback.
+  /// - Parameter playEndMarkerFrame: A flag to determine whether or not to play the frame of the end marker. If the
+  /// end marker represents the end of the section to play, it should be to true. If the provided end marker
+  /// represents the beginning of the next section, it should be false.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  public static func toMarker(
+    _ toMarker: String,
+    playEndMarkerFrame: Bool = true,
+    loopMode: LottieLoopMode)
+    -> LottiePlaybackMode
+  {
+    .fromMarker(nil, toMarker: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode)
+  }
+}


### PR DESCRIPTION
This PR adds a new `LottiePlaybackMode` type, which we can use to add SwiftUI APIs for controlling the animation's playback behavior.

https://github.com/airbnb/lottie-ios/issues/2123 revealed an issue with the previous implementation approach using `configure { ... }`. Here's an example where the `LottieView` unexpectedly doesn't respect that the playback should be unexpectedly starts playing again. This was because `looping()` and `currentProgress(...)` were both adding a separate `configure` closure, which conflicted with eachother.

<img src="https://github.com/airbnb/lottie-ios/assets/1811727/5eaf6051-ca15-408a-9377-4b3c4c0dd17d" width=500>

Instead, we should have a single property that is the source of truth for the animation playback configuration (`playbackMode`) which is set by both of these different APIs:

```swift
public func looping() -> Self {
  var copy = self
  copy.playbackMode = .fromProgress(0, toProgress: 1, loopMode: .loop)
  return copy
}

public func currentProgress(_ currentProgress: AnimationProgressTime?) -> Self {
  guard let currentProgress = currentProgress else { return self }
  var copy = self
  copy.playbackMode = .progress(currentProgress)
  return copy
}
```

This lets consumers express the current playback mode more fluently:

```swift
private var playbackMode: LottiePlaybackMode {
  if animationPlaying {
    return .fromProgress(playFromProgress, toProgress: playToProgress, loopMode: loopMode)
  } else {
    return .progress(sliderValue)
  }
}
```

This API also gives us an easy way to support playback modes other than just `looping`, so this PR also adds full parity with all of the playback options supported by `LottieAnimationView`. 

<img src="https://github.com/airbnb/lottie-ios/assets/1811727/3473cf9b-1896-4b3d-ae5b-81fd70a8c3bd" width=500>

Fixes https://github.com/airbnb/lottie-ios/issues/2123.