### PR TITLE
Fix: added visionOS and simplified conditional

### DIFF
--- a/Sources/Public/iOS/UIColorExtension.swift
+++ b/Sources/Public/iOS/UIColorExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-#if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
+#if canImport(UIKit)
 import UIKit
 
 extension UIColor {


### PR DESCRIPTION
This PR fixes #2279 by indirectly including `visionOS` into the extension's conditional.