### PR TITLE
add a switch to ignore internal image cache

### DIFF
--- a/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
@@ -21,7 +21,7 @@ private final class CachedImageProvider: AnimationImageProvider {
   // MARK: Public
 
   public func imageForAsset(asset: ImageAsset) -> CGImage? {
-    if imageProvider.ignoreInternalImageCache == false, let image = imageCache.object(forKey: asset.id as NSString) {
+    if imageProvider.cacheEligible, let image = imageCache.object(forKey: asset.id as NSString) {
       return image
     }
     if let image = imageProvider.imageForAsset(asset: asset) {

--- a/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
@@ -21,7 +21,7 @@ private final class CachedImageProvider: AnimationImageProvider {
   // MARK: Public
 
   public func imageForAsset(asset: ImageAsset) -> CGImage? {
-    if let image = imageCache.object(forKey: asset.id as NSString) {
+    if imageProvider.ignoreInternalImageCache == false, let image = imageCache.object(forKey: asset.id as NSString) {
       return image
     }
     if let image = imageProvider.imageForAsset(asset: asset) {

--- a/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
@@ -21,7 +21,7 @@ private final class CachedImageProvider: AnimationImageProvider {
   // MARK: Public
 
   public func imageForAsset(asset: ImageAsset) -> CGImage? {
-    if imageProvider.cacheEligible, let image = imageCache.object(forKey: asset.id as NSString) {
+    if let image = imageCache.object(forKey: asset.id as NSString) {
       return image
     }
     if let image = imageProvider.imageForAsset(asset: asset) {
@@ -42,6 +42,7 @@ extension AnimationImageProvider {
   /// It wraps the current provider as image loader, and uses `NSCache` to cache the images for resue.
   /// The cache will be reset when the `animation` is reset.
   var cachedImageProvider: AnimationImageProvider {
-    CachedImageProvider(imageProvider: self)
+    guard cacheEligible else { return self }
+    return CachedImageProvider(imageProvider: self)
   }
 }

--- a/Sources/Public/ImageProvider/AnimationImageProvider.swift
+++ b/Sources/Public/ImageProvider/AnimationImageProvider.swift
@@ -8,6 +8,8 @@
 import CoreGraphics
 import Foundation
 
+// MARK: - AnimationImageProvider
+
 /// Image provider is a protocol that is used to supply images to `LottieAnimationView`.
 ///
 /// Some animations require a reference to an image. The image provider loads and
@@ -17,15 +19,17 @@ import Foundation
 /// Additionally custom Image Providers can be made to load images from a URL,
 /// or to Cache images.
 public protocol AnimationImageProvider {
-    
-  var ignoreInternalImageCache: Bool { get set }
-    
+
+  /// Whether or not the resulting image of this image provider can be cached by Lottie. Defaults to true.
+  /// If true, Lottie may internally cache the result of `imageForAsset`
+  var cacheEligible: Bool { get set }
+
   func imageForAsset(asset: ImageAsset) -> CGImage?
 }
 
-public extension AnimationImageProvider {
-    var ignoreInternalImageCache: Bool {
-        get { return false }
-        set { }
-    }
+extension AnimationImageProvider {
+  public var cacheEligible: Bool {
+    get { true }
+    set { }
+  }
 }

--- a/Sources/Public/ImageProvider/AnimationImageProvider.swift
+++ b/Sources/Public/ImageProvider/AnimationImageProvider.swift
@@ -17,5 +17,15 @@ import Foundation
 /// Additionally custom Image Providers can be made to load images from a URL,
 /// or to Cache images.
 public protocol AnimationImageProvider {
+    
+  var ignoreInternalImageCache: Bool { get set }
+    
   func imageForAsset(asset: ImageAsset) -> CGImage?
+}
+
+public extension AnimationImageProvider {
+    var ignoreInternalImageCache: Bool {
+        get { return false }
+        set { }
+    }
 }

--- a/Sources/Public/ImageProvider/AnimationImageProvider.swift
+++ b/Sources/Public/ImageProvider/AnimationImageProvider.swift
@@ -22,14 +22,13 @@ public protocol AnimationImageProvider {
 
   /// Whether or not the resulting image of this image provider can be cached by Lottie. Defaults to true.
   /// If true, Lottie may internally cache the result of `imageForAsset`
-  var cacheEligible: Bool { get set }
+  var cacheEligible: Bool { get }
 
   func imageForAsset(asset: ImageAsset) -> CGImage?
 }
 
 extension AnimationImageProvider {
   public var cacheEligible: Bool {
-    get { true }
-    set { }
+    true
   }
 }


### PR DESCRIPTION
feature: add a switch to ignore internal image cache or not , in image provider protocol, default is false. (some scene some one want to custom the image cache in custom image provider such as replace some image in image  provider, if internal image cache enable, the replace event will fail.)