### PR TITLE
Allow pausing at marker

### DIFF
--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -121,7 +121,7 @@ struct AnimationPreviewView: View {
 
   private var playbackMode: LottiePlaybackMode {
     if animationPlaying {
-      return .play(.progress(from: playFromProgress, to: playToProgress, loopMode: loopMode))
+      return .play(.fromProgress(playFromProgress, toProgress: playToProgress, loopMode: loopMode))
     } else {
       return .paused(at: .progress(sliderValue))
     }

--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -121,7 +121,7 @@ struct AnimationPreviewView: View {
 
   private var playbackMode: LottiePlaybackMode {
     if animationPlaying {
-      return .play(.fromProgress(playFromProgress, toProgress: playToProgress, loopMode: loopMode))
+      return .playing(.fromProgress(playFromProgress, toProgress: playToProgress, loopMode: loopMode))
     } else {
       return .paused(at: .progress(sliderValue))
     }

--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -121,9 +121,9 @@ struct AnimationPreviewView: View {
 
   private var playbackMode: LottiePlaybackMode {
     if animationPlaying {
-      return .fromProgress(playFromProgress, toProgress: playToProgress, loopMode: loopMode)
+      return .play(.progress(from: playFromProgress, to: playToProgress, loopMode: loopMode))
     } else {
-      return .progress(sliderValue)
+      return .paused(at: .progress(sliderValue))
     }
   }
 

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -107,7 +107,7 @@ public class LottieAnimationLayer: CALayer {
     guard let animation = animation else { return }
 
     defer {
-      currentPlaybackMode = .play(.progress(to: 1, loopMode: loopMode))
+      currentPlaybackMode = .play(.fromProgress(nil, toProgress: 1, loopMode: loopMode))
     }
 
     if shouldOverrideWithReducedMotionAnimation {
@@ -139,7 +139,7 @@ public class LottieAnimationLayer: CALayer {
     guard let animation = animation else { return }
 
     defer {
-      currentPlaybackMode = .play(.progress(from: fromProgress, to: toProgress, loopMode: loopMode ?? self.loopMode))
+      currentPlaybackMode = .play(.fromProgress(fromProgress, toProgress: toProgress, loopMode: loopMode ?? self.loopMode))
     }
 
     if shouldOverrideWithReducedMotionAnimation {
@@ -172,7 +172,7 @@ public class LottieAnimationLayer: CALayer {
     completion: LottieCompletionBlock? = nil)
   {
     defer {
-      currentPlaybackMode = .play(.frames(from: fromFrame, to: toFrame, loopMode: loopMode ?? self.loopMode))
+      currentPlaybackMode = .play(.fromFrame(fromFrame, toFrame: toFrame, loopMode: loopMode ?? self.loopMode))
     }
 
     if shouldOverrideWithReducedMotionAnimation {
@@ -216,9 +216,9 @@ public class LottieAnimationLayer: CALayer {
     completion: LottieCompletionBlock? = nil)
   {
     defer {
-      currentPlaybackMode = .play(.markers(
-        from: fromMarker,
-        to: toMarker,
+      currentPlaybackMode = .play(.fromMarker(
+        fromMarker,
+        toMarker: toMarker,
         playEndMarkerFrame: playEndMarkerFrame,
         loopMode: loopMode ?? self.loopMode))
     }
@@ -311,7 +311,7 @@ public class LottieAnimationLayer: CALayer {
     guard !markers.isEmpty else { return }
 
     defer {
-      currentPlaybackMode = .play(.markerList(markers))
+      currentPlaybackMode = .play(.markers(markers))
     }
 
     if shouldOverrideWithReducedMotionAnimation {
@@ -371,7 +371,7 @@ public class LottieAnimationLayer: CALayer {
 
     case .frame(let animationFrameTime):
       currentFrame = animationFrameTime
-    case .timestamp(let timeInterval):
+    case .time(let timeInterval):
       currentTime = timeInterval
 
     case .marker(let name, let position):
@@ -399,6 +399,7 @@ public class LottieAnimationLayer: CALayer {
   }
 
   /// Applies the given `LottiePlaybackMode` to this layer.
+  /// - Parameter playbackMode: The playback mode to apply
   /// - Parameter completion: A closure that is called after
   ///   an animation triggered by this method completes.
   open func setPlaybackMode(
@@ -419,45 +420,49 @@ public class LottieAnimationLayer: CALayer {
       pause(at: .frame(frame))
 
     case .time(let time):
-      pause(at: .timestamp(time))
+      pause(at: .time(time))
 
     case .pause:
       pause(at: .currentFrame)
 
     case .fromProgress(let from, let to, let loopMode):
-      play(.progress(from: from, to: to, loopMode: loopMode), completion: completion)
+      play(.fromProgress(from, toProgress: to, loopMode: loopMode), completion: completion)
 
     case .fromFrame(let from, let to, let loopMode):
-      play(.frames(from: from, to: to, loopMode: loopMode), completion: completion)
+      play(.fromFrame(from, toFrame: to, loopMode: loopMode), completion: completion)
 
     case .fromMarker(let from, let to, let playEndMarkerFrame, let loopMode):
-      play(.markers(from: from, to: to, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode), completion: completion)
+      play(.fromMarker(from, toMarker: to, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode), completion: completion)
 
     case .marker(let name, let loopMode):
       play(.marker(name, loopMode: loopMode), completion: completion)
 
     case .markers(let names):
-      play(.markerList(names), completion: completion)
+      play(.markers(names), completion: completion)
     }
   }
 
-  open func play(_ mode: LottiePlaybackMode.PlaybackMode, completion: LottieCompletionBlock? = nil) {
-    switch mode {
-    case .progress(from: let from, to: let to, loopMode: let loopMode):
+  /// Applies the given `LottiePlaybackMode` to this layer.
+  /// - Parameter playbackMode: The playback mode to apply
+  /// - Parameter completion: A closure that is called after
+  ///   an animation triggered by this method completes.
+  open func play(_ playbackMode: LottiePlaybackMode.PlaybackMode, completion: LottieCompletionBlock? = nil) {
+    switch playbackMode {
+    case .fromProgress(let from, let to, let loopMode):
       play(
         fromProgress: from,
         toProgress: to,
         loopMode: loopMode,
         completion: completion)
 
-    case .frames(from: let from, to: let to, loopMode: let loopMode):
+    case .fromFrame(let from, let to, let loopMode):
       play(
         fromFrame: from,
         toFrame: to,
         loopMode: loopMode,
         completion: completion)
 
-    case .markers(let from, let to, let playEndMarkerFrame, let loopMode):
+    case .fromMarker(let from, let to, let playEndMarkerFrame, let loopMode):
       play(
         fromMarker: from,
         toMarker: to,
@@ -468,7 +473,7 @@ public class LottieAnimationLayer: CALayer {
     case .marker(let name, loopMode: let loopMode):
       play(marker: name, loopMode: loopMode, completion: completion)
 
-    case .markerList(let names):
+    case .markers(let names):
       play(markers: names, completion: completion)
     }
   }
@@ -681,7 +686,7 @@ public class LottieAnimationLayer: CALayer {
     set {
       if let animation = animation {
         currentFrame = animation.frameTime(forTime: newValue)
-        currentPlaybackMode = .paused(at: .timestamp(newValue))
+        currentPlaybackMode = .paused(at: .time(newValue))
       } else {
         currentFrame = 0
       }

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -345,6 +345,25 @@ public class LottieAnimationLayer: CALayer {
     })
   }
 
+  /// Pauses the animation at a given marker and position
+  open func pause(at marker: String, position: LottiePlaybackMode.MarkerPosition)
+  {
+    guard let from = animation?.markerMap?[marker] else {
+      return
+    }
+
+    defer {
+      currentPlaybackMode = .pausedAtMarker(marker, position: position)
+    }
+
+    switch position {
+    case .start:
+      currentTime = from.frameTime
+    case .end:
+      currentTime = from.frameTime + from.durationFrameTime
+    }
+  }
+
   /// Stops the animation and resets the layer to its start frame.
   ///
   /// The completion closure will be called with `false`
@@ -382,6 +401,9 @@ public class LottieAnimationLayer: CALayer {
 
     case .pause:
       pause()
+
+    case .pausedAtMarker(let marker, let position):
+      pause(at: marker, position: position)
 
     case .fromProgress(let fromProgress, let toProgress, let loopMode):
       play(

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -107,7 +107,7 @@ public class LottieAnimationLayer: CALayer {
     guard let animation = animation else { return }
 
     defer {
-      currentPlaybackMode = .play(.fromProgress(nil, toProgress: 1, loopMode: loopMode))
+      currentPlaybackMode = .playing(.fromProgress(nil, toProgress: 1, loopMode: loopMode))
     }
 
     if shouldOverrideWithReducedMotionAnimation {
@@ -139,7 +139,7 @@ public class LottieAnimationLayer: CALayer {
     guard let animation = animation else { return }
 
     defer {
-      currentPlaybackMode = .play(.fromProgress(fromProgress, toProgress: toProgress, loopMode: loopMode ?? self.loopMode))
+      currentPlaybackMode = .playing(.fromProgress(fromProgress, toProgress: toProgress, loopMode: loopMode ?? self.loopMode))
     }
 
     if shouldOverrideWithReducedMotionAnimation {
@@ -172,7 +172,7 @@ public class LottieAnimationLayer: CALayer {
     completion: LottieCompletionBlock? = nil)
   {
     defer {
-      currentPlaybackMode = .play(.fromFrame(fromFrame, toFrame: toFrame, loopMode: loopMode ?? self.loopMode))
+      currentPlaybackMode = .playing(.fromFrame(fromFrame, toFrame: toFrame, loopMode: loopMode ?? self.loopMode))
     }
 
     if shouldOverrideWithReducedMotionAnimation {
@@ -216,7 +216,7 @@ public class LottieAnimationLayer: CALayer {
     completion: LottieCompletionBlock? = nil)
   {
     defer {
-      currentPlaybackMode = .play(.fromMarker(
+      currentPlaybackMode = .playing(.fromMarker(
         fromMarker,
         toMarker: toMarker,
         playEndMarkerFrame: playEndMarkerFrame,
@@ -273,7 +273,7 @@ public class LottieAnimationLayer: CALayer {
     }
 
     defer {
-      currentPlaybackMode = .play(.marker(marker, loopMode: loopMode ?? self.loopMode))
+      currentPlaybackMode = .playing(.marker(marker, loopMode: loopMode ?? self.loopMode))
     }
 
     if shouldOverrideWithReducedMotionAnimation {
@@ -311,7 +311,7 @@ public class LottieAnimationLayer: CALayer {
     guard !markers.isEmpty else { return }
 
     defer {
-      currentPlaybackMode = .play(.markers(markers))
+      currentPlaybackMode = .playing(.markers(markers))
     }
 
     if shouldOverrideWithReducedMotionAnimation {
@@ -410,7 +410,7 @@ public class LottieAnimationLayer: CALayer {
     case .paused(at: let state):
       pause(at: state)
 
-    case .play(let mode):
+    case .playing(let mode):
       play(mode, completion: completion)
 
     case .progress(let progress):

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -346,8 +346,7 @@ public class LottieAnimationLayer: CALayer {
   }
 
   /// Pauses the animation at a given marker and position
-  open func pause(at marker: String, position: LottiePlaybackMode.MarkerPosition)
-  {
+  open func pause(at marker: String, position: LottiePlaybackMode.MarkerPosition) {
     guard let from = animation?.markerMap?[marker] else {
       return
     }

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -219,6 +219,13 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   // MARK: Open
 
+  /// Applies the given `LottiePlaybackMode` to this layer.
+  /// - Parameter completion: A closure that is called after
+  ///   an animation triggered by this method completes.
+  open func play(_ mode: LottiePlaybackMode.PlaybackMode, completion: LottieCompletionBlock? = nil) {
+    lottieAnimationLayer.play(mode, completion: completion)
+  }
+
   /// Plays the animation from its current state to the end.
   ///
   /// - Parameter completion: An optional completion closure to be called when the animation completes playing.
@@ -341,16 +348,22 @@ open class LottieAnimationView: LottieAnimationViewBase {
     lottieAnimationLayer.pause()
   }
 
-  /// Applies the given `LottiePlaybackMode` to this layer.
-  /// - Parameter animationCompletionHandler: A closure that is called after
-  ///   an animation triggered by this method completes. This completion
-  ///   handler is **not called** after setting the playback mode to a
-  ///   mode that doesn't animate (e.g. `progress`, `frame`, `time`, or `pause`).
+  @available(*, deprecated, renamed: "setPlaybackMode(_:completion:)", message: "Will be removed in a future major release.")
   open func play(
     _ playbackMode: LottiePlaybackMode,
     animationCompletionHandler: LottieCompletionBlock? = nil)
   {
-    lottieAnimationLayer.play(playbackMode, animationCompletionHandler: animationCompletionHandler)
+    lottieAnimationLayer.setPlaybackMode(playbackMode, completion: animationCompletionHandler)
+  }
+
+  /// Applies the given `LottiePlaybackMode` to this layer.
+  /// - Parameter completion: A closure that is called after
+  ///   an animation triggered by this method completes.
+  open func setPlaybackMode(
+    _ playbackMode: LottiePlaybackMode,
+    completion: LottieCompletionBlock? = nil)
+  {
+    lottieAnimationLayer.setPlaybackMode(playbackMode, completion: completion)
   }
 
   // MARK: Public

--- a/Sources/Public/Animation/LottiePlaybackMode.swift
+++ b/Sources/Public/Animation/LottiePlaybackMode.swift
@@ -10,7 +10,7 @@ public enum LottiePlaybackMode: Hashable {
 
   case paused(at: PausedState)
 
-  case play(_ mode: PlaybackMode)
+  case playing(_ mode: PlaybackMode)
 
   @available(*, deprecated, renamed: "LottiePlaybackMode.paused(at:)", message: "Will be removed in a future major release.")
   case progress(_ progress: AnimationProgressTime)
@@ -141,12 +141,12 @@ extension LottiePlaybackMode {
 
   @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   public static func toProgress(_ toProgress: AnimationProgressTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
-    .play(.fromProgress(nil, toProgress: toProgress, loopMode: loopMode))
+    .playing(.fromProgress(nil, toProgress: toProgress, loopMode: loopMode))
   }
 
   @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   public static func toFrame(_ toFrame: AnimationFrameTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
-    .play(.fromFrame(nil, toFrame: toFrame, loopMode: loopMode))
+    .playing(.fromFrame(nil, toFrame: toFrame, loopMode: loopMode))
   }
 
   @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
@@ -156,7 +156,7 @@ extension LottiePlaybackMode {
     loopMode: LottieLoopMode)
     -> LottiePlaybackMode
   {
-    .play(.fromMarker(nil, toMarker: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode))
+    .playing(.fromMarker(nil, toMarker: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode))
   }
 }
 

--- a/Sources/Public/Animation/LottiePlaybackMode.swift
+++ b/Sources/Public/Animation/LottiePlaybackMode.swift
@@ -7,6 +7,13 @@ import Foundation
 
 /// Configuration for how a Lottie animation should be played
 public enum LottiePlaybackMode: Hashable {
+
+  /// The position within a marker.
+  public enum MarkerPosition: Hashable {
+    case start
+    case end
+  }
+
   /// The animation is paused at the given progress value,
   /// a value between 0.0 (0% progress) and 1.0 (100% progress).
   case progress(_ progress: AnimationProgressTime)
@@ -19,6 +26,9 @@ public enum LottiePlaybackMode: Hashable {
 
   /// Any existing animation will be paused at the current frame.
   case pause
+
+  /// Pauses the animation at a given marker and position
+  case pausedAtMarker(_ marker: String, position: MarkerPosition)
 
   /// Plays the animation from a progress (0-1) to a progress (0-1).
   /// - Parameter fromProgress: The start progress of the animation. If `nil` the animation will start at the current progress.

--- a/Sources/Public/Animation/LottiePlaybackMode.swift
+++ b/Sources/Public/Animation/LottiePlaybackMode.swift
@@ -3,14 +3,6 @@
 
 import Foundation
 
-// MARK: - LottieMarkerPosition
-
-/// The position within a marker.
-public enum LottieMarkerPosition: Hashable {
-  case start
-  case end
-}
-
 // MARK: - LottiePlaybackMode
 
 /// Configuration for how a Lottie animation should be played
@@ -65,7 +57,7 @@ public enum LottiePlaybackMode: Hashable {
     case frame(_ frame: AnimationFrameTime)
 
     /// The animation is paused at the given time value from the start of the animation.
-    case timestamp(_ time: TimeInterval)
+    case time(_ time: TimeInterval)
 
     /// Pauses the animation at a given marker and position
     case marker(_ name: String, position: LottieMarkerPosition = .start)
@@ -73,16 +65,22 @@ public enum LottiePlaybackMode: Hashable {
 
   public enum PlaybackMode: Hashable {
     /// Plays the animation from a progress (0-1) to a progress (0-1).
-    /// - Parameter from: The start progress of the animation. If `nil` the animation will start at the current progress.
-    /// - Parameter to: The end progress of the animation.
+    /// - Parameter fromProgress: The start progress of the animation. If `nil` the animation will start at the current progress.
+    /// - Parameter toProgress: The end progress of the animation.
     /// - Parameter loopMode: The loop behavior of the animation.
-    case progress(from: AnimationProgressTime? = nil, to: AnimationProgressTime, loopMode: LottieLoopMode)
+    case fromProgress(
+      _ fromProgress: AnimationProgressTime?,
+      toProgress: AnimationProgressTime,
+      loopMode: LottieLoopMode)
 
     /// The animation plays from the given `fromFrame` to the given `toFrame`.
-    /// - Parameter from: The start frame of the animation. If `nil` the animation will start at the current frame.
-    /// - Parameter to: The end frame of the animation.
+    /// - Parameter fromFrame: The start frame of the animation. If `nil` the animation will start at the current frame.
+    /// - Parameter toFrame: The end frame of the animation.
     /// - Parameter loopMode: The loop behavior of the animation.
-    case frames(from: AnimationFrameTime? = nil, to: AnimationFrameTime, loopMode: LottieLoopMode)
+    case fromFrame(
+      _ fromFrame: AnimationFrameTime?,
+      toFrame: AnimationFrameTime,
+      loopMode: LottieLoopMode)
 
     /// Plays the animation from a named marker to another marker.
     ///
@@ -90,14 +88,18 @@ public enum LottiePlaybackMode: Hashable {
     ///
     /// NOTE: If markers are not found the play command will exit.
     ///
-    /// - Parameter from: The start marker for the animation playback. If `nil` the
+    /// - Parameter fromMarker: The start marker for the animation playback. If `nil` the
     /// animation will start at the current progress.
-    /// - Parameter to: The end marker for the animation playback.
+    /// - Parameter toMarker: The end marker for the animation playback.
     /// - Parameter playEndMarkerFrame: A flag to determine whether or not to play the frame of the end marker. If the
     /// end marker represents the end of the section to play, it should be to true. If the provided end marker
     /// represents the beginning of the next section, it should be false.
     /// - Parameter loopMode: The loop behavior of the animation.
-    case markers(from: String? = nil, to: String, playEndMarkerFrame: Bool = true, loopMode: LottieLoopMode)
+    case fromMarker(
+      _ fromMarker: String?,
+      toMarker: String,
+      playEndMarkerFrame: Bool = true,
+      loopMode: LottieLoopMode)
 
     /// Plays the animation from a named marker to the end of the marker's duration.
     ///
@@ -108,7 +110,9 @@ public enum LottiePlaybackMode: Hashable {
     ///
     /// - Parameter marker: The start marker for the animation playback.
     /// - Parameter loopMode: The loop behavior of the animation.
-    case marker(_ name: String, loopMode: LottieLoopMode)
+    case marker(
+      _ marker: String,
+      loopMode: LottieLoopMode)
 
     /// Plays the given markers sequentially in order.
     ///
@@ -124,8 +128,8 @@ public enum LottiePlaybackMode: Hashable {
     /// If another animation is played (by calling any `play` method) while this
     /// marker sequence is playing, the marker sequence will be cancelled.
     ///
-    /// - Parameter names: The list of markers to play sequentially.
-    case markerList(_ names: [String])
+    /// - Parameter markers: The list of markers to play sequentially.
+    case markers(_ markers: [String])
   }
 
 }
@@ -137,12 +141,12 @@ extension LottiePlaybackMode {
 
   @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   public static func toProgress(_ toProgress: AnimationProgressTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
-    .play(.progress(from: nil, to: toProgress, loopMode: loopMode))
+    .play(.fromProgress(nil, toProgress: toProgress, loopMode: loopMode))
   }
 
   @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   public static func toFrame(_ toFrame: AnimationFrameTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
-    .play(.frames(from: nil, to: toFrame, loopMode: loopMode))
+    .play(.fromFrame(nil, toFrame: toFrame, loopMode: loopMode))
   }
 
   @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
@@ -152,6 +156,14 @@ extension LottiePlaybackMode {
     loopMode: LottieLoopMode)
     -> LottiePlaybackMode
   {
-    .play(.markers(from: nil, to: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode))
+    .play(.fromMarker(nil, toMarker: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode))
   }
+}
+
+// MARK: - LottieMarkerPosition
+
+/// The position within a marker.
+public enum LottieMarkerPosition: Hashable {
+  case start
+  case end
 }

--- a/Sources/Public/Animation/LottiePlaybackMode.swift
+++ b/Sources/Public/Animation/LottiePlaybackMode.swift
@@ -8,8 +8,10 @@ import Foundation
 /// Configuration for how a Lottie animation should be played
 public enum LottiePlaybackMode: Hashable {
 
+  /// The animation is paused at the given state (e.g. paused at a specific frame)
   case paused(at: PausedState)
 
+  /// The animation is playing using the given playback mode (e.g. looping from the start to the end)
   case playing(_ mode: PlaybackMode)
 
   @available(*, deprecated, renamed: "LottiePlaybackMode.paused(at:)", message: "Will be removed in a future major release.")
@@ -24,23 +26,23 @@ public enum LottiePlaybackMode: Hashable {
   @available(*, deprecated, renamed: "LottiePlaybackMode.paused(at:)", message: "Will be removed in a future major release.")
   case pause
 
-  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "LottiePlaybackMode.playing(_:)", message: "Will be removed in a future major release.")
   case fromProgress(_ fromProgress: AnimationProgressTime?, toProgress: AnimationProgressTime, loopMode: LottieLoopMode)
 
-  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "LottiePlaybackMode.playing(_:)", message: "Will be removed in a future major release.")
   case fromFrame(_ fromFrame: AnimationFrameTime?, toFrame: AnimationFrameTime, loopMode: LottieLoopMode)
 
-  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "LottiePlaybackMode.playing(_:)", message: "Will be removed in a future major release.")
   case fromMarker(
     _ fromMarker: String?,
     toMarker: String,
     playEndMarkerFrame: Bool = true,
     loopMode: LottieLoopMode)
 
-  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "LottiePlaybackMode.playing(_:)", message: "Will be removed in a future major release.")
   case marker(_ marker: String, loopMode: LottieLoopMode)
 
-  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "LottiePlaybackMode.playing(_:)", message: "Will be removed in a future major release.")
   case markers(_ markers: [String])
 
   // MARK: Public
@@ -139,17 +141,17 @@ extension LottiePlaybackMode {
     .paused(at: .currentFrame)
   }
 
-  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "LottiePlaybackMode.playing(_:)", message: "Will be removed in a future major release.")
   public static func toProgress(_ toProgress: AnimationProgressTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
     .playing(.fromProgress(nil, toProgress: toProgress, loopMode: loopMode))
   }
 
-  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "LottiePlaybackMode.playing(_:)", message: "Will be removed in a future major release.")
   public static func toFrame(_ toFrame: AnimationFrameTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
     .playing(.fromFrame(nil, toFrame: toFrame, loopMode: loopMode))
   }
 
-  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "LottiePlaybackMode.playing(_:)", message: "Will be removed in a future major release.")
   public static func toMarker(
     _ toMarker: String,
     playEndMarkerFrame: Bool = true,
@@ -157,6 +159,42 @@ extension LottiePlaybackMode {
     -> LottiePlaybackMode
   {
     .playing(.fromMarker(nil, toMarker: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode))
+  }
+}
+
+extension LottiePlaybackMode.PlaybackMode {
+  /// Plays the animation from the current progress to a progress value (0-1).
+  /// - Parameter toProgress: The end progress of the animation.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  public static func toProgress(_ toProgress: AnimationProgressTime, loopMode: LottieLoopMode) -> Self {
+    .fromProgress(nil, toProgress: toProgress, loopMode: loopMode)
+  }
+
+  // Plays the animation from the current frame to the given frame.
+  /// - Parameter toFrame: The end frame of the animation.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  public static func toFrame(_ toFrame: AnimationFrameTime, loopMode: LottieLoopMode) -> Self {
+    .fromFrame(nil, toFrame: toFrame, loopMode: loopMode)
+  }
+
+  /// Plays the animation from the current frame to some marker.
+  ///
+  /// Markers are point in time that are encoded into the Animation data and assigned a name.
+  ///
+  /// NOTE: If the marker isn't found the play command will exit.
+  ///
+  /// - Parameter toMarker: The end marker for the animation playback.
+  /// - Parameter playEndMarkerFrame: A flag to determine whether or not to play the frame of the end marker. If the
+  /// end marker represents the end of the section to play, it should be to true. If the provided end marker
+  /// represents the beginning of the next section, it should be false.
+  /// - Parameter loopMode: The loop behavior of the animation.
+  public static func toMarker(
+    _ toMarker: String,
+    playEndMarkerFrame: Bool = true,
+    loopMode: LottieLoopMode)
+    -> Self
+  {
+    .fromMarker(nil, toMarker: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode)
   }
 }
 

--- a/Sources/Public/Animation/LottiePlaybackMode.swift
+++ b/Sources/Public/Animation/LottiePlaybackMode.swift
@@ -3,128 +3,155 @@
 
 import Foundation
 
+// MARK: - LottieMarkerPosition
+
+/// The position within a marker.
+public enum LottieMarkerPosition: Hashable {
+  case start
+  case end
+}
+
 // MARK: - LottiePlaybackMode
 
 /// Configuration for how a Lottie animation should be played
 public enum LottiePlaybackMode: Hashable {
 
-  /// The animation is paused at the given progress value,
-  /// a value between 0.0 (0% progress) and 1.0 (100% progress).
+  case paused(at: PausedState)
+
+  case play(_ mode: PlaybackMode)
+
+  @available(*, deprecated, renamed: "LottiePlaybackMode.paused(at:)", message: "Will be removed in a future major release.")
   case progress(_ progress: AnimationProgressTime)
 
-  /// The animation is paused at the given frame of the animation.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.paused(at:)", message: "Will be removed in a future major release.")
   case frame(_ frame: AnimationFrameTime)
 
-  /// The animation is paused at the given time value from the start of the animation.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.paused(at:)", message: "Will be removed in a future major release.")
   case time(_ time: TimeInterval)
 
-  /// Any existing animation will be paused at the current frame.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.paused(at:)", message: "Will be removed in a future major release.")
   case pause
 
-  /// Pauses the animation at a given marker and position
-  case pausedAtMarker(_ marker: String, position: MarkerPosition)
-
-  /// Plays the animation from a progress (0-1) to a progress (0-1).
-  /// - Parameter fromProgress: The start progress of the animation. If `nil` the animation will start at the current progress.
-  /// - Parameter toProgress: The end progress of the animation.
-  /// - Parameter loopMode: The loop behavior of the animation.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   case fromProgress(_ fromProgress: AnimationProgressTime?, toProgress: AnimationProgressTime, loopMode: LottieLoopMode)
 
-  /// The animation plays from the given `fromFrame` to the given `toFrame`.
-  /// - Parameter fromFrame: The start frame of the animation. If `nil` the animation will start at the current frame.
-  /// - Parameter toFrame: The end frame of the animation.
-  /// - Parameter loopMode: The loop behavior of the animation.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   case fromFrame(_ fromFrame: AnimationFrameTime?, toFrame: AnimationFrameTime, loopMode: LottieLoopMode)
 
-  /// Plays the animation from a named marker to another marker.
-  ///
-  /// Markers are point in time that are encoded into the Animation data and assigned a name.
-  ///
-  /// NOTE: If markers are not found the play command will exit.
-  ///
-  /// - Parameter fromMarker: The start marker for the animation playback. If `nil` the
-  /// animation will start at the current progress.
-  /// - Parameter toMarker: The end marker for the animation playback.
-  /// - Parameter playEndMarkerFrame: A flag to determine whether or not to play the frame of the end marker. If the
-  /// end marker represents the end of the section to play, it should be to true. If the provided end marker
-  /// represents the beginning of the next section, it should be false.
-  /// - Parameter loopMode: The loop behavior of the animation.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   case fromMarker(
     _ fromMarker: String?,
     toMarker: String,
     playEndMarkerFrame: Bool = true,
     loopMode: LottieLoopMode)
 
-  /// Plays the animation from a named marker to the end of the marker's duration.
-  ///
-  /// A marker is a point in time with an associated duration that is encoded into the
-  /// animation data and assigned a name.
-  ///
-  /// NOTE: If marker is not found the play command will exit.
-  ///
-  /// - Parameter marker: The start marker for the animation playback.
-  /// - Parameter loopMode: The loop behavior of the animation.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   case marker(_ marker: String, loopMode: LottieLoopMode)
 
-  /// Plays the given markers sequentially in order.
-  ///
-  /// A marker is a point in time with an associated duration that is encoded into the
-  /// animation data and assigned a name. Multiple markers can be played sequentially
-  /// to create programmable animations.
-  ///
-  /// If a marker is not found, it will be skipped.
-  ///
-  /// If a marker doesn't have a duration value, it will play with a duration of 0
-  /// (effectively being skipped).
-  ///
-  /// If another animation is played (by calling any `play` method) while this
-  /// marker sequence is playing, the marker sequence will be cancelled.
-  ///
-  /// - Parameter markers: The list of markers to play sequentially.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   case markers(_ markers: [String])
 
   // MARK: Public
 
-  /// The position within a marker.
-  public enum MarkerPosition: Hashable {
-    case start
-    case end
+  public enum PausedState: Hashable {
+    /// Any existing animation will be paused at the current frame.
+    case currentFrame
+
+    /// The animation is paused at the given progress value,
+    /// a value between 0.0 (0% progress) and 1.0 (100% progress).
+    case progress(_ progress: AnimationProgressTime)
+
+    /// The animation is paused at the given frame of the animation.
+    case frame(_ frame: AnimationFrameTime)
+
+    /// The animation is paused at the given time value from the start of the animation.
+    case timestamp(_ time: TimeInterval)
+
+    /// Pauses the animation at a given marker and position
+    case marker(_ name: String, position: LottieMarkerPosition = .start)
+  }
+
+  public enum PlaybackMode: Hashable {
+    /// Plays the animation from a progress (0-1) to a progress (0-1).
+    /// - Parameter from: The start progress of the animation. If `nil` the animation will start at the current progress.
+    /// - Parameter to: The end progress of the animation.
+    /// - Parameter loopMode: The loop behavior of the animation.
+    case progress(from: AnimationProgressTime? = nil, to: AnimationProgressTime, loopMode: LottieLoopMode)
+
+    /// The animation plays from the given `fromFrame` to the given `toFrame`.
+    /// - Parameter from: The start frame of the animation. If `nil` the animation will start at the current frame.
+    /// - Parameter to: The end frame of the animation.
+    /// - Parameter loopMode: The loop behavior of the animation.
+    case frames(from: AnimationFrameTime? = nil, to: AnimationFrameTime, loopMode: LottieLoopMode)
+
+    /// Plays the animation from a named marker to another marker.
+    ///
+    /// Markers are point in time that are encoded into the Animation data and assigned a name.
+    ///
+    /// NOTE: If markers are not found the play command will exit.
+    ///
+    /// - Parameter from: The start marker for the animation playback. If `nil` the
+    /// animation will start at the current progress.
+    /// - Parameter to: The end marker for the animation playback.
+    /// - Parameter playEndMarkerFrame: A flag to determine whether or not to play the frame of the end marker. If the
+    /// end marker represents the end of the section to play, it should be to true. If the provided end marker
+    /// represents the beginning of the next section, it should be false.
+    /// - Parameter loopMode: The loop behavior of the animation.
+    case markers(from: String? = nil, to: String, playEndMarkerFrame: Bool = true, loopMode: LottieLoopMode)
+
+    /// Plays the animation from a named marker to the end of the marker's duration.
+    ///
+    /// A marker is a point in time with an associated duration that is encoded into the
+    /// animation data and assigned a name.
+    ///
+    /// NOTE: If marker is not found the play command will exit.
+    ///
+    /// - Parameter marker: The start marker for the animation playback.
+    /// - Parameter loopMode: The loop behavior of the animation.
+    case marker(_ name: String, loopMode: LottieLoopMode)
+
+    /// Plays the given markers sequentially in order.
+    ///
+    /// A marker is a point in time with an associated duration that is encoded into the
+    /// animation data and assigned a name. Multiple markers can be played sequentially
+    /// to create programmable animations.
+    ///
+    /// If a marker is not found, it will be skipped.
+    ///
+    /// If a marker doesn't have a duration value, it will play with a duration of 0
+    /// (effectively being skipped).
+    ///
+    /// If another animation is played (by calling any `play` method) while this
+    /// marker sequence is playing, the marker sequence will be cancelled.
+    ///
+    /// - Parameter names: The list of markers to play sequentially.
+    case markerList(_ names: [String])
   }
 
 }
 
 extension LottiePlaybackMode {
-  /// Plays the animation from the current progress to a progress value (0-1).
-  /// - Parameter toProgress: The end progress of the animation.
-  /// - Parameter loopMode: The loop behavior of the animation.
+  public static var paused: Self {
+    .paused(at: .currentFrame)
+  }
+
+  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   public static func toProgress(_ toProgress: AnimationProgressTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
-    .fromProgress(nil, toProgress: toProgress, loopMode: loopMode)
+    .play(.progress(from: nil, to: toProgress, loopMode: loopMode))
   }
 
-  // Plays the animation from the current frame to the given frame.
-  /// - Parameter toFrame: The end frame of the animation.
-  /// - Parameter loopMode: The loop behavior of the animation.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   public static func toFrame(_ toFrame: AnimationFrameTime, loopMode: LottieLoopMode) -> LottiePlaybackMode {
-    .fromFrame(nil, toFrame: toFrame, loopMode: loopMode)
+    .play(.frames(from: nil, to: toFrame, loopMode: loopMode))
   }
 
-  /// Plays the animation from the current frame to some marker.
-  ///
-  /// Markers are point in time that are encoded into the Animation data and assigned a name.
-  ///
-  /// NOTE: If the marker isn't found the play command will exit.
-  ///
-  /// - Parameter toMarker: The end marker for the animation playback.
-  /// - Parameter playEndMarkerFrame: A flag to determine whether or not to play the frame of the end marker. If the
-  /// end marker represents the end of the section to play, it should be to true. If the provided end marker
-  /// represents the beginning of the next section, it should be false.
-  /// - Parameter loopMode: The loop behavior of the animation.
+  @available(*, deprecated, renamed: "LottiePlaybackMode.play(_:)", message: "Will be removed in a future major release.")
   public static func toMarker(
     _ toMarker: String,
     playEndMarkerFrame: Bool = true,
     loopMode: LottieLoopMode)
     -> LottiePlaybackMode
   {
-    .fromMarker(nil, toMarker: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode)
+    .play(.markers(from: nil, to: toMarker, playEndMarkerFrame: playEndMarkerFrame, loopMode: loopMode))
   }
 }

--- a/Sources/Public/Animation/LottiePlaybackMode.swift
+++ b/Sources/Public/Animation/LottiePlaybackMode.swift
@@ -8,12 +8,6 @@ import Foundation
 /// Configuration for how a Lottie animation should be played
 public enum LottiePlaybackMode: Hashable {
 
-  /// The position within a marker.
-  public enum MarkerPosition: Hashable {
-    case start
-    case end
-  }
-
   /// The animation is paused at the given progress value,
   /// a value between 0.0 (0% progress) and 1.0 (100% progress).
   case progress(_ progress: AnimationProgressTime)
@@ -88,6 +82,15 @@ public enum LottiePlaybackMode: Hashable {
   ///
   /// - Parameter markers: The list of markers to play sequentially.
   case markers(_ markers: [String])
+
+  // MARK: Public
+
+  /// The position within a marker.
+  public enum MarkerPosition: Hashable {
+    case start
+    case end
+  }
+
 }
 
 extension LottiePlaybackMode {

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -175,7 +175,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     return copy
   }
 
-  @available(*, deprecated, renamed: "playing(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "playing()", message: "Will be removed in a future major release.")
   public func play() -> Self {
     playbackMode(.playing(.fromProgress(nil, toProgress: 1, loopMode: .playOnce)))
   }
@@ -185,7 +185,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     playbackMode(.playing(.fromProgress(0, toProgress: 1, loopMode: .loop)))
   }
 
-  @available(*, deprecated, renamed: "playbackMode(_:)", message: "Will be removed in a future major release.")
+  @available(*, deprecated, renamed: "playing(_:)", message: "Will be removed in a future major release.")
   public func play(loopMode: LottieLoopMode = .playOnce) -> Self {
     playbackMode(.playing(.fromProgress(nil, toProgress: 1, loopMode: loopMode)))
   }
@@ -196,17 +196,13 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   }
 
   /// Returns a copy of this view playing with the given playback mode
-  public func playing(
-    _ playbackMode: LottiePlaybackMode
-      .PlaybackMode = .fromProgress(nil, toProgress: 1, loopMode: .playOnce))
-    -> Self
-  {
-    self.playbackMode(.playing(playbackMode))
+  public func playing(_ mode: LottiePlaybackMode.PlaybackMode) -> Self {
+    playbackMode(.playing(mode))
   }
 
   /// Returns a copy of this view playing from the current frame to the end frame,
   /// with the given `LottiePlaybackMode`.
-  public func playing(loopMode: LottieLoopMode = .playOnce) -> Self {
+  public func playing(loopMode: LottieLoopMode) -> Self {
     playbackMode(.playing(.fromProgress(nil, toProgress: 1, loopMode: loopMode)))
   }
 
@@ -218,11 +214,6 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   /// Returns a copy of this view paused with the given state
   public func paused(at state: LottiePlaybackMode.PausedState = .currentFrame) -> Self {
     playbackMode(.paused(at: state))
-  }
-
-  /// Returns a copy of this view paused with the current frame
-  public func paused() -> Self {
-    playbackMode(.paused(at: .currentFrame))
   }
 
   /// Returns a copy of this view using the given `LottiePlaybackMode`

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -177,17 +177,17 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
 
   @available(*, deprecated, renamed: "playing(_:)", message: "Will be removed in a future major release.")
   public func play() -> Self {
-    playbackMode(.play(.fromProgress(nil, toProgress: 1, loopMode: .playOnce)))
+    playbackMode(.playing(.fromProgress(nil, toProgress: 1, loopMode: .playOnce)))
   }
 
   /// Returns a copy of this view that loops its animation from the start to end whenever visible
   public func looping() -> Self {
-    playbackMode(.play(.fromProgress(0, toProgress: 1, loopMode: .loop)))
+    playbackMode(.playing(.fromProgress(0, toProgress: 1, loopMode: .loop)))
   }
 
   @available(*, deprecated, renamed: "playbackMode(_:)", message: "Will be removed in a future major release.")
   public func play(loopMode: LottieLoopMode = .playOnce) -> Self {
-    playbackMode(.play(.fromProgress(nil, toProgress: 1, loopMode: loopMode)))
+    playbackMode(.playing(.fromProgress(nil, toProgress: 1, loopMode: loopMode)))
   }
 
   @available(*, deprecated, renamed: "playbackMode(_:)", message: "Will be removed in a future major release.")
@@ -201,18 +201,18 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
       .PlaybackMode = .fromProgress(nil, toProgress: 1, loopMode: .playOnce))
     -> Self
   {
-    self.playbackMode(.play(playbackMode))
+    self.playbackMode(.playing(playbackMode))
   }
 
   /// Returns a copy of this view playing from the current frame to the end frame,
   /// with the given `LottiePlaybackMode`.
   public func playing(loopMode: LottieLoopMode = .playOnce) -> Self {
-    playbackMode(.play(.fromProgress(nil, toProgress: 1, loopMode: loopMode)))
+    playbackMode(.playing(.fromProgress(nil, toProgress: 1, loopMode: loopMode)))
   }
 
   // Returns a copy of this view playing once from the current frame to the end frame
   public func playing() -> Self {
-    playbackMode(.play(.fromProgress(nil, toProgress: 1, loopMode: .playOnce)))
+    playbackMode(.playing(.fromProgress(nil, toProgress: 1, loopMode: .playOnce)))
   }
 
   /// Returns a copy of this view paused with the given state

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -140,7 +140,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
             let playbackMode = playbackMode,
             playbackMode != context.view.currentPlaybackMode
           {
-            context.view.play(playbackMode, animationCompletionHandler: animationCompletionHandler)
+            context.view.setPlaybackMode(playbackMode, completion: animationCompletionHandler)
           }
         }
         .configurations(configurations)
@@ -177,23 +177,33 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
 
   // Returns a copy of this view playing once from the current frame to the end frame
   public func play() -> Self {
-    play(loopMode: .playOnce)
+    playbackMode(.play(.progress(to: 1, loopMode: .playOnce)))
   }
 
   /// Returns a copy of this view that loops its animation from the start to end whenever visible
   public func looping() -> Self {
-    play(.fromProgress(0, toProgress: 1, loopMode: .loop))
+    playbackMode(.play(.progress(from: 0, to: 1, loopMode: .loop)))
   }
 
   /// Returns a copy of this view playing from the current frame to the end frame,
   /// with the given `LottiePlaybackMode`.
   public func play(loopMode: LottieLoopMode = .playOnce) -> Self {
-    play(.toProgress(1, loopMode: loopMode))
+    playbackMode(.play(.progress(to: 1, loopMode: loopMode)))
   }
 
   /// Returns a copy of this view playing with the given `LottiePlaybackMode`
   public func play(_ playbackMode: LottiePlaybackMode) -> Self {
     self.playbackMode(playbackMode)
+  }
+
+  /// Returns a copy of this view playing with the given playback mode
+  public func playing(_ playbackMode: LottiePlaybackMode.PlaybackMode) -> Self {
+    self.playbackMode(.play(playbackMode))
+  }
+
+  /// Returns a copy of this view paused with the given state
+  public func paused(at state: LottiePlaybackMode.PausedState) -> Self {
+    playbackMode(.paused(at: state))
   }
 
   /// Returns a copy of this view using the given `LottiePlaybackMode`
@@ -332,7 +342,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   public func currentProgress(_ currentProgress: AnimationProgressTime?) -> Self {
     guard let currentProgress = currentProgress else { return self }
     var copy = self
-    copy.playbackMode = .progress(currentProgress)
+    copy.playbackMode = .paused(at: .progress(currentProgress))
     return copy
   }
 
@@ -344,7 +354,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   public func currentFrame(_ currentFrame: AnimationFrameTime?) -> Self {
     guard let currentFrame = currentFrame else { return self }
     var copy = self
-    copy.playbackMode = .frame(currentFrame)
+    copy.playbackMode = .paused(at: .frame(currentFrame))
     return copy
   }
 
@@ -356,7 +366,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   public func currentTime(_ currentTime: TimeInterval?) -> Self {
     guard let currentTime = currentTime else { return self }
     var copy = self
-    copy.playbackMode = .time(currentTime)
+    copy.playbackMode = .paused(at: .timestamp(currentTime))
     return copy
   }
 

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -175,7 +175,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     return copy
   }
 
-  // Returns a copy of this view playing once from the current frame to the end frame
+  @available(*, deprecated, renamed: "playing(_:)", message: "Will be removed in a future major release.")
   public func play() -> Self {
     playbackMode(.play(.progress(to: 1, loopMode: .playOnce)))
   }
@@ -185,24 +185,23 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     playbackMode(.play(.progress(from: 0, to: 1, loopMode: .loop)))
   }
 
-  /// Returns a copy of this view playing from the current frame to the end frame,
-  /// with the given `LottiePlaybackMode`.
+  @available(*, deprecated, renamed: "playbackMode(_:)", message: "Will be removed in a future major release.")
   public func play(loopMode: LottieLoopMode = .playOnce) -> Self {
     playbackMode(.play(.progress(to: 1, loopMode: loopMode)))
   }
 
-  /// Returns a copy of this view playing with the given `LottiePlaybackMode`
+  @available(*, deprecated, renamed: "playbackMode(_:)", message: "Will be removed in a future major release.")
   public func play(_ playbackMode: LottiePlaybackMode) -> Self {
     self.playbackMode(playbackMode)
   }
 
   /// Returns a copy of this view playing with the given playback mode
-  public func playing(_ playbackMode: LottiePlaybackMode.PlaybackMode) -> Self {
+  public func playing(_ playbackMode: LottiePlaybackMode.PlaybackMode = .progress(to: 1, loopMode: .playOnce)) -> Self {
     self.playbackMode(.play(playbackMode))
   }
 
   /// Returns a copy of this view paused with the given state
-  public func paused(at state: LottiePlaybackMode.PausedState) -> Self {
+  public func paused(at state: LottiePlaybackMode.PausedState = .currentFrame) -> Self {
     playbackMode(.paused(at: state))
   }
 

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -177,17 +177,17 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
 
   @available(*, deprecated, renamed: "playing(_:)", message: "Will be removed in a future major release.")
   public func play() -> Self {
-    playbackMode(.play(.progress(to: 1, loopMode: .playOnce)))
+    playbackMode(.play(.fromProgress(nil, toProgress: 1, loopMode: .playOnce)))
   }
 
   /// Returns a copy of this view that loops its animation from the start to end whenever visible
   public func looping() -> Self {
-    playbackMode(.play(.progress(from: 0, to: 1, loopMode: .loop)))
+    playbackMode(.play(.fromProgress(0, toProgress: 1, loopMode: .loop)))
   }
 
   @available(*, deprecated, renamed: "playbackMode(_:)", message: "Will be removed in a future major release.")
   public func play(loopMode: LottieLoopMode = .playOnce) -> Self {
-    playbackMode(.play(.progress(to: 1, loopMode: loopMode)))
+    playbackMode(.play(.fromProgress(nil, toProgress: 1, loopMode: loopMode)))
   }
 
   @available(*, deprecated, renamed: "playbackMode(_:)", message: "Will be removed in a future major release.")
@@ -196,13 +196,33 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   }
 
   /// Returns a copy of this view playing with the given playback mode
-  public func playing(_ playbackMode: LottiePlaybackMode.PlaybackMode = .progress(to: 1, loopMode: .playOnce)) -> Self {
+  public func playing(
+    _ playbackMode: LottiePlaybackMode
+      .PlaybackMode = .fromProgress(nil, toProgress: 1, loopMode: .playOnce))
+    -> Self
+  {
     self.playbackMode(.play(playbackMode))
+  }
+
+  /// Returns a copy of this view playing from the current frame to the end frame,
+  /// with the given `LottiePlaybackMode`.
+  public func playing(loopMode: LottieLoopMode = .playOnce) -> Self {
+    playbackMode(.play(.fromProgress(nil, toProgress: 1, loopMode: loopMode)))
+  }
+
+  // Returns a copy of this view playing once from the current frame to the end frame
+  public func playing() -> Self {
+    playbackMode(.play(.fromProgress(nil, toProgress: 1, loopMode: .playOnce)))
   }
 
   /// Returns a copy of this view paused with the given state
   public func paused(at state: LottiePlaybackMode.PausedState = .currentFrame) -> Self {
     playbackMode(.paused(at: state))
+  }
+
+  /// Returns a copy of this view paused with the current frame
+  public func paused() -> Self {
+    playbackMode(.paused(at: .currentFrame))
   }
 
   /// Returns a copy of this view using the given `LottiePlaybackMode`
@@ -365,7 +385,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   public func currentTime(_ currentTime: TimeInterval?) -> Self {
     guard let currentTime = currentTime else { return self }
     var copy = self
-    copy.playbackMode = .paused(at: .timestamp(currentTime))
+    copy.playbackMode = .paused(at: .time(currentTime))
     return copy
   }
 


### PR DESCRIPTION
This change adds support for pausing playback at markers.

Thought on restructuring the `PlaybackMode` enum? This is a bigger change which IMO could clean things up quite a bit (we could leave current APIs in-place marked as deprecated until the next major version bump):
```
enum LottiePlaybackMode {

  case paused(Paused)

  enum Paused {
    case currentFrame
    case progress(AnimationProgressTime)
    case frame(AnimationFrameTime)
    case timestamp(TimeInterval)
    case marker(_ name: String, position: MarkerPosition)
  }

  case play(PlayRange)

  enum PlayRange {
    case progress(_ from: AnimationProgressTime?, to: AnimationProgressTime, loopMode: LottieLoopMode)
    case frames(_ from: AnimationFrameTime?, to: AnimationFrameTime, loopMode: LottieLoopMode)
    case marker(_ name: String, loopMode: LottieLoopMode)
    case markers(_ names: [String])
  }

  @available(*, deprecated, message: "Will be removed in a future major release.")
  case progress(_ progress: AnimationProgressTime)

  @available(*, deprecated, message: "Will be removed in a future major release.")
  case frame(_ frame: AnimationFrameTime)

  @available(*, deprecated, message: "Will be removed in a future major release.")
  case time(_ time: TimeInterval)

  @available(*, deprecated, message: "Will be removed in a future major release.")
  case pause

  @available(*, deprecated, message: "Will be removed in a future major release.")
  case fromProgress(_ fromProgress: AnimationProgressTime?, toProgress: AnimationProgressTime, loopMode: LottieLoopMode)

  @available(*, deprecated, message: "Will be removed in a future major release.")
  case fromFrame(_ fromFrame: AnimationFrameTime?, toFrame: AnimationFrameTime, loopMode: LottieLoopMode)

  @available(*, deprecated, message: "Will be removed in a future major release.")
  case marker(_ marker: String, loopMode: LottieLoopMode)

  @available(*, deprecated, message: "Will be removed in a future major release.")
  case markers(_ markers: [String])
}
```