### PR TITLE
Fix build warnings

### DIFF
--- a/Sources/Public/Animation/LottieAnimation.swift
+++ b/Sources/Public/Animation/LottieAnimation.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
+import Foundation
+
 // MARK: - CoordinateSpace
 
 public enum CoordinateSpace: Int, Codable, Sendable {

--- a/Sources/Public/DynamicProperties/AnyValueProvider.swift
+++ b/Sources/Public/DynamicProperties/AnyValueProvider.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+import Foundation
+
 // MARK: - AnyValueProvider
 
 /// `AnyValueProvider` is a protocol that return animation data for a property at a

--- a/Sources/Public/Keyframes/Keyframe.swift
+++ b/Sources/Public/Keyframes/Keyframe.swift
@@ -1,6 +1,8 @@
 // Created by Cal Stephens on 1/24/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+import CoreFoundation
+
 // MARK: - Keyframe
 
 /// A keyframe with a single value, and timing information


### PR DESCRIPTION
Address the following build warnings that were introduced in #2253. Verified the issue is solved by running `$ bundle exec rake build:xcframework`. 

```
⚠️  /Users/calstephens/Documents/lottie/Sources/Public/Animation/LottieAnimation.swift:100:26: 'AnimationFrameTime' aliases 'CoreFoundation.CGFloat' and cannot be used here because 'CoreFoundation' was not imported by this file; this is an error in Swift 6
  public let startFrame: AnimationFrameTime
                         ^
⚠️  /Users/calstephens/Documents/lottie/Sources/Public/Animation/LottieAnimation.swift:103:24: 'AnimationFrameTime' aliases 'CoreFoundation.CGFloat' and cannot be used here because 'CoreFoundation' was not imported by this file; this is an error in Swift 6
  public let endFrame: AnimationFrameTime
                       ^
⚠️  /Users/calstephens/Documents/lottie/Sources/Public/DynamicProperties/AnyValueProvider.swift:25:25: 'AnimationFrameTime' aliases 'CoreFoundation.CGFloat' and cannot be used here because 'CoreFoundation' was not imported by this file; this is an error in Swift 6
  func hasUpdate(frame: AnimationFrameTime) -> Bool
                        ^
⚠️  /Users/calstephens/Documents/lottie/Sources/Public/DynamicProperties/AnyValueProvider.swift:31:28: 'AnimationFrameTime' aliases 'CoreFoundation.CGFloat' and cannot be used here because 'CoreFoundation' was not imported by this file; this is an error in Swift 6
  public func value(frame: AnimationFrameTime) -> Any {
                           ^
⚠️  /Users/calstephens/Documents/lottie/Sources/Public/DynamicProperties/AnyValueProvider.swift:82:17: 'AnimationFrameTime' aliases 'CoreFoundation.CGFloat' and cannot be used here because 'CoreFoundation' was not imported by this file; this is an error in Swift 6
  case closure((AnimationFrameTime) -> T)
                ^
⚠️  /Users/calstephens/Documents/lottie/Sources/Public/DynamicProperties/AnyValueProvider.swift:110:49: 'AnimationFrameTime' aliases 'CoreFoundation.CGFloat' and cannot be used here because 'CoreFoundation' was not imported by this file; this is an error in Swift 6
  case keyframes([Keyframe<Any>], interpolate: (AnimationFrameTime) -> Any)
                                                ^
⚠️  /Users/calstephens/Documents/lottie/Sources/Public/DynamicProperties/AnyValueProvider.swift:113:17: 'AnimationFrameTime' aliases 'CoreFoundation.CGFloat' and cannot be used here because 'CoreFoundation' was not imported by this file; this is an error in Swift 6
  case closure((AnimationFrameTime) -> Any)
                ^
⚠️  /Users/calstephens/Documents/lottie/Sources/Public/Keyframes/Keyframe.swift:31:11: 'AnimationFrameTime' aliases 'CoreFoundation.CGFloat' and cannot be used here because 'CoreFoundation' was not imported by this file; this is an error in Swift 6
    time: AnimationFrameTime,
          ^
⚠️  /Users/calstephens/Documents/lottie/Sources/Public/Keyframes/Keyframe.swift:52:20: 'AnimationFrameTime' aliases 'CoreFoundation.CGFloat' and cannot be used here because 'CoreFoundation' was not imported by this file; this is an error in Swift 6
```

cc: @calda 

