### PR TITLE
[lottie/objectiveC] Add support for visionOS

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -1823,6 +1823,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos xrsimulator xros";
 				WARNING_CFLAGS = "";
 			};
 			name = Debug;
@@ -1844,6 +1845,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.airbnb.Lottie;
 				PRODUCT_NAME = Lottie;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos xrsimulator xros";
 				WARNING_CFLAGS = "";
 			};
 			name = Release;
@@ -1877,6 +1879,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = Lottie;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos xrsimulator xros";
 			};
 			name = Debug;
 		};
@@ -1887,6 +1890,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = Lottie;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos xrsimulator xros";
 			};
 			name = Release;
 		};

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -691,7 +691,11 @@ static NSString * const kCompContainerAnimationKey = @"play";
 }
 
 - (void)didMoveToWindow {
+#if TARGET_OS_IOS
     _compContainer.rasterizationScale = self.window.screen.scale;
+#elif TARGET_OS_VISION
+    _compContainer.rasterizationScale = 2;
+#endif
 }
 
 - (void)setContentMode:(LOTViewContentMode)contentMode {

--- a/lottie-ios/Classes/Private/LOTAnimationView.m
+++ b/lottie-ios/Classes/Private/LOTAnimationView.m
@@ -691,10 +691,10 @@ static NSString * const kCompContainerAnimationKey = @"play";
 }
 
 - (void)didMoveToWindow {
-#if TARGET_OS_IOS
-    _compContainer.rasterizationScale = self.window.screen.scale;
-#elif TARGET_OS_VISION
+#if TARGET_OS_VISION
     _compContainer.rasterizationScale = 2;
+#else
+    _compContainer.rasterizationScale = self.window.screen.scale;
 #endif
 }
 


### PR DESCRIPTION
Added support for visionOS. 

Currently all of the iOS code builds for visionOS except `_compContainer.rasterizationScale = self.window.screen.scale;`, which uses `UIScreen` (unavailable on visionOS). If-def it and use a default value of 2.