### PR TITLE
Fix unexpected crossfade animation when updating Lottie animation or rendering engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install Lottie using [Swift Package Manager](https://github.com/apple/swift-p
 or you can add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.3.2")
+.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.3.3")
 ```
 
 When using Swift Package Manager we recommend using the [lottie-spm](https://github.com/airbnb/lottie-spm) repo instead of the main lottie-ios repo.  The main git repository for [lottie-ios](https://github.com/airbnb/lottie-ios) is somewhat large (300+ MB), and Swift Package Manager always downloads the full repository with all git history. The [lottie-spm](https://github.com/airbnb/lottie-spm) repo is much smaller (less than 500kb), so can be downloaded much more quickly. 

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1134,6 +1134,10 @@ public class LottieAnimationLayer: CALayer {
   }
 
   fileprivate func makeAnimationLayer(usingEngine renderingEngine: RenderingEngineOption) {
+    /// Disable the default implicit crossfade animation Core Animation creates
+    /// when adding or removing sublayers.
+    actions = ["sublayers": NSNull()]
+
     /// Remove current animation if any
     removeCurrentAnimation()
 

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'lottie-ios'
-  s.version          = '4.3.2'
+  s.version          = '4.3.3'
   s.summary          = 'A library to render native animations from bodymovin json'
 
   s.description = <<-DESC

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-ios",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes an issue where updating the animation displayed by a `LottieAnimationView`, or its current rendering engine, would unexpectedly trigger a short crossfade animation. 

This was a default implicit animation added by Core Animation, which we can disable by disabling it in `actions`.

This was a regression introduced by the architecture change that created the `LottieAnimationLayer` `CALayer` subclass (#2073). I think the `CALayer` of a `UIView` has all of these implicit actions disabled by default, so moving this code from a `UIView` subclass to a `CALayer` subclass changed the behavior of inserting a sublayer.

Fixes #2200:

| Before | After |
| ----- | ----- |
| ![2023-09-28 08 22 57](https://github.com/airbnb/lottie-ios/assets/1811727/09f23eda-0097-4b27-af12-bd3153779fa2) | ![2023-09-28 08 30 41](https://github.com/airbnb/lottie-ios/assets/1811727/4d509f66-e424-4de1-b580-f8984fb43995) |

This also fixes an issue I had noticed in the example app where the view would animate strangely when updating the rendering engine:

### Before

![2023-09-28 08 42 19](https://github.com/airbnb/lottie-ios/assets/1811727/9aeb02ba-e9ac-4024-9852-1d635ed14d85)

### After

![2023-09-28 08 41 51](https://github.com/airbnb/lottie-ios/assets/1811727/783dbbb0-1a44-4cf4-9321-3969230d75ef)

fyi @eromanc in case you find this interesting / helpful