### PR TITLE
Remove a few unused imports

### DIFF
--- a/Sources/Private/CoreAnimation/Animations/StrokeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/StrokeAnimation.swift
@@ -1,7 +1,6 @@
 // Created by Cal Stephens on 2/10/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-import Foundation
 import QuartzCore
 
 // MARK: - StrokeShapeItem

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -1,7 +1,6 @@
 // Created by Cal Stephens on 12/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-import Foundation
 import QuartzCore
 
 // MARK: - CoreAnimationLayer

--- a/Sources/Private/CoreAnimation/Layers/LayerModel+makeAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/LayerModel+makeAnimationLayer.swift
@@ -1,8 +1,6 @@
 // Created by Cal Stephens on 12/20/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-import QuartzCore
-
 // MARK: - LayerContext
 
 /// Context available when constructing an `AnimationLayer`

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/CompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/CompositionLayer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/22/19.
 //
 
-import Foundation
 import QuartzCore
 
 // MARK: - CompositionLayer

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/ImageCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/ImageCompositionLayer.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-import CoreGraphics
-import Foundation
 import QuartzCore
 
 final class ImageCompositionLayer: CompositionLayer {

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/MaskContainerLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/MaskContainerLayer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-import Foundation
 import QuartzCore
 
 extension MaskMode {

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/PreCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/PreCompositionLayer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-import Foundation
 import QuartzCore
 
 final class PreCompositionLayer: CompositionLayer {

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/ShapeCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/ShapeCompositionLayer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/22/19.
 //
 
-import CoreGraphics
 import Foundation
 
 /// A CompositionLayer responsible for initializing and rendering shapes

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/SolidCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/SolidCompositionLayer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-import Foundation
 import QuartzCore
 
 final class SolidCompositionLayer: CompositionLayer {

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/TextCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/TextCompositionLayer.swift
@@ -5,11 +5,6 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-import CoreGraphics
-import CoreText
-import Foundation
-import QuartzCore
-
 /// Needed for NSMutableParagraphStyle...
 #if os(OSX)
 import AppKit

--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/24/19.
 //
 
-import Foundation
 import QuartzCore
 
 // MARK: - MainThreadAnimationLayer

--- a/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
@@ -1,8 +1,6 @@
 // Created by Jianjun Wu on 2022/5/12.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-import CoreGraphics
-import Foundation
 import QuartzCore
 
 // MARK: - CachedImageProvider

--- a/Sources/Private/MainThread/LayerContainers/Utility/CompositionLayersInitializer.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CompositionLayersInitializer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-import CoreGraphics
 import Foundation
 
 extension Array where Element == LayerModel {

--- a/Sources/Private/MainThread/LayerContainers/Utility/CoreTextRenderLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CoreTextRenderLayer.swift
@@ -5,10 +5,6 @@
 //  Created by Brandon Withrow on 8/3/20.
 //
 
-import CoreGraphics
-import CoreText
-import Foundation
-import QuartzCore
 /// Needed for NSMutableParagraphStyle...
 #if os(OSX)
 import AppKit

--- a/Sources/Private/MainThread/LayerContainers/Utility/InvertedMatteLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/InvertedMatteLayer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/28/19.
 //
 
-import Foundation
 import QuartzCore
 
 /// A layer that inverses the alpha output of its input layer.

--- a/Sources/Private/MainThread/LayerContainers/Utility/LayerFontProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/LayerFontProvider.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2020 YurtvilleProds. All rights reserved.
 //
 
-import Foundation
-
 /// Connects a LottieFontProvider to a group of text layers
 final class LayerFontProvider {
 

--- a/Sources/Private/MainThread/LayerContainers/Utility/LayerImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/LayerImageProvider.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-import Foundation
-
 /// Connects a LottieImageProvider to a group of image layers
 final class LayerImageProvider {
 

--- a/Sources/Private/MainThread/LayerContainers/Utility/LayerTextProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/LayerTextProvider.swift
@@ -5,8 +5,6 @@
 //  Created by Alexandr Goncharov on 07/06/2019.
 //
 
-import Foundation
-
 /// Connects a LottieTextProvider to a group of text layers
 final class LayerTextProvider {
 

--- a/Sources/Private/MainThread/LayerContainers/Utility/LayerTransformNode.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/LayerTransformNode.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import CoreGraphics
-import Foundation
 import QuartzCore
 
 // MARK: - LayerTransformProperties

--- a/Sources/Private/MainThread/NodeRenderSystem/Extensions/ItemsExtension.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Extensions/ItemsExtension.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/18/19.
 //
 
-import Foundation
-
 // MARK: - NodeTree
 
 final class NodeTree {

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/NodeProperty.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/NodeProperty.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import CoreGraphics
 import Foundation
 
 /// A node property that holds a reference to a T ValueProvider and a T ValueContainer.

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/AnyNodeProperty.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/AnyNodeProperty.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - AnyNodeProperty

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/AnyValueContainer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/AnyValueContainer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import CoreGraphics
 import Foundation
 
 /// The container for the value of a property.

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/KeypathSearchable.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/KeypathSearchable.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import Foundation
 import QuartzCore
 
 /// Protocol that provides keypath search functionality. Returns all node properties associated with a keypath.

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/NodePropertyMap.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/NodePropertyMap.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/21/19.
 //
 
-import Foundation
 import QuartzCore
 
 // MARK: - NodePropertyMap

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueContainer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueContainer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import CoreGraphics
 import Foundation
 
 /// A container for a node value that is Typed to T.

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueProviders/GroupInterpolator.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueProviders/GroupInterpolator.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/22/19.
 //
 
-import CoreGraphics
 import Foundation
 
 /// A value provider that produces an array of values from an array of Keyframe Interpolators

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueProviders/SingleValueProvider.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueProviders/SingleValueProvider.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import QuartzCore
 
 /// Returns a value for every frame.
 final class SingleValueProvider<ValueType: AnyInterpolatable>: ValueProvider {

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/ModifierNodes/RoundedCornersNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/ModifierNodes/RoundedCornersNode.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import QuartzCore
 
 // MARK: - RoundedCornersProperties
 

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/ModifierNodes/TrimPathNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/ModifierNodes/TrimPathNode.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import QuartzCore
 
 // MARK: - TrimPathProperties
 

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/GroupOutputNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/GroupOutputNode.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import CoreGraphics
-import Foundation
 import QuartzCore
 
 class GroupOutputNode: NodeOutput {

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/PassThroughOutputNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/PassThroughOutputNode.swift
@@ -6,7 +6,6 @@
 //
 
 import CoreGraphics
-import Foundation
 
 class PassThroughOutputNode: NodeOutput {
 

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/PathOutputNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/PathOutputNode.swift
@@ -6,7 +6,6 @@
 //
 
 import CoreGraphics
-import Foundation
 
 /// A node that has an output of a BezierPath
 class PathOutputNode: NodeOutput {

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/FillRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/FillRenderer.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import CoreGraphics
-import Foundation
 import QuartzCore
 
 extension FillRule {

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import Foundation
 import QuartzCore
 
 // MARK: - GradientFillLayer

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientStrokeRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientStrokeRenderer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import Foundation
 import QuartzCore
 
 // MARK: - Renderer

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/LegacyGradientFillRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/LegacyGradientFillRenderer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import Foundation
 import QuartzCore
 
 /// A rendered for a Path Fill

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/StrokeRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/StrokeRenderer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import Foundation
 import QuartzCore
 
 extension LineJoin {

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/EllipseNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/EllipseNode.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import QuartzCore
 
 // MARK: - EllipseNodeProperties
 

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/PolygonNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/PolygonNode.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import QuartzCore
 
 // MARK: - PolygonNodeProperties
 

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/RectNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/RectNode.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/21/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - RectNodeProperties

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/ShapeNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/ShapeNode.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/16/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - ShapeNodeProperties

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/StarNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/StarNode.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import QuartzCore
 
 // MARK: - StarNodeProperties
 

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderContainers/GroupNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderContainers/GroupNode.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/18/19.
 //
 
-import CoreGraphics
-import Foundation
 import QuartzCore
 
 // MARK: - GroupNodeProperties

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/FillNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/FillNode.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/17/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - FillNodeProperties

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientFillNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientFillNode.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import QuartzCore
 
 // MARK: - GradientFillProperties
 

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientStrokeNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientStrokeNode.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/23/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - GradientStrokeProperties

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/StrokeNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/StrokeNode.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import QuartzCore
 
 // MARK: - StrokeNodeProperties
 

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/Text/TextAnimatorNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/Text/TextAnimatorNode.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 2/19/19.
 //
 
-import CoreGraphics
-import Foundation
 import QuartzCore
 
 // MARK: - TextAnimatorNodeProperties

--- a/Sources/Private/MainThread/NodeRenderSystem/Protocols/AnimatorNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Protocols/AnimatorNode.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/15/19.
 //
 
-import Foundation
 import QuartzCore
 
 // MARK: - NodeOutput

--- a/Sources/Private/MainThread/NodeRenderSystem/Protocols/PathNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Protocols/PathNode.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/17/19.
 //
 
-import Foundation
-
 // MARK: - PathNode
 
 protocol PathNode {

--- a/Sources/Private/MainThread/NodeRenderSystem/Protocols/RenderNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Protocols/RenderNode.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/17/19.
 //
 
-import CoreGraphics
-import Foundation
 import QuartzCore
 
 // MARK: - RenderNode

--- a/Sources/Private/MainThread/NodeRenderSystem/RenderLayers/ShapeContainerLayer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/RenderLayers/ShapeContainerLayer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import Foundation
 import QuartzCore
 
 /// The base layer that holds Shapes and Shape Renderers

--- a/Sources/Private/MainThread/NodeRenderSystem/RenderLayers/ShapeRenderLayer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/RenderLayers/ShapeRenderLayer.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/18/19.
 //
 
-import Foundation
 import QuartzCore
 
 /// The layer responsible for rendering shape objects

--- a/Sources/Private/Model/Assets/Asset.swift
+++ b/Sources/Private/Model/Assets/Asset.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
-import Foundation
-
 // MARK: - Asset
 
 public class Asset: Codable, DictionaryInitializable {

--- a/Sources/Private/Model/Assets/AssetLibrary.swift
+++ b/Sources/Private/Model/Assets/AssetLibrary.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
-import Foundation
-
 final class AssetLibrary: Codable, AnyInitializable, Sendable {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/Assets/PrecompAsset.swift
+++ b/Sources/Private/Model/Assets/PrecompAsset.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
-import Foundation
-
 final class PrecompAsset: Asset {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/DictionaryInitializable.swift
+++ b/Sources/Private/Model/DictionaryInitializable.swift
@@ -5,8 +5,6 @@
 //  Created by Marcelo Fabri on 5/5/22.
 //
 
-import Foundation
-
 // MARK: - InitializableError
 
 enum InitializableError: Error {

--- a/Sources/Private/Model/DotLottie/DotLottieImageProvider.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieImageProvider.swift
@@ -5,7 +5,6 @@
 //  Created by Evandro Hoffmann on 20/10/22.
 //
 
-import Foundation
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)

--- a/Sources/Private/Model/Extensions/KeyedDecodingContainerExtensions.swift
+++ b/Sources/Private/Model/Extensions/KeyedDecodingContainerExtensions.swift
@@ -1,7 +1,5 @@
 // From: https://medium.com/@kewindannerfjordremeczki/swift-4-0-decodable-heterogeneous-collections-ecc0e6b468cf
 
-import Foundation
-
 // MARK: - ClassFamily
 
 /// To support a new class family, create an enum that conforms to this protocol and contains the different types.

--- a/Sources/Private/Model/Keyframes/KeyframeData.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeData.swift
@@ -5,9 +5,6 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
-import CoreGraphics
-import Foundation
-
 // MARK: - KeyframeData
 
 /// A generic class used to parse and remap keyframe json.

--- a/Sources/Private/Model/Keyframes/KeyframeGroup.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeGroup.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/14/19.
 //
 
-import Foundation
-
 // MARK: - KeyframeGroup
 
 /// Used for coding/decoding a group of Keyframes by type.

--- a/Sources/Private/Model/LayerEffects/DropShadowEffect.swift
+++ b/Sources/Private/Model/LayerEffects/DropShadowEffect.swift
@@ -1,8 +1,6 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-import Foundation
-
 final class DropShadowEffect: LayerEffect {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/LayerEffects/EffectValues/ColorEffectValue.swift
+++ b/Sources/Private/Model/LayerEffects/EffectValues/ColorEffectValue.swift
@@ -1,8 +1,6 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-import Foundation
-
 final class ColorEffectValue: EffectValue {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/LayerEffects/EffectValues/EffectValue.swift
+++ b/Sources/Private/Model/LayerEffects/EffectValues/EffectValue.swift
@@ -1,8 +1,6 @@
 // Created by Cal Stephens on 8/15/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-import Foundation
-
 // MARK: - EffectValueType
 
 /// https://lottiefiles.github.io/lottie-docs/schema/#/$defs/effect-values

--- a/Sources/Private/Model/LayerEffects/EffectValues/Vector1DEffectValue.swift
+++ b/Sources/Private/Model/LayerEffects/EffectValues/Vector1DEffectValue.swift
@@ -1,8 +1,6 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-import Foundation
-
 final class Vector1DEffectValue: EffectValue {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/LayerEffects/LayerEffect.swift
+++ b/Sources/Private/Model/LayerEffects/LayerEffect.swift
@@ -1,8 +1,6 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-import Foundation
-
 // MARK: - LayerEffectType
 
 /// https://lottiefiles.github.io/lottie-docs/schema/#/$defs/effects

--- a/Sources/Private/Model/LayerStyles/DropShadowStyle.swift
+++ b/Sources/Private/Model/LayerStyles/DropShadowStyle.swift
@@ -1,8 +1,6 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-import Foundation
-
 final class DropShadowStyle: LayerStyle {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/LayerStyles/LayerStyle.swift
+++ b/Sources/Private/Model/LayerStyles/LayerStyle.swift
@@ -1,8 +1,6 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-import Foundation
-
 // MARK: - LayerStyleType
 
 enum LayerStyleType: Int, Codable, Sendable {

--- a/Sources/Private/Model/Layers/ImageLayerModel.swift
+++ b/Sources/Private/Model/Layers/ImageLayerModel.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 /// A layer that holds an image.
 final class ImageLayerModel: LayerModel {
 

--- a/Sources/Private/Model/Layers/LayerModel.swift
+++ b/Sources/Private/Model/Layers/LayerModel.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
-import Foundation
-
 // MARK: - LayerType + ClassFamily
 
 /// Used for mapping a heterogeneous list to classes for parsing.

--- a/Sources/Private/Model/Layers/PreCompLayerModel.swift
+++ b/Sources/Private/Model/Layers/PreCompLayerModel.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 /// A layer that holds another animation composition.
 final class PreCompLayerModel: LayerModel {
 

--- a/Sources/Private/Model/Layers/ShapeLayerModel.swift
+++ b/Sources/Private/Model/Layers/ShapeLayerModel.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 /// A layer that holds vector shape objects.
 final class ShapeLayerModel: LayerModel {
 

--- a/Sources/Private/Model/Layers/SolidLayerModel.swift
+++ b/Sources/Private/Model/Layers/SolidLayerModel.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 /// A layer that holds a solid color.
 final class SolidLayerModel: LayerModel {
 

--- a/Sources/Private/Model/Layers/TextLayerModel.swift
+++ b/Sources/Private/Model/Layers/TextLayerModel.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 /// A layer that holds text.
 final class TextLayerModel: LayerModel {
 

--- a/Sources/Private/Model/Objects/DashPattern.swift
+++ b/Sources/Private/Model/Objects/DashPattern.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/22/19.
 //
 
-import Foundation
-
 // MARK: - DashElementType
 
 enum DashElementType: String, Codable {

--- a/Sources/Private/Model/Objects/Marker.swift
+++ b/Sources/Private/Model/Objects/Marker.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
-import Foundation
-
 /// A time marker
 final class Marker: Codable, Sendable, DictionaryInitializable {
 

--- a/Sources/Private/Model/Objects/Mask.swift
+++ b/Sources/Private/Model/Objects/Mask.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 // MARK: - MaskMode
 
 enum MaskMode: String, Codable {

--- a/Sources/Private/Model/Objects/Transform.swift
+++ b/Sources/Private/Model/Objects/Transform.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
-import Foundation
-
 /// The animatable transform for a layer. Controls position, rotation, scale, and opacity.
 final class Transform: Codable, DictionaryInitializable {
 

--- a/Sources/Private/Model/ShapeItems/Ellipse.swift
+++ b/Sources/Private/Model/ShapeItems/Ellipse.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 // MARK: - PathDirection
 
 enum PathDirection: Int, Codable {

--- a/Sources/Private/Model/ShapeItems/Fill.swift
+++ b/Sources/Private/Model/ShapeItems/Fill.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 // MARK: - FillRule
 
 enum FillRule: Int, Codable {

--- a/Sources/Private/Model/ShapeItems/GradientFill.swift
+++ b/Sources/Private/Model/ShapeItems/GradientFill.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 // MARK: - GradientType
 
 enum GradientType: Int, Codable, Sendable {

--- a/Sources/Private/Model/ShapeItems/GradientStroke.swift
+++ b/Sources/Private/Model/ShapeItems/GradientStroke.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 // MARK: - LineCap
 
 enum LineCap: Int, Codable, Sendable {

--- a/Sources/Private/Model/ShapeItems/Group.swift
+++ b/Sources/Private/Model/ShapeItems/Group.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 /// An item that define a a group of shape items
 final class Group: ShapeItem {
 

--- a/Sources/Private/Model/ShapeItems/Merge.swift
+++ b/Sources/Private/Model/ShapeItems/Merge.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 // MARK: - MergeMode
 
 enum MergeMode: Int, Codable, Sendable {

--- a/Sources/Private/Model/ShapeItems/Rectangle.swift
+++ b/Sources/Private/Model/ShapeItems/Rectangle.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 final class Rectangle: ShapeItem {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/ShapeItems/Repeater.swift
+++ b/Sources/Private/Model/ShapeItems/Repeater.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 final class Repeater: ShapeItem {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/ShapeItems/RoundedCorners.swift
+++ b/Sources/Private/Model/ShapeItems/RoundedCorners.swift
@@ -5,8 +5,6 @@
 //  Created by Duolingo on 10/31/22.
 //
 
-import Foundation
-
 // MARK: - RoundedCorners
 
 final class RoundedCorners: ShapeItem {

--- a/Sources/Private/Model/ShapeItems/Shape.swift
+++ b/Sources/Private/Model/ShapeItems/Shape.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 /// An item that defines an custom shape
 final class Shape: ShapeItem {
 

--- a/Sources/Private/Model/ShapeItems/ShapeItem.swift
+++ b/Sources/Private/Model/ShapeItems/ShapeItem.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 // MARK: - ShapeType
 
 enum ShapeType: String, Codable, Sendable {

--- a/Sources/Private/Model/ShapeItems/ShapeTransform.swift
+++ b/Sources/Private/Model/ShapeItems/ShapeTransform.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 final class ShapeTransform: ShapeItem {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/ShapeItems/Star.swift
+++ b/Sources/Private/Model/ShapeItems/Star.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 // MARK: - StarType
 
 enum StarType: Int, Codable, Sendable {

--- a/Sources/Private/Model/ShapeItems/Stroke.swift
+++ b/Sources/Private/Model/ShapeItems/Stroke.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 final class Stroke: ShapeItem {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/ShapeItems/Trim.swift
+++ b/Sources/Private/Model/ShapeItems/Trim.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
-import Foundation
-
 // MARK: - TrimType
 
 enum TrimType: Int, Codable {

--- a/Sources/Private/Model/Text/Font.swift
+++ b/Sources/Private/Model/Text/Font.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
-import Foundation
-
 // MARK: - Font
 
 final class Font: Codable, Sendable, DictionaryInitializable {

--- a/Sources/Private/Model/Text/Glyph.swift
+++ b/Sources/Private/Model/Text/Glyph.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
-import Foundation
-
 /// A model that holds a vector character
 final class Glyph: Codable, Sendable, DictionaryInitializable {
 

--- a/Sources/Private/Model/Text/TextAnimator.swift
+++ b/Sources/Private/Model/Text/TextAnimator.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
-import Foundation
-
 final class TextAnimator: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle

--- a/Sources/Private/Model/Text/TextDocument.swift
+++ b/Sources/Private/Model/Text/TextDocument.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
-import Foundation
-
 // MARK: - TextJustification
 
 enum TextJustification: Int, Codable {

--- a/Sources/Private/Utility/Debugging/AnimatorNodeDebugging.swift
+++ b/Sources/Private/Utility/Debugging/AnimatorNodeDebugging.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/18/19.
 //
 
-import Foundation
-
 extension AnimatorNode {
 
   func printNodeTree() {

--- a/Sources/Private/Utility/Debugging/LayerDebugging.swift
+++ b/Sources/Private/Utility/Debugging/LayerDebugging.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/24/19.
 //
 
-import Foundation
 import QuartzCore
 
 // MARK: - LayerDebugStyle

--- a/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
+++ b/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import Foundation
 import QuartzCore
 
 extension KeypathSearchable {

--- a/Sources/Private/Utility/Extensions/CGFloatExtensions.swift
+++ b/Sources/Private/Utility/Extensions/CGFloatExtensions.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import QuartzCore
 
 extension CGFloat {
 

--- a/Sources/Private/Utility/Extensions/DataExtension.swift
+++ b/Sources/Private/Utility/Extensions/DataExtension.swift
@@ -5,7 +5,6 @@
 //  Created by René Fouquet on 03.05.21.
 //
 
-import Foundation
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)

--- a/Sources/Private/Utility/Extensions/MathKit.swift
+++ b/Sources/Private/Utility/Extensions/MathKit.swift
@@ -6,7 +6,6 @@
 //
 // From https://github.com/buba447/UIToolBox
 
-import CoreGraphics
 import Foundation
 
 extension Int {

--- a/Sources/Private/Utility/Helpers/AnimationContext.swift
+++ b/Sources/Private/Utility/Helpers/AnimationContext.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/1/19.
 //
 
-import CoreGraphics
 import Foundation
 import QuartzCore
 

--- a/Sources/Private/Utility/Helpers/AnyEquatable.swift
+++ b/Sources/Private/Utility/Helpers/AnyEquatable.swift
@@ -1,8 +1,6 @@
 // Created by miguel_jimenez on 8/2/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-import Foundation
-
 // MARK: - AnyEquatable
 
 struct AnyEquatable {

--- a/Sources/Private/Utility/Interpolatable/InterpolatableExtensions.swift
+++ b/Sources/Private/Utility/Interpolatable/InterpolatableExtensions.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/14/19.
 //
 
-import CoreGraphics
 import Foundation
 
 extension LottieColor {

--- a/Sources/Private/Utility/Interpolatable/KeyframeExtensions.swift
+++ b/Sources/Private/Utility/Interpolatable/KeyframeExtensions.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/14/19.
 //
 
-import CoreGraphics
 import Foundation
 
 extension Keyframe where T: AnyInterpolatable {

--- a/Sources/Private/Utility/Interpolatable/KeyframeInterpolator.swift
+++ b/Sources/Private/Utility/Interpolatable/KeyframeInterpolator.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/15/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - KeyframeInterpolator

--- a/Sources/Private/Utility/Primitives/BezierPath.swift
+++ b/Sources/Private/Utility/Primitives/BezierPath.swift
@@ -6,7 +6,6 @@
 //
 
 import CoreGraphics
-import Foundation
 
 // MARK: - BezierPath
 

--- a/Sources/Private/Utility/Primitives/BezierPathRoundExtension.swift
+++ b/Sources/Private/Utility/Primitives/BezierPathRoundExtension.swift
@@ -5,7 +5,6 @@
 //  Created by Duolingo on 11/1/22.
 //
 
-import CoreGraphics
 import Foundation
 
 //    Adapted to Swift from lottie-web & lottie-android:

--- a/Sources/Private/Utility/Primitives/ColorExtension.swift
+++ b/Sources/Private/Utility/Primitives/ColorExtension.swift
@@ -6,7 +6,6 @@
 //
 
 import CoreGraphics
-import Foundation
 
 // MARK: - LottieColor + Codable
 

--- a/Sources/Private/Utility/Primitives/CompoundBezierPath.swift
+++ b/Sources/Private/Utility/Primitives/CompoundBezierPath.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/14/19.
 //
 
-import CoreGraphics
 import Foundation
 
 /// A collection of BezierPath objects that can be trimmed and added.

--- a/Sources/Private/Utility/Primitives/CurveVertex.swift
+++ b/Sources/Private/Utility/Primitives/CurveVertex.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/11/19.
 //
 
-import CoreGraphics
 import Foundation
 
 /// A single vertex with an in and out tangent

--- a/Sources/Private/Utility/Primitives/PathElement.swift
+++ b/Sources/Private/Utility/Primitives/PathElement.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/11/19.
 //
 
-import CoreGraphics
 import Foundation
 
 /// A path section, containing one point and its length to the previous point.

--- a/Sources/Private/Utility/Primitives/VectorsExtensions.swift
+++ b/Sources/Private/Utility/Primitives/VectorsExtensions.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
-import CoreGraphics
 import Foundation
 import QuartzCore
 

--- a/Sources/Public/Animation/LottieAnimation.swift
+++ b/Sources/Public/Animation/LottieAnimation.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
-import Foundation
-
 // MARK: - CoordinateSpace
 
 public enum CoordinateSpace: Int, Codable, Sendable {

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/5/19.
 //
 
-import CoreGraphics
 import Foundation
 
 extension LottieAnimation {

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -3,7 +3,6 @@
 //  Lottie
 //
 
-import Foundation
 import QuartzCore
 
 // MARK: - LottieAnimationLayer

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 1/23/19.
 //
 
-import Foundation
 import QuartzCore
 
 // MARK: - LottieBackgroundBehavior

--- a/Sources/Public/AnimationCache/AnimationCacheProvider.swift
+++ b/Sources/Public/AnimationCache/AnimationCacheProvider.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 2/5/19.
 //
 
-import Foundation
-
 /// `AnimationCacheProvider` is a protocol that describes an Animation Cache.
 /// Animation Cache is used when loading `LottieAnimation` models. Using an Animation Cache
 /// can increase performance when loading an animation multiple times.

--- a/Sources/Public/AnimationCache/LRUAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LRUAnimationCache.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 2/5/19.
 //
 
-import Foundation
-
 @available(*, deprecated, message: """
   Use DefaultAnimationCache instead, which is thread-safe and automatically responds to memory pressure.
   """)

--- a/Sources/Public/Controls/AnimatedButton.swift
+++ b/Sources/Public/Controls/AnimatedButton.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import Foundation
-
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)

--- a/Sources/Public/Controls/AnimatedControl.swift
+++ b/Sources/Public/Controls/AnimatedControl.swift
@@ -11,8 +11,6 @@ import UIKit
 import AppKit
 #endif
 
-import Foundation
-
 // MARK: - AnimatedControl
 
 /// Lottie comes prepacked with a two Animated Controls, `AnimatedSwitch` and

--- a/Sources/Public/Controls/AnimatedSwitch.swift
+++ b/Sources/Public/Controls/AnimatedSwitch.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import Foundation
-
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)

--- a/Sources/Public/DotLottie/Cache/DotLottieCacheProvider.swift
+++ b/Sources/Public/DotLottie/Cache/DotLottieCacheProvider.swift
@@ -5,8 +5,6 @@
 //  Created by Evandro Hoffmann on 20/10/22.
 //
 
-import Foundation
-
 /// `DotLottieCacheProvider` is a protocol that describes a DotLottie Cache.
 /// DotLottie Cache is used when loading `DotLottie` models. Using a DotLottie Cache
 /// can increase performance when loading an animation multiple times.

--- a/Sources/Public/DynamicProperties/AnimationKeypath.swift
+++ b/Sources/Public/DynamicProperties/AnimationKeypath.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import Foundation
-
 /// `AnimationKeypath` is an object that describes a keypath search for nodes in the
 /// animation JSON. `AnimationKeypath` matches views and properties inside of `LottieAnimationView`
 /// to their backing `LottieAnimation` model by name.

--- a/Sources/Public/DynamicProperties/AnyValueProvider.swift
+++ b/Sources/Public/DynamicProperties/AnyValueProvider.swift
@@ -5,9 +5,6 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
-import CoreGraphics
-import Foundation
-
 // MARK: - AnyValueProvider
 
 /// `AnyValueProvider` is a protocol that return animation data for a property at a

--- a/Sources/Public/DynamicProperties/ValueProviders/ColorValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/ColorValueProvider.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - ColorValueProvider

--- a/Sources/Public/DynamicProperties/ValueProviders/FloatValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/FloatValueProvider.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - FloatValueProvider

--- a/Sources/Public/DynamicProperties/ValueProviders/GradientValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/GradientValueProvider.swift
@@ -5,7 +5,6 @@
 //  Created by Enrique Bermúdez on 10/27/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - GradientValueProvider

--- a/Sources/Public/DynamicProperties/ValueProviders/PointValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/PointValueProvider.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - PointValueProvider

--- a/Sources/Public/DynamicProperties/ValueProviders/SizeValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/SizeValueProvider.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import CoreGraphics
 import Foundation
 
 // MARK: - SizeValueProvider

--- a/Sources/Public/FontProvider/AnimationFontProvider.swift
+++ b/Sources/Public/FontProvider/AnimationFontProvider.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2020 YurtvilleProds. All rights reserved.
 //
 
-import CoreGraphics
 import CoreText
-import Foundation
 
 // MARK: - AnimationFontProvider
 

--- a/Sources/Public/ImageProvider/AnimationImageProvider.swift
+++ b/Sources/Public/ImageProvider/AnimationImageProvider.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-import CoreGraphics
-import Foundation
 import QuartzCore
 
 // MARK: - AnimationImageProvider

--- a/Sources/Public/Keyframes/Keyframe.swift
+++ b/Sources/Public/Keyframes/Keyframe.swift
@@ -1,8 +1,6 @@
 // Created by Cal Stephens on 1/24/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-import CoreFoundation
-
 // MARK: - Keyframe
 
 /// A keyframe with a single value, and timing information

--- a/Sources/Public/Primitives/AnimationTime.swift
+++ b/Sources/Public/Primitives/AnimationTime.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/6/19.
 //
 
-import CoreGraphics
 import Foundation
 
 /// Defines animation time in Frames (Seconds * Framerate).

--- a/Sources/Public/Primitives/LottieColor.swift
+++ b/Sources/Public/Primitives/LottieColor.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import Foundation
-
 // MARK: - ColorFormatDenominator
 
 public enum ColorFormatDenominator: Hashable {

--- a/Sources/Public/Primitives/Vectors.swift
+++ b/Sources/Public/Primitives/Vectors.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import Foundation
-
 // MARK: - LottieVector1D
 
 public struct LottieVector1D: Hashable, Sendable {

--- a/Sources/Public/TextProvider/AnimationTextProvider.swift
+++ b/Sources/Public/TextProvider/AnimationTextProvider.swift
@@ -5,8 +5,6 @@
 //  Created by Alexandr Goncharov on 07/06/2019.
 //
 
-import Foundation
-
 // MARK: - AnimationKeypathTextProvider
 
 /// Protocol for providing dynamic text to for a Lottie animation.

--- a/Sources/Public/iOS/AnimationSubview.swift
+++ b/Sources/Public/iOS/AnimationSubview.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import Foundation
 #if canImport(UIKit)
 import UIKit
 

--- a/Sources/Public/iOS/BundleImageProvider.swift
+++ b/Sources/Public/iOS/BundleImageProvider.swift
@@ -5,8 +5,6 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-import CoreGraphics
-import Foundation
 #if canImport(UIKit)
 import UIKit
 

--- a/Sources/Public/iOS/UIColorExtension.swift
+++ b/Sources/Public/iOS/UIColorExtension.swift
@@ -5,7 +5,6 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-import Foundation
 #if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
 import UIKit
 


### PR DESCRIPTION
This PR removes unused Swift imports, enhancing code clarity and easing maintenance. Although their direct effect on compilation time is minimal, in extensive projects with numerous dependencies, these unused imports might slightly increase overhead. The removal ensures a cleaner, more efficient codebase and clearer, more manageable dependencies. 