### PR TITLE
Replace `UIScreen.main` to get display scale on iOS 13.0 and later (#2215)

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -4035,7 +4035,7 @@
 		2E8040A227A0725D006E74CB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -4068,7 +4068,7 @@
 		2E8040A327A0725D006E74CB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -4035,7 +4035,7 @@
 		2E8040A227A0725D006E74CB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -4068,7 +4068,7 @@
 		2E8040A327A0725D006E74CB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -40,9 +40,9 @@ open class LottieAnimationViewBase: UIView {
   var screenScale: CGFloat {
     #if os(iOS) || os(tvOS)
     if #available(iOS 13.0, tvOS 13.0, *) {
-        return window?.windowScene?.screen.scale ?? 1.0
+      return window?.windowScene?.screen.scale ?? 1.0
     } else {
-        return UIScreen.main.scale
+      return UIScreen.main.scale
     }
     #else // if os(visionOS)
     // We intentionally don't check `#if os(visionOS)`, because that emits

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -94,8 +94,8 @@ open class LottieAnimationViewBase: UIView {
     // Implemented by subclasses.
   }
 
-  // MARK: - Private
-  
+  // MARK: Private
+
   private var _screenScale: CGFloat = .zero
 }
 #endif

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -40,7 +40,7 @@ open class LottieAnimationViewBase: UIView {
   var screenScale: CGFloat {
     #if os(iOS) || os(tvOS)
     if #available(iOS 13.0, tvOS 13.0, *) {
-        return window?.windowScene?.screen.scale ?? .zero
+        return window?.windowScene?.screen.scale ?? 1.0
     } else {
         return UIScreen.main.scale
     }

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -24,11 +24,6 @@ open class LottieAnimationViewBase: UIView {
   public override func didMoveToWindow() {
     super.didMoveToWindow()
     animationMovedToWindow()
-    #if os(iOS) || os(tvOS)
-    if #available(iOS 13.0, tvOS 13.0, *) {
-      screenScale = window?.windowScene?.screen.scale ?? 1.0
-    }
-    #endif
   }
 
   public override func layoutSubviews() {
@@ -43,22 +38,18 @@ open class LottieAnimationViewBase: UIView {
   }
 
   var screenScale: CGFloat {
-    get {
-      #if os(iOS) || os(tvOS)
-      if #available(iOS 13.0, tvOS 13.0, *) {
-        return window?.windowScene?.screen.scale ?? 1.0
-      } else {
-        return UIScreen.main.scale
-      }
-      #else // if os(visionOS)
-      // We intentionally don't check `#if os(visionOS)`, because that emits
-      // a warning when building on Xcode 14 and earlier.
-      1.0
-      #endif
+    #if os(iOS) || os(tvOS)
+    if #available(iOS 13.0, tvOS 13.0, *) {
+        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        return windowScene?.screen.scale ?? 1.0
+    } else {
+      return UIScreen.main.scale
     }
-    set {
-      _screenScale = newValue
-    }
+    #else // if os(visionOS)
+    // We intentionally don't check `#if os(visionOS)`, because that emits
+    // a warning when building on Xcode 14 and earlier.
+    1.0
+    #endif
   }
 
   func layoutAnimation() {
@@ -93,9 +84,5 @@ open class LottieAnimationViewBase: UIView {
   func animationWillEnterForeground() {
     // Implemented by subclasses.
   }
-
-  // MARK: Private
-
-  private var _screenScale: CGFloat = .zero
 }
 #endif

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -40,7 +40,7 @@ open class LottieAnimationViewBase: UIView {
   var screenScale: CGFloat {
     #if os(iOS) || os(tvOS)
     if #available(iOS 13.0, tvOS 13.0, *) {
-        return UITraitCollection.current.displayScale
+      return UITraitCollection.current.displayScale
     } else {
       return UIScreen.main.scale
     }

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -39,7 +39,7 @@ open class LottieAnimationViewBase: UIView {
 
   var screenScale: CGFloat {
     #if os(iOS) || os(tvOS)
-    if #available(iOS 13.0, *) {
+    if #available(iOS 13.0, tvOS 13.0, *) {
         return window?.windowScene?.screen.scale ?? .zero
     } else {
         return UIScreen.main.scale

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -24,6 +24,11 @@ open class LottieAnimationViewBase: UIView {
   public override func didMoveToWindow() {
     super.didMoveToWindow()
     animationMovedToWindow()
+    #if os(iOS) || os(tvOS)
+    if #available(iOS 13.0, tvOS 13.0, *) {
+      screenScale = window?.windowScene?.screen.scale ?? 1.0
+    }
+    #endif
   }
 
   public override func layoutSubviews() {
@@ -38,17 +43,22 @@ open class LottieAnimationViewBase: UIView {
   }
 
   var screenScale: CGFloat {
-    #if os(iOS) || os(tvOS)
-    if #available(iOS 13.0, tvOS 13.0, *) {
-      return window?.windowScene?.screen.scale ?? 1.0
-    } else {
-      return UIScreen.main.scale
+    get {
+      #if os(iOS) || os(tvOS)
+      if #available(iOS 13.0, tvOS 13.0, *) {
+        window?.windowScene?.screen.scale ?? 1.0
+      } else {
+        UIScreen.main.scale
+      }
+      #else // if os(visionOS)
+      // We intentionally don't check `#if os(visionOS)`, because that emits
+      // a warning when building on Xcode 14 and earlier.
+      1.0
+      #endif
     }
-    #else // if os(visionOS)
-    // We intentionally don't check `#if os(visionOS)`, because that emits
-    // a warning when building on Xcode 14 and earlier.
-    1.0
-    #endif
+    set {
+      _screenScale = newValue
+    }
   }
 
   func layoutAnimation() {
@@ -84,5 +94,8 @@ open class LottieAnimationViewBase: UIView {
     // Implemented by subclasses.
   }
 
+  // MARK: - Private
+  
+  private var _screenScale: CGFloat = .zero
 }
 #endif

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -40,8 +40,7 @@ open class LottieAnimationViewBase: UIView {
   var screenScale: CGFloat {
     #if os(iOS) || os(tvOS)
     if #available(iOS 13.0, tvOS 13.0, *) {
-        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-        return windowScene?.screen.scale ?? 1.0
+        return UITraitCollection.current.displayScale
     } else {
       return UIScreen.main.scale
     }

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -39,7 +39,12 @@ open class LottieAnimationViewBase: UIView {
 
   var screenScale: CGFloat {
     #if os(iOS) || os(tvOS)
-    UIScreen.main.scale
+    if #available(iOS 13.0, *) {
+        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        return windowScene?.screen.scale ?? .zero
+    } else {
+        return UIScreen.main.scale
+    }
     #else // if os(visionOS)
     // We intentionally don't check `#if os(visionOS)`, because that emits
     // a warning when building on Xcode 14 and earlier.

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -46,9 +46,9 @@ open class LottieAnimationViewBase: UIView {
     get {
       #if os(iOS) || os(tvOS)
       if #available(iOS 13.0, tvOS 13.0, *) {
-        window?.windowScene?.screen.scale ?? 1.0
+        return window?.windowScene?.screen.scale ?? 1.0
       } else {
-        UIScreen.main.scale
+        return UIScreen.main.scale
       }
       #else // if os(visionOS)
       // We intentionally don't check `#if os(visionOS)`, because that emits

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -40,8 +40,7 @@ open class LottieAnimationViewBase: UIView {
   var screenScale: CGFloat {
     #if os(iOS) || os(tvOS)
     if #available(iOS 13.0, *) {
-        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-        return windowScene?.screen.scale ?? .zero
+        return window?.windowScene?.screen.scale ?? .zero
     } else {
         return UIScreen.main.scale
     }

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -40,7 +40,7 @@ open class LottieAnimationViewBase: UIView {
   var screenScale: CGFloat {
     #if os(iOS) || os(tvOS)
     if #available(iOS 13.0, tvOS 13.0, *) {
-      return UITraitCollection.current.displayScale
+      return max(UITraitCollection.current.displayScale, 1)
     } else {
       return UIScreen.main.scale
     }


### PR DESCRIPTION
`UIScree.main` will be deprecated in a future version of iOS.
I used `window.windowScene.screen` to get display's scale.

developer doc > [mian](https://developer.apple.com/documentation/uikit/uiscreen/1617815-main) already deprecated. It causes serious errors in the near future.

So have to change another way. And `window.windowScene.screen` is the one way of getting display's scale. That is available from `iOS 13.0`. This is why control flow has `iOS 13.0` condition.

Resolved: #2215
