### PR TITLE
Simple: Change accesscontrol to methods that are not used in other files to private.

### DIFF
--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1007,7 +1007,6 @@ public class LottieAnimationLayer: CALayer {
       }
     }
   }
-  
   public func updateAnimationForForegroundState(wasWaitingToPlayAnimation: Bool) {
     if let currentContext = animationContext {
       if wasWaitingToPlayAnimation {
@@ -1467,7 +1466,6 @@ public class LottieAnimationLayer: CALayer {
       return animation?.reducedMotionMarker
     }
   }
-  
   private func loadAnimation(_ dotLottieAnimation: DotLottieFile.Animation) {
     loopMode = dotLottieAnimation.configuration.loopMode
     animationSpeed = CGFloat(dotLottieAnimation.configuration.speed)

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1089,7 +1089,7 @@ public class LottieAnimationLayer: CALayer {
 
     addNewAnimationForContext(newContext)
   }
-  
+
   func updateRasterizationState() {
     if isAnimationPlaying {
       animationLayer?.shouldRasterize = false

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1041,14 +1041,6 @@ public class LottieAnimationLayer: CALayer {
     }
   }
 
-  func updateRasterizationState() {
-    if isAnimationPlaying {
-      animationLayer?.shouldRasterize = false
-    } else {
-      animationLayer?.shouldRasterize = shouldRasterizeWhenIdle
-    }
-  }
-
   /// Updates the animation frame. Does not affect any current animations
   func updateAnimationFrame(_ newFrame: CGFloat) {
     // In performance tests, we have to wrap the animation layer setup
@@ -1468,6 +1460,14 @@ public class LottieAnimationLayer: CALayer {
     }
   }
 
+  private func updateRasterizationState() {
+    if isAnimationPlaying {
+      animationLayer?.shouldRasterize = false
+    } else {
+      animationLayer?.shouldRasterize = shouldRasterizeWhenIdle
+    }
+  }
+  
   private func loadAnimation(_ dotLottieAnimation: DotLottieFile.Animation) {
     loopMode = dotLottieAnimation.configuration.loopMode
     animationSpeed = CGFloat(dotLottieAnimation.configuration.speed)

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1467,6 +1467,7 @@ public class LottieAnimationLayer: CALayer {
       return animation?.reducedMotionMarker
     }
   }
+
   private func loadAnimation(_ dotLottieAnimation: DotLottieFile.Animation) {
     loopMode = dotLottieAnimation.configuration.loopMode
     animationSpeed = CGFloat(dotLottieAnimation.configuration.speed)

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1007,6 +1007,7 @@ public class LottieAnimationLayer: CALayer {
       }
     }
   }
+
   public func updateAnimationForForegroundState(wasWaitingToPlayAnimation: Bool) {
     if let currentContext = animationContext {
       if wasWaitingToPlayAnimation {

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1007,14 +1007,6 @@ public class LottieAnimationLayer: CALayer {
       }
     }
   }
-
-  public func updateRasterizationState() {
-    if isAnimationPlaying {
-      animationLayer?.shouldRasterize = false
-    } else {
-      animationLayer?.shouldRasterize = shouldRasterizeWhenIdle
-    }
-  }
   
   public func updateAnimationForForegroundState(wasWaitingToPlayAnimation: Bool) {
     if let currentContext = animationContext {
@@ -1096,6 +1088,14 @@ public class LottieAnimationLayer: CALayer {
     rootAnimationLayer?.currentFrame = pauseFrame
 
     addNewAnimationForContext(newContext)
+  }
+  
+  func updateRasterizationState() {
+    if isAnimationPlaying {
+      animationLayer?.shouldRasterize = false
+    } else {
+      animationLayer?.shouldRasterize = shouldRasterizeWhenIdle
+    }
   }
 
   func loadAnimation(_ animationSource: LottieAnimationSource?) {

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1008,6 +1008,14 @@ public class LottieAnimationLayer: CALayer {
     }
   }
 
+  public func updateRasterizationState() {
+    if isAnimationPlaying {
+      animationLayer?.shouldRasterize = false
+    } else {
+      animationLayer?.shouldRasterize = shouldRasterizeWhenIdle
+    }
+  }
+  
   public func updateAnimationForForegroundState(wasWaitingToPlayAnimation: Bool) {
     if let currentContext = animationContext {
       if wasWaitingToPlayAnimation {
@@ -1457,14 +1465,6 @@ public class LottieAnimationLayer: CALayer {
       return nil
     case .reducedMotion:
       return animation?.reducedMotionMarker
-    }
-  }
-
-  private func updateRasterizationState() {
-    if isAnimationPlaying {
-      animationLayer?.shouldRasterize = false
-    } else {
-      animationLayer?.shouldRasterize = shouldRasterizeWhenIdle
     }
   }
   

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -995,11 +995,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   func updateRasterizationState() {
-    if lottieAnimationLayer.isAnimationPlaying {
-      lottieAnimationLayer.animationLayer?.shouldRasterize = false
-    } else {
-      lottieAnimationLayer.animationLayer?.shouldRasterize = lottieAnimationLayer.shouldRasterizeWhenIdle
-    }
+    lottieAnimationLayer.updateRasterizationState()
   }
 
   /// Updates the animation frame. Does not affect any current animations


### PR DESCRIPTION
Currently, the updateRasterizationState method is not being used in other files, but the accesscontrol is set to internal. So I changed it to private.

If you need to use it in another file in the future, it would be a good idea to change it to internal.