### PR TITLE
fix: add visionOS support in the Lottie podspec

### DIFF
--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -26,6 +26,7 @@ Lottie enables designers to create and ship beautiful animations without an engi
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '11.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source_files = 'Sources/**/*'
   s.exclude_files = 'Sources/**/*.md'


### PR DESCRIPTION
Was updating to 4.4.0 and i noticed that even though the Package.swift declares vision os support, the podspec doesn't. Not sure if i am missing something or not, but i figured a PR wouldn't hurt