### PR TITLE
Add `animationDidFinish` API to LottieView

### DIFF
--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -54,6 +54,11 @@ struct AnimationPreviewView: View {
       .resizable()
       .reloadAnimationTrigger(currentURLIndex, showPlaceholder: false)
       .playbackMode(playbackMode)
+      .animationDidFinish { completed in
+        if completed {
+          animationPlaying = false
+        }
+      }
       .getRealtimeAnimationProgress(animationPlaying ? $sliderValue : nil)
 
       Spacer()

--- a/Sources/Private/Utility/Helpers/AnimationContext.swift
+++ b/Sources/Private/Utility/Helpers/AnimationContext.swift
@@ -9,8 +9,10 @@ import CoreGraphics
 import Foundation
 import QuartzCore
 
-/// A completion block for animations. `true` is passed in if the animation completed playing.
-public typealias LottieCompletionBlock = (Bool) -> Void
+/// A completion block for animations.
+///  - `true` is passed in if the animation completed playing.
+///  - `false` is passed in if the animation was interrupted and did not complete playing.
+public typealias LottieCompletionBlock = (_ completed: Bool) -> Void
 
 // MARK: - AnimationContext
 

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -319,8 +319,12 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// marker sequence is playing, the marker sequence will be cancelled.
   ///
   /// - Parameter markers: The list of markers to play sequentially.
-  open func play(markers: [String]) {
-    lottieAnimationLayer.play(markers: markers)
+  /// - Parameter completion: An optional completion closure to be called when the animation stops.
+  open func play(
+    markers: [String],
+    completion: LottieCompletionBlock? = nil)
+  {
+    lottieAnimationLayer.play(markers: markers, completion: completion)
   }
 
   /// Stops the animation and resets the view to its start frame.
@@ -338,8 +342,15 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   /// Applies the given `LottiePlaybackMode` to this layer.
-  open func play(_ playbackMode: LottiePlaybackMode) {
-    lottieAnimationLayer.play(playbackMode)
+  /// - Parameter animationCompletionHandler: A closure that is called after
+  ///   an animation triggered by this method completes. This completion
+  ///   handler is **not called** after setting the playback mode to a
+  ///   mode that doesn't animate (e.g. `progress`, `frame`, `time`, or `pause`).
+  open func play(
+    _ playbackMode: LottiePlaybackMode,
+    animationCompletionHandler: LottieCompletionBlock? = nil)
+  {
+    lottieAnimationLayer.play(playbackMode, animationCompletionHandler: animationCompletionHandler)
   }
 
   // MARK: Public

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -193,7 +193,10 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   /// when an animation finishes playing.
   public func animationDidFinish(_ animationCompletionHandler: LottieCompletionBlock?) -> Self {
     var copy = self
-    copy.animationCompletionHandler = animationCompletionHandler
+    copy.animationCompletionHandler = { completed in
+      animationCompletionHandler?(completed)
+      copy.animationCompletionHandler?(completed)
+    }
     return copy
   }
 

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -137,7 +137,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
             let playbackMode = playbackMode,
             playbackMode != context.view.currentPlaybackMode
           {
-            context.view.play(playbackMode)
+            context.view.play(playbackMode, animationCompletionHandler: animationCompletionHandler)
           }
         }
         .configurations(configurations)
@@ -186,6 +186,14 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   public func playbackMode(_ playbackMode: LottiePlaybackMode) -> Self {
     var copy = self
     copy.playbackMode = playbackMode
+    return copy
+  }
+
+  /// Returns a copy of this view with the given `LottieCompletionBlock` that is called
+  /// when an animation finishes playing.
+  public func animationDidFinish(_ animationCompletionHandler: LottieCompletionBlock?) -> Self {
+    var copy = self
+    copy.animationCompletionHandler = animationCompletionHandler
     return copy
   }
 
@@ -394,6 +402,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   private var playbackMode: LottiePlaybackMode?
   private var reloadAnimationTrigger: AnyEquatable?
   private var loadAnimation: (() async throws -> LottieAnimationSource?)?
+  private var animationCompletionHandler: LottieCompletionBlock?
   private var showPlaceholderWhileReloading = false
   private var imageProvider: AnimationImageProvider?
   private var textProvider: AnimationTextProvider = DefaultTextProvider()


### PR DESCRIPTION
This PR adds an `animationDidFinish` API to LottieView. 

When using `loopMode: .playOnce`, or another finite duration animation like `.repeat(3)`, this lets you know when the animation is complete. 

For example, in the example app you can see we previously didn't update the "pause" button to the "play" state when the animation ended. Now we do:

```swift
.animationDidFinish { completed in
  if completed {
    animationPlaying = false
  }
}
```

| Before | After |
| ---- | ----- |
| ![2023-08-10 10 43 29](https://github.com/airbnb/lottie-ios/assets/1811727/794e6d83-1ab1-47df-a41d-e34dbfb57050) | ![2023-08-10 10 59 35](https://github.com/airbnb/lottie-ios/assets/1811727/ca082a73-9dda-421c-bf7a-a51665c35fec) |
