### PR TITLE
Replace os check with canImport so classes are available on visionOS

### DIFF
--- a/Sources/Private/Model/DotLottie/DotLottieImageProvider.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieImageProvider.swift
@@ -55,14 +55,14 @@ class DotLottieImageProvider: AnimationImageProvider {
 
   private func loadImages() {
     for url in filepath.urls {
-      #if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
+      #if canImport(UIKit)
       if
         let data = try? Data(contentsOf: url),
         let image = UIImage(data: data)?.cgImage
       {
         images[url.lastPathComponent] = image
       }
-      #elseif os(macOS)
+      #elseif canImport(AppKit)
       if
         let data = try? Data(contentsOf: url),
         let image = NSImage(data: data)?.lottie_CGImage

--- a/Sources/Private/Model/Extensions/Bundle.swift
+++ b/Sources/Private/Model/Extensions/Bundle.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
+#if canImport(UIKit)
 import UIKit
 #endif
 

--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationKeypath.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationKeypath.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-#if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
+#if canImport(UIKit)
 
 /// An Objective-C compatible wrapper around Lottie's AnimationKeypath
 @objc

--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-#if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
+#if canImport(UIKit)
 import UIKit
 
 /// An Objective-C compatible wrapper around Lottie's Animation class.


### PR DESCRIPTION
CompatibleAnimationKeypath and CompatibleAnimationView weren't being included in the visionOS variant.