### PR TITLE
Add option make main thread rendering engine force display update on every frame

### DIFF
--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -94,8 +94,8 @@ final class CoreAnimationLayer: BaseAnimationLayer {
     }
   }
 
-  /// The parent `LottieAnimationView` that manages this layer
-  weak var animationView: LottieAnimationView?
+  /// The parent `LottieAnimationLayer` that manages this layer
+  weak var lottieAnimationLayer: LottieAnimationLayer?
 
   /// A closure that is called after this layer sets up its animation.
   /// If the animation setup was unsuccessful and encountered compatibility issues,
@@ -316,7 +316,7 @@ final class CoreAnimationLayer: BaseAnimationLayer {
     else { return }
 
     if isAnimationPlaying == true {
-      animationView?.updateInFlightAnimation()
+      lottieAnimationLayer?.updateInFlightAnimation()
     } else {
       let currentFrame = currentFrame
       removeAnimations()

--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -140,7 +140,7 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
       newFrame = floor(newFrame)
     }
     for animationLayer in animationLayers {
-      animationLayer.displayWithFrame(frame: newFrame, forceUpdates: false)
+      animationLayer.displayWithFrame(frame: newFrame, forceUpdates: forceDisplayUpdateOnEachFrame)
     }
   }
 
@@ -149,8 +149,16 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
   /// The animatable Current Frame Property
   @NSManaged var currentFrame: CGFloat
 
-  /// The parent `LottieAnimationView` that manages this layer
-  weak var animationView: LottieAnimationView?
+  /// The parent `LottieAnimationLayer` that manages this layer
+  weak var lottieAnimationLayer: LottieAnimationLayer?
+
+  /// Whether or not to use `forceDisplayUpdate()` when rendering each individual frame.
+  ///  - The main thread rendering engine implements optimizations to decrease the amount
+  ///    of properties that have to be re-rendered on each frame. There are some cases
+  ///    where this can result in bugs / incorrect behavior, so we allow it to be disabled.
+  ///  - Forcing a full render on every frame will decrease performance, and is not recommended
+  ///    except as a workaround to a bug in the main thread rendering engine.
+  var forceDisplayUpdateOnEachFrame = false
 
   var animationLayers: ContiguousArray<CompositionLayer>
 

--- a/Sources/Private/RootAnimationLayer.swift
+++ b/Sources/Private/RootAnimationLayer.swift
@@ -7,7 +7,7 @@ import QuartzCore
 
 /// A root `CALayer` responsible for playing a Lottie animation
 protocol RootAnimationLayer: CALayer {
-  var animationView: LottieAnimationView? { get set }
+  var lottieAnimationLayer: LottieAnimationLayer? { get set }
 
   var currentFrame: AnimationFrameTime { get set }
   var renderScale: CGFloat { get set }

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -427,9 +427,6 @@ public class LottieAnimationLayer: CALayer {
   /// Will inform the receiver the type of rendering engine that is used for the layer.
   public var animationLayerDidLoad:((_ animationLayer: LottieAnimationLayer, _ renderingEngine: RenderingEngineOption) -> Void)?
 
-  /// The parent `LottieAnimationView` of this layer, if applicable.
-  public internal(set) weak var animationView: LottieAnimationView?
-
   /// The configuration that this `LottieAnimationView` uses when playing its animation
   public var configuration: LottieConfiguration {
     didSet {

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -427,6 +427,9 @@ public class LottieAnimationLayer: CALayer {
   /// Will inform the receiver the type of rendering engine that is used for the layer.
   public var animationLayerDidLoad:((_ animationLayer: LottieAnimationLayer, _ renderingEngine: RenderingEngineOption) -> Void)?
 
+  /// The parent `LottieAnimationView` of this layer, if applicable.
+  public internal(set) weak var animationView: LottieAnimationView?
+
   /// The configuration that this `LottieAnimationView` uses when playing its animation
   public var configuration: LottieConfiguration {
     didSet {
@@ -703,9 +706,19 @@ public class LottieAnimationLayer: CALayer {
     }
   }
 
-  public var animationView: LottieAnimationView? {
-    set { rootAnimationLayer?.animationView = newValue }
-    get { rootAnimationLayer?.animationView }
+  /// Whether or not the Main Thread rendering engine should use `forceDisplayUpdate()`
+  /// when rendering each individual frame.
+  ///  - The main thread rendering engine implements optimizations to decrease the amount
+  ///    of properties that have to be re-rendered on each frame. There are some cases
+  ///    where this can result in bugs / incorrect behavior, so we allow it to be disabled.
+  ///  - Forcing a full render on every frame will decrease performance, and is not recommended
+  ///    except as a workaround to a bug in the main thread rendering engine.
+  ///  - Has no effect when using the Core Animation rendering engine.
+  public var mainThreadRenderingEngineShouldForceDisplayUpdateOnEachFrame = false {
+    didSet {
+      (rootAnimationLayer as? MainThreadAnimationLayer)?.forceDisplayUpdateOnEachFrame
+        = mainThreadRenderingEngineShouldForceDisplayUpdateOnEachFrame
+    }
   }
 
   /// Sets the lottie file backing the animation layer. Setting this will clear the
@@ -1085,6 +1098,8 @@ public class LottieAnimationLayer: CALayer {
       return
     }
 
+    animationLayer.lottieAnimationLayer = self
+
     animationLayerDidLoad?(self, renderingEngine)
 
     animationLayer.renderScale = screenScale
@@ -1098,13 +1113,16 @@ public class LottieAnimationLayer: CALayer {
   }
 
   fileprivate func makeMainThreadAnimationLayer(for animation: LottieAnimation) -> MainThreadAnimationLayer {
-    MainThreadAnimationLayer(
+    let mainThreadAnimationLayer = MainThreadAnimationLayer(
       animation: animation,
       imageProvider: imageProvider.cachedImageProvider,
       textProvider: textProvider,
       fontProvider: fontProvider,
       maskAnimationToBounds: maskAnimationToBounds,
       logger: logger)
+
+    mainThreadAnimationLayer.forceDisplayUpdateOnEachFrame = mainThreadRenderingEngineShouldForceDisplayUpdateOnEachFrame
+    return mainThreadAnimationLayer
   }
 
   fileprivate func makeCoreAnimationLayer(for animation: LottieAnimation) -> CoreAnimationLayer? {

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -808,7 +808,6 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   override func commonInit() {
     super.commonInit()
-    lottieAnimationLayer.animationView = self
     lottieAnimationLayer.screenScale = screenScale
     viewLayer?.addSublayer(lottieAnimationLayer)
 

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -573,6 +573,19 @@ open class LottieAnimationView: LottieAnimationViewBase {
     lottieAnimationLayer.currentPlaybackMode
   }
 
+  /// Whether or not the Main Thread rendering engine should use `forceDisplayUpdate()`
+  /// when rendering each individual frame.
+  ///  - The main thread rendering engine implements optimizations to decrease the amount
+  ///    of properties that have to be re-rendered on each frame. There are some cases
+  ///    where this can result in bugs / incorrect behavior, so we allow it to be disabled.
+  ///  - Forcing a full render on every frame will decrease performance, and is not recommended
+  ///    except as a workaround to a bug in the main thread rendering engine.
+  ///  - Has no effect when using the Core Animation rendering engine.
+  public var mainThreadRenderingEngineShouldForceDisplayUpdateOnEachFrame: Bool {
+    get { lottieAnimationLayer.mainThreadRenderingEngineShouldForceDisplayUpdateOnEachFrame }
+    set { lottieAnimationLayer.mainThreadRenderingEngineShouldForceDisplayUpdateOnEachFrame = newValue }
+  }
+
   /// Sets the lottie file backing the animation view. Setting this will clear the
   /// view's contents, completion blocks and current state. The new animation will
   /// be loaded up and set to the beginning of its timeline.
@@ -795,6 +808,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   override func commonInit() {
     super.commonInit()
+    lottieAnimationLayer.animationView = self
     lottieAnimationLayer.screenScale = screenScale
     viewLayer?.addSublayer(lottieAnimationLayer)
 
@@ -805,11 +819,10 @@ open class LottieAnimationView: LottieAnimationViewBase {
       self.setNeedsLayout()
     }
 
-    lottieAnimationLayer.animationLayerDidLoad = { [weak self] lottieAnimationLayer, _ in
+    lottieAnimationLayer.animationLayerDidLoad = { [weak self] _, _ in
       guard let self = self else { return }
       self.invalidateIntrinsicContentSize()
       self.setNeedsLayout()
-      lottieAnimationLayer.animationView = self
     }
   }
 


### PR DESCRIPTION
This PR adds a workaround for a bug in the main thread rendering engine where it's possible for layer properties to be rendered with a stale, out-of-date value.

In the animation below (with colors modified for emphasis), the animation plays correctly during the first loop. But after it completes the first loop and starts playing subsequent loops, the bottom row of circles will unexpectedly flash red.

I spent a bit of time looking in to the underlying issue. This seems to be a bug in how the main thread rendering engine decides whether or not a property (in this case, a `FillNode`) needs to be re-rendered. This is pretty complex though because it involves all of the parent layers (which in this case includes multiple parent precomp layers) and a much of mutable state that gets modified every frame. I didn't see any obvious ways to fix the issue. 

As a simple workaround, we can provide the ability to make the main thread rendering engine pass in `forceUpdates: true` on every frame. This guarantees that each property will be re-rendered each frame, avoiding the bug.

| Before | With `forceDisplayUpdateOnEachFrame` |
| ---- | ---- |
| <img src="https://github.com/airbnb/lottie-ios/assets/1811727/b9e68eed-6874-4ea4-be2f-308f8eaa602c" width=400> | <img src="https://github.com/airbnb/lottie-ios/assets/1811727/d666569e-e9b3-463a-b844-3822e2c214bd" width=400> |