### PR TITLE
Add LottieView.animationDidLoad API

### DIFF
--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 
 // MARK: - AnimationPreviewView
 
-/// TODO: Implement functionality from UIKit `AnimationPreviewViewController`
 struct AnimationPreviewView: View {
 
   // MARK: Lifecycle

--- a/Lottie.xcodeproj/xcshareddata/xcschemes/Lottie (visionOS).xcscheme
+++ b/Lottie.xcodeproj/xcshareddata/xcschemes/Lottie (visionOS).xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "080DEF612A95707B00BE2D96"
-               BuildableName = "Lottie_visionOS.framework"
+               BuildableName = "Lottie.framework"
                BlueprintName = "Lottie-visionOS"
                ReferencedContainer = "container:Lottie.xcodeproj">
             </BuildableReference>
@@ -50,7 +50,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "080DEF612A95707B00BE2D96"
-            BuildableName = "Lottie_visionOS.framework"
+            BuildableName = "Lottie.framework"
             BlueprintName = "Lottie-visionOS"
             ReferencedContainer = "container:Lottie.xcodeproj">
          </BuildableReference>

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -117,7 +117,8 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     ZStack {
       if let animationSource = animationSource {
         LottieAnimationView.swiftUIView {
-          LottieAnimationView(
+          defer { animationDidLoad?(animationSource) }
+          return LottieAnimationView(
             animationSource: animationSource,
             imageProvider: imageProvider,
             textProvider: textProvider,
@@ -132,6 +133,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
           // prohibitive to do so on every state update.
           if animationSource.animation !== context.view.animation {
             context.view.loadAnimation(animationSource)
+            animationDidLoad?(animationSource)
           }
 
           if
@@ -187,6 +189,14 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   public func playbackMode(_ playbackMode: LottiePlaybackMode) -> Self {
     var copy = self
     copy.playbackMode = playbackMode
+    return copy
+  }
+
+  /// Returns a copy of this view with the given closure that is called whenever the
+  /// `LottieAnimationSource` of the underlying `LottieAnimationView` is updated.
+  public func animationDidLoad(_ animationDidLoad: @escaping (LottieAnimationSource) -> Void) -> Self {
+    var copy = self
+    copy.animationDidLoad = animationDidLoad
     return copy
   }
 
@@ -406,6 +416,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   private var playbackMode: LottiePlaybackMode?
   private var reloadAnimationTrigger: AnyEquatable?
   private var loadAnimation: (() async throws -> LottieAnimationSource?)?
+  private var animationDidLoad: ((LottieAnimationSource) -> Void)?
   private var animationCompletionHandler: LottieCompletionBlock?
   private var showPlaceholderWhileReloading = false
   private var imageProvider: AnimationImageProvider?

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -193,7 +193,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   }
 
   /// Returns a copy of this view with the given closure that is called whenever the
-  /// `LottieAnimationSource` of the underlying `LottieAnimationView` is updated.
+  /// `LottieAnimationSource` provided via `init` is loaded and applied to the underlying `LottieAnimationView`.
   public func animationDidLoad(_ animationDidLoad: @escaping (LottieAnimationSource) -> Void) -> Self {
     var copy = self
     copy.animationDidLoad = animationDidLoad


### PR DESCRIPTION
This PR adds a new `animationDidLoad` API to the SwiftUI `LottieView`.

`LottieAnimationView` has an `animationLoaded` API, but its design makes it hard to use from SwiftUI. To support some specific implementation details of supporting both `LottieAnimation` and `DotLottieFile` in `LottieAnimationView`, the closure is called immediately when set if `animation` isn't nil:

```swift
/// A closure that is called when `self.animation` is loaded. When setting this closure,
/// it is called immediately if `self.animation` is non-nil.
///
/// When initializing a `LottieAnimationView`, the animation will either be loaded
/// synchronously (when loading a `LottieAnimation` from a .json file on disk)
/// or asynchronously (when loading a `DotLottieFile` from disk, or downloading
/// an animation from a URL). This closure is called in both cases once the
/// animation is loaded and applied, so can be a useful way to configure this
/// `LottieAnimationView` regardless of which initializer was used. For example:
///
/// ```
/// let animationView: LottieAnimationView
///
/// if loadDotLottieFile {
///   // Loads the .lottie file asynchronously
///   animationView = LottieAnimationView(dotLottieName: "animation")
/// } else {
///   // Loads the .json file synchronously
///   animationView = LottieAnimationView(name: "animation")
/// }
///
/// animationView.animationLoaded = { animationView, animation in
///   // If using a .lottie file, this is called once the file finishes loading.
///   // If using a .json file, this is called immediately (since the animation is loaded synchronously).
///   animationView.play()
/// }
/// ```
public var animationLoaded: ((_ animationView: LottieAnimationView, _ animation: LottieAnimation) -> Void)? {
  didSet {
    if let animation = animation {
      animationLoaded?(self, animation)
    }
  }
}
```

This doesn't work well when paired with `.configure`, because a call like this will invoke `animationLoaded` every time `configure` is called (which is arbitrarily often):

```swift
.configure { animationView in
  animationView.animationLoaded = {  _, _ in
    // handle the animation being loaded
    // (whoops, this is called way too often)
  }
}
```

In retrospect this was a bad API choice (imo) and we would have been better off with an API more similar to how `LottieView` works with `LottieAnimationSource`. Unfortunately we're stuck with this design on `LottieAnimationView` due to backwards compatibility.

To make this more obvious when using `LottieView`, lets just add a new `animationDidLoad` API with the expected semantics (only called after calling `animationView.loadAnimation(animationSource)`):

```swift
.animationDidLoad { _ in
  // handle the animation being loaded
}
```