### PR TITLE
Mark DotLottieCache as Sendable

### DIFF
--- a/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,43 +1,40 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Difference",
-        "repositoryURL": "https://github.com/krzysztofzablocki/Difference",
-        "state": {
-          "branch": null,
-          "revision": "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
-          "version": "1.0.1"
-        }
-      },
-      {
-        "package": "AirbnbSwift",
-        "repositoryURL": "https://github.com/airbnb/swift",
-        "state": {
-          "branch": null,
-          "revision": "6900f5ab7ab7394ac85eb9da52b2528ee329b206",
-          "version": "1.0.4"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": null,
-          "revision": "fddd1c00396eed152c45a46bea9f47b98e59301d",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "swift-snapshot-testing",
-        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
-        "state": {
-          "branch": null,
-          "revision": "0c2826f26d00ff5ddf2de92cb6b2139b0dd3d1ee",
-          "version": null
-        }
+  "pins" : [
+    {
+      "identity" : "difference",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzysztofzablocki/Difference",
+      "state" : {
+        "revision" : "02fe1111edc8318c4f8a0da96336fcbcc201f38b",
+        "version" : "1.0.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/swift",
+      "state" : {
+        "revision" : "6900f5ab7ab7394ac85eb9da52b2528ee329b206",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
+      "state" : {
+        "revision" : "0c2826f26d00ff5ddf2de92cb6b2139b0dd3d1ee"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Sources/Public/DotLottie/Cache/DotLottieCache.swift
+++ b/Sources/Public/DotLottie/Cache/DotLottieCache.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// Once `cacheSize` is reached, the least recently used lottie will be ejected.
 /// The default size of the cache is 100.
-public class DotLottieCache: DotLottieCacheProvider {
+public class DotLottieCache: DotLottieCacheProvider, @unchecked Sendable {
 
   // MARK: Lifecycle
 

--- a/Sources/Public/DotLottie/Cache/DotLottieCache.swift
+++ b/Sources/Public/DotLottie/Cache/DotLottieCache.swift
@@ -7,11 +7,13 @@
 
 import Foundation
 
+// MARK: - DotLottieCache
+
 /// A DotLottie Cache that will store lottie files up to `cacheSize`.
 ///
 /// Once `cacheSize` is reached, the least recently used lottie will be ejected.
 /// The default size of the cache is 100.
-public class DotLottieCache: DotLottieCacheProvider, @unchecked Sendable {
+public class DotLottieCache: DotLottieCacheProvider {
 
   // MARK: Lifecycle
 
@@ -55,3 +57,10 @@ public class DotLottieCache: DotLottieCacheProvider, @unchecked Sendable {
   private var cache = LRUCache<String, DotLottieFile>()
 
 }
+
+// MARK: Sendable
+
+// DotLottieCacheProvider has a Sendable requirement, but we can't
+// redesign DotLottieCache to be properly Sendable without making breaking changes.
+// swiftlint:disable:next no_unchecked_sendable
+extension DotLottieCache: @unchecked Sendable { }

--- a/Sources/Public/DotLottie/Cache/DotLottieCacheProvider.swift
+++ b/Sources/Public/DotLottie/Cache/DotLottieCacheProvider.swift
@@ -10,7 +10,7 @@
 /// can increase performance when loading an animation multiple times.
 ///
 /// Lottie comes with a prebuilt LRU DotLottie Cache.
-public protocol DotLottieCacheProvider {
+public protocol DotLottieCacheProvider: Sendable {
 
   func file(forKey: String) -> DotLottieFile?
 


### PR DESCRIPTION
This PR marks `DotLottieCache` as `Sendable`, which is required to use the SwiftUI `LottieView` with targeted concurrency checking enabled. Fixes #2235.

This is the same approach used for `DefaultAnimationCache`: https://github.com/airbnb/lottie-ios/blob/master/Sources/Public/AnimationCache/DefaultAnimationCache.swift#L67