### PR TITLE
Fix layout animation regression introduced in 4.3.0

### DIFF
--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -449,7 +449,9 @@ extension CoreAnimationLayer: RootAnimationLayer {
   }
 
   func forceDisplayUpdate() {
-    display()
+    // Unimplemented
+    //  - We can't call `display()` here, because it would cause unexpected frame animations:
+    //    https://github.com/airbnb/lottie-ios/issues/2193
   }
 
   func logHierarchyKeypaths() {

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -794,6 +794,9 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   // MARK: Internal
 
+  // The backing CALayer for this animation view.
+  let lottieAnimationLayer: LottieAnimationLayer
+
   var animationLayer: RootAnimationLayer? {
     lottieAnimationLayer.rootAnimationLayer
   }
@@ -1028,9 +1031,6 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   // MARK: Private
-
-  // The backing CALayer for this animation view.
-  private let lottieAnimationLayer: LottieAnimationLayer
 
   private let logger: LottieLogger
 }

--- a/Tests/TextProviderTests.swift
+++ b/Tests/TextProviderTests.swift
@@ -1,9 +1,6 @@
 // Created by Cal Stephens on 9/12/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-// Created by Cal Stephens on 5/2/22.
-// Copyright © 2022 Airbnb Inc. All rights reserved.
-
 import SnapshotTesting
 import UIKit
 import XCTest
@@ -79,7 +76,7 @@ final class TextProviderTests: XCTestCase {
       configuration: configuration,
       customSnapshotConfiguration: .customTextProvider(textProvider))!
 
-    animationView.forceDisplayUpdate()
+    animationView.renderContentsForUnitTests()
 
     return textProvider.methodCalls
   }
@@ -128,5 +125,18 @@ private final class LoggingAnimationKeypathTextProvider: AnimationKeypathTextPro
     let keypathString = keypath.keys.joined(separator: ".")
     methodCalls.append("text(for: \"\(keypathString)\", sourceText: \"\(sourceText)\")")
     return nil
+  }
+}
+
+extension LottieAnimationView {
+  // Causes this `LottieAnimationView` to render its contents immediately
+  func renderContentsForUnitTests() {
+    if let mainThreadAnimationLayer = lottieAnimationLayer.animationLayer as? MainThreadAnimationLayer {
+      mainThreadAnimationLayer.forceDisplayUpdate()
+    } else if let coreAnimationLayer = lottieAnimationLayer.animationLayer as? CoreAnimationLayer {
+      // `forceDisplayUpdate()` is not implemented for `CoreAnimationLayer`, so instead we call
+      // `display()` to force it to render any pending animation configurations.
+      coreAnimationLayer.display()
+    }
   }
 }


### PR DESCRIPTION
This PR fixes a regression introduced by #2183 where the frame of the animation layer could unexpectedly animate.

I don't have repro steps for this, but I worked with @aureliencolas to identify the change that introduced the regression: https://github.com/airbnb/lottie-ios/issues/2193#issuecomment-1722586996

#2183 added a `display()` call to `CoreAnimationLayer.forceDisplayUpdate()`, which appears to be the culprit here. We can revert that change and implement the behavior needed for those tests a different way.

Here's a gif from the issue showing the regression, which is fixed by this change:

<img src="https://user-images.githubusercontent.com/82930766/268718609-26c85e69-f70c-489c-8c05-bbffebfa6a99.gif">