### PR TITLE
Fix issue where `LottieAnimationLayer.pause()` didn't update `currentPlaybackMode`

### DIFF
--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -358,6 +358,7 @@ public class LottieAnimationLayer: CALayer {
   /// The completion closure will be called with `false`
   open func pause() {
     removeCurrentAnimation()
+    currentPlaybackMode = .pause
   }
 
   /// Applies the given `LottiePlaybackMode` to this layer.


### PR DESCRIPTION
This PR fixes an issue where `LottieAnimationLayer.pause()` didn't update `currentPlaybackMode`.

I was writing the announcement for Lottie 4.3.0, and included this sample code:

```swift
// The Lottie animation is controlled by this SwiftUI state
@State var playbackMode = LottiePlaybackMode.pause

var body: some View {
  HStack {
    LottieView(animation: .named("HeartAnimation"))
      .play(playbackMode)
      .animationDidFinish { _ in
        playbackMode = .pause
      }
  
    // When the button is pressed, trigger the animation to start playing from the beginning
    Button {
      playbackMode = .fromProgress(0, toProgress: 1, loopMode: .playOnce)
    } label: {
      Image(systemName: "play.fill")
    }
  }
}
```

When testing that on master, setting `playbackMode = .fromProgress(0, toProgress: 1, loopMode: .playOnce)` didn't cause the animation to start playing again.

This was because `LottieAnimationLayer.pause()` wasn't updating `currentPlaybackMode`, so the value of `currentPlaybackMode` was still `.fromProgress(0, toProgress: 1, loopMode: .playOnce)`. That caused subsequent calls to be ignored.

| Before | After |
| ---- | ---- |
| ![2023-09-14 12 07 47](https://github.com/airbnb/lottie-ios/assets/1811727/72d7d6da-f4ed-4f0c-9092-38f1f6943dea) | ![2023-09-14 12 08 38](https://github.com/airbnb/lottie-ios/assets/1811727/032e3c01-1540-4a3a-86a8-e041ac629546) |