### PR TITLE
Add simplified `play()` API to LottieView

### DIFF
--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -175,9 +175,20 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     return copy
   }
 
-  /// Returns a copy of this view that loops its animation whenever visible
+  // Returns a copy of this view playing once from the current frame to the end frame
+  public func play() -> Self {
+    play(loopMode: .playOnce)
+  }
+
+  /// Returns a copy of this view that loops its animation from the start to end whenever visible
   public func looping() -> Self {
-    play(.fromProgress(0, toProgress: 1, loopMode: .loop))
+    play(loopMode: .loop)
+  }
+
+  /// Returns a copy of this view playing from the current frame to the end frame,
+  /// with the given `LottiePlaybackMode`.
+  public func play(loopMode: LottieLoopMode = .playOnce) -> Self {
+    play(.toProgress(1, loopMode: loopMode))
   }
 
   /// Returns a copy of this view playing with the given `LottiePlaybackMode`

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -182,7 +182,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
 
   /// Returns a copy of this view that loops its animation from the start to end whenever visible
   public func looping() -> Self {
-    play(loopMode: .loop)
+    play(.fromProgress(0, toProgress: 1, loopMode: .loop))
   }
 
   /// Returns a copy of this view playing from the current frame to the end frame,


### PR DESCRIPTION
This PR adds a simplified `play()` and `play(loopMode:)` API to `LottieView` for the use case where you just want to play the animation from the start to the end. `LottieAnimationView` provides a similar API.

We got feedback from early adopters at Airbnb that the existing API for this (`.play(.toFrame(1, loopMode: .playOnce))`) felt too verbose compared to the simple `play()` method folks are used to on `LottieAnimationView`.