### PR TITLE
Continue XCFramework job if certificate install step fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: apple-actions/import-codesign-certs@v2
+        continue-on-error: true
         with:
           p12-file-base64: ${{ secrets.SIGNING_CERTIFICATE_BASE_64 }}
           p12-password: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
This PR updates the job that builds `Lottie.xcframework` to continue if the certificate install step fails. Should fix CI for https://github.com/airbnb/lottie-ios/pull/2263.