### PR TITLE
Use resource_bundles instead of resource in podspec for privacy manifest

### DIFF
--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -29,7 +29,9 @@ Lottie enables designers to create and ship beautiful animations without an engi
 
   s.source_files = 'Sources/**/*'
   s.exclude_files = 'Sources/**/*.md'
-  s.resource = 'Sources/PrivacyInfo.xcprivacy'
+  s.resource_bundles = {
+    'Lottie_Privacy' => ['Sources/PrivacyInfo.xcprivacy'],
+  }
   s.ios.exclude_files = 'Sources/Public/MacOS/**/*'
   s.tvos.exclude_files = 'Sources/Public/MacOS/**/*'
   s.osx.exclude_files = 'Sources/Public/iOS/**/*'


### PR DESCRIPTION
In #2252 the privacy manifest was added. For cocoapods it is being added using `resource`, which can end up with duplicate files if other library linked on the application provides a file with the same name and you are linking them statically.

By using resource_bundles, we can ensure that there will not be overlaps.

More details in this comment in a Google repository on this same topic:
https://github.com/google/promises/pull/226#discussion_r1447871477