### PR TITLE
Remove old animation layer when creating a new animation layer

### DIFF
--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1143,7 +1143,7 @@ public class LottieAnimationLayer: CALayer {
 
     if let oldAnimation = animationLayer {
       oldAnimation.removeFromSuperlayer()
-			rootAnimationLayer = nil
+      rootAnimationLayer = nil
     }
 
     guard let animation = animation else {

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1143,6 +1143,7 @@ public class LottieAnimationLayer: CALayer {
 
     if let oldAnimation = animationLayer {
       oldAnimation.removeFromSuperlayer()
+			rootAnimationLayer = nil
     }
 
     guard let animation = animation else {


### PR DESCRIPTION
This PR fixes an issue in 4.3.0 where old animation layers were still rendering images after removing animation. This is because the old animation layer is still working in memory because it is not released.

The fix is to release the old animation layer when removing it from the superlayer.