### PR TITLE
Initialization fix for xib files

### DIFF
--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -193,8 +193,10 @@ public final class CompatibleAnimationView: UIView {
     commonInit()
   }
 
-  required init?(coder _: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
+  required init?(coder: NSCoder) {
+    animationView = LottieAnimationView()
+    super.init(coder: coder)
+    commonInit()
   }
 
   // MARK: Public


### PR DESCRIPTION
xib uses init method with NSCoder parameter.
Fix is pretty simple: just add initialization logic for this method instead of throwing fatal error