### PR TITLE
Change  pod dependencies `SwiftUI` and `Combine` to `weak` to ensure compatibility with iOS 12

### DIFF
--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
@@ -1,9 +1,9 @@
 // Created by eric_horacek on 10/8/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI) && !os(macOS)
 import SwiftUI
 
-#if !os(macOS)
 // MARK: - EpoxySwiftUIUIHostingController
 
 /// A `UIHostingController` that hosts SwiftUI views within an Epoxy container, e.g. an Epoxy

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -1,10 +1,9 @@
 // Created by eric_horacek on 9/16/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(Combine) && canImport(SwiftUI) && !os(macOS)
 import Combine
 import SwiftUI
-
-#if !os(macOS)
 
 // MARK: - SwiftUIHostingViewReuseBehavior
 
@@ -387,5 +386,4 @@ struct EpoxyHostingWrapper<Content: View>: View {
       .environment(\.epoxyIntrinsicContentSizeInvalidator, environment.intrinsicContentSizeInvalidator)
   }
 }
-
 #endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIIntrinsicContentSizeInvalidator.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIIntrinsicContentSizeInvalidator.swift
@@ -1,6 +1,7 @@
 // Created by matthew_cheok on 11/19/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 // MARK: - EpoxyIntrinsicContentSizeInvalidator
@@ -42,3 +43,4 @@ extension EnvironmentValues {
 private struct EpoxyIntrinsicContentSizeInvalidatorKey: EnvironmentKey {
   static let defaultValue = EpoxyIntrinsicContentSizeInvalidator(invalidate: { })
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUILayoutMargins.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUILayoutMargins.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 10/8/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 // MARK: - View
@@ -49,3 +50,4 @@ private struct EpoxyLayoutMarginsPadding: ViewModifier {
     content.padding(epoxyLayoutMargins)
   }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 9/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 // MARK: - StyledView
@@ -170,3 +171,4 @@ extension StyledView
     }
   }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringViewRepresentable.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringViewRepresentable.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 6/22/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 // MARK: - MeasuringViewRepresentable
@@ -125,4 +126,5 @@ extension MeasuringViewRepresentable {
   }
   #endif
 }
+#endif
 #endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -1,6 +1,7 @@
 // Created by Bryn Bodayle on 1/24/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 // MARK: - SwiftUIMeasurementContainer
@@ -450,3 +451,4 @@ extension CGSize {
       height: height == ViewType.noIntrinsicMetric ? fallback.height : height)
   }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/SwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/SwiftUIView.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 9/8/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 // MARK: - SwiftUIView
@@ -146,3 +147,4 @@ extension SwiftUIView {
     fileprivate(set) var storage: Storage
   }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 3/3/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 // MARK: - ViewTypeProtocol + swiftUIView
@@ -38,3 +39,4 @@ protocol ViewTypeProtocol: ViewType { }
 // MARK: - ViewType + ViewTypeProtocol
 
 extension ViewType: ViewTypeProtocol { }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 3/4/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 // MARK: - UIViewConfiguringSwiftUIView
@@ -41,3 +42,4 @@ extension UIViewConfiguringSwiftUIView {
     return copy
   }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ViewType.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ViewType.swift
@@ -1,8 +1,9 @@
 // Created by Cal Stephens on 6/26/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI) && canImport(UIKit)
+#if canImport(SwiftUI)
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
 
 /// The platform's main view type.
@@ -47,4 +48,5 @@ extension ViewRepresentableType {
   /// Either `UIViewType` on iOS/tvOS or `NSViewType` on macOS.
   typealias RepresentableViewType = NSViewType
 }
+#endif
 #endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ViewType.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ViewType.swift
@@ -1,9 +1,8 @@
 // Created by Cal Stephens on 6/26/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI) && canImport(UIKit)
 import SwiftUI
-
-#if canImport(UIKit)
 import UIKit
 
 /// The platform's main view type.

--- a/Sources/Private/Utility/Helpers/Binding+Map.swift
+++ b/Sources/Private/Utility/Helpers/Binding+Map.swift
@@ -1,6 +1,7 @@
 // Created by miguel_jimenez on 7/27/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
@@ -16,3 +17,4 @@ extension Binding {
     }
   }
 }
+#endif

--- a/Sources/Private/Utility/Helpers/View+ValueChanged.swift
+++ b/Sources/Private/Utility/Helpers/View+ValueChanged.swift
@@ -1,6 +1,7 @@
 // Created by miguel_jimenez on 7/26/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(Combine) && canImport(SwiftUI)
 import Combine
 import SwiftUI
 
@@ -18,3 +19,4 @@ extension View {
     }
   }
 }
+#endif

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -1,6 +1,7 @@
 // Created by Bryn Bodayle on 1/20/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 // MARK: - LottieView
@@ -480,3 +481,4 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     loadAnimationIfNecessary()
   }
 }
+#endif

--- a/Sources/Public/Controls/LottieButton.swift
+++ b/Sources/Public/Controls/LottieButton.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// A wrapper which exposes Lottie's `AnimatedButton` to SwiftUI
@@ -118,5 +119,5 @@ public struct LottieButton: UIViewConfiguringSwiftUIView {
   private let animation: LottieAnimation?
   private let action: () -> Void
   private var configuration: LottieConfiguration = .shared
-
 }
+#endif

--- a/Sources/Public/Controls/LottieSwitch.swift
+++ b/Sources/Public/Controls/LottieSwitch.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/11/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// A wrapper which exposes Lottie's `AnimatedSwitch` to SwiftUI
@@ -142,3 +143,4 @@ public struct LottieSwitch: UIViewConfiguringSwiftUIView {
   private var isOn: Binding<Bool>?
 
 }
+#endif

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -36,5 +36,6 @@ Lottie enables designers to create and ship beautiful animations without an engi
   s.ios.frameworks = ['UIKit', 'CoreGraphics', 'QuartzCore']
   s.tvos.frameworks = ['UIKit', 'CoreGraphics', 'QuartzCore']
   s.osx.frameworks = ['AppKit', 'CoreGraphics', 'QuartzCore']
+  s.weak_frameworks = ['SwiftUI', 'Combine']
   s.module_name = 'Lottie'
 end


### PR DESCRIPTION
Since [SwiftUI was added](https://github.com/airbnb/lottie-ios/commit/5189094838e7fadfec2bd1466aaddabcbb73742c) to lottie-ios, it no longer runs on iOS 12 devices when embedded through CocoaPods. The runtime error encountered on iOS 12:

```
dyld: Library not loaded: /System/Library/Frameworks/SwiftUI.framework/SwiftUI
Referenced from: /private/var/containers/Bundle/Application/[...]/Frameworks/Lottie.framework/Lottie
Reason: image not found
```

The reason for this is, that CocoaPods automatically adds strong dependencies to any used frameworks, unless otherwise specified.

With this PR, we specifically add SwiftUI and Combine as `weak` dependencies, meaning that projects embedding lottie-ios as pod are not required to embed SwiftUI and Combine.
Additionally, all files using SwiftUI are prefixed with a `canImport(SwiftUI)`.