### PR TITLE
Update CI jobs to run on Apple Silicon macOS 14 runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-package-no-visionOS:
     name: "Build Package"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +27,7 @@ jobs:
 
   build-package:
     name: "Build Package"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
@@ -44,7 +44,7 @@ jobs:
 
   build-example:
     name: "Build Example App"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -55,7 +55,7 @@ jobs:
 
   test-package:
     name: "Test Package"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -75,7 +75,7 @@ jobs:
 
   emerge-upload:
     name: "Emerge Upload"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -87,7 +87,7 @@ jobs:
 
   build-xcframework-minimum-supported-version:
     name: "Build XCFramework"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         xcode:
@@ -121,7 +121,7 @@ jobs:
 
   build-xcframework-with-visionOS-support:
     name: "Build XCFramework"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         xcode:
@@ -146,7 +146,7 @@ jobs:
 
   cocoapod:
     name: "Lint CocoaPods podspec"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -157,7 +157,7 @@ jobs:
 
   spm-xcode-15:
     name: "Test Swift Package Manager"
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         xcode:
@@ -173,7 +173,7 @@ jobs:
 
   carthage:
     name: "Test Carthage support"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -186,7 +186,7 @@ jobs:
 
   swiftlint:
     name: "Lint Swift"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -195,7 +195,7 @@ jobs:
 
   embedded-libraries:
     name: "Lint Embedded Libraries"
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-package-no-visionOS:
     name: "Build Package"
-    runs-on: macos-14
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
@@ -87,7 +87,7 @@ jobs:
 
   build-xcframework-minimum-supported-version:
     name: "Build XCFramework"
-    runs-on: macos-14
+    runs-on: macos-13
     strategy:
       matrix:
         xcode:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org' do
-  gem 'cocoapods', '~> 1.11.0'
+  gem 'cocoapods', '~> 1.15.0'
   gem "rake", "~> 13.0.0"
   gem 'git', '~> 1.18'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,9 +4,9 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.6)
       rexml
-    activesupport (6.1.4.1)
+    activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -18,16 +18,16 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
-    claide (1.0.3)
-    cocoapods (1.11.2)
+    claide (1.1.0)
+    cocoapods (1.15.0)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.11.2)
+      cocoapods-core (= 1.15.0)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.4.0, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.4.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
@@ -35,10 +35,10 @@ GEM
       gh_inspector (~> 1.0)
       molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (>= 1.0, < 3.0)
-      xcodeproj (>= 1.21.0, < 2.0)
-    cocoapods-core (1.11.2)
-      activesupport (>= 5.0, < 7)
+      ruby-macho (>= 2.3.0, < 3.0)
+      xcodeproj (>= 1.23.0, < 2.0)
+    cocoapods-core (1.15.0)
+      activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
@@ -48,7 +48,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.6.3)
+    cocoapods-downloader (2.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -57,11 +57,11 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.3)
     escape (0.0.4)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.15.4)
+    ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -69,10 +69,10 @@ GEM
       addressable (~> 2.8)
       rchardet (~> 1.8)
     httpclient (2.8.3)
-    i18n (1.8.11)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json (2.6.1)
-    minitest (5.14.4)
+    json (2.7.1)
+    minitest (5.21.2)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)
@@ -80,28 +80,28 @@ GEM
     public_suffix (4.0.6)
     rake (13.0.6)
     rchardet (1.8.0)
-    rexml (3.2.5)
+    rexml (3.2.6)
     ruby-macho (2.5.1)
-    typhoeus (1.4.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.21.0)
+    xcodeproj (1.24.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    zeitwerk (2.5.1)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.11.0)!
+  cocoapods (~> 1.15.0)!
   git (~> 1.18)!
   rake (~> 13.0.0)!
 
 BUNDLED WITH
-   2.2.16
+   2.3.19

--- a/Rakefile
+++ b/Rakefile
@@ -262,10 +262,5 @@ def ifVisionOSEnabled
 end
 
 def installVisionOSIfNecessary
-  # visionOS is unsupported by default on Intel, but we can override this
-  # https://github.com/actions/runner-images/issues/8144#issuecomment-1902072070
-  sh 'defaults write com.apple.dt.Xcode AllowUnsupportedVisionOSHost -bool YES'
-  sh 'defaults write com.apple.CoreSimulator AllowUnsupportedVisionOSHost -bool YES'
-
   xcodebuild("-downloadPlatform visionOS")
 end


### PR DESCRIPTION
GitHub released a new macOS 14 runner that uses Apple Silicon: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

This PR adopts the new macOS 14 runner. Since we now run our CI jobs on Apple Silicon, we no longer need the workaround for using the visionOS SDK on Intel.

The Apple Silicon runner is also WAY FASTER than the previous Intel runner. Now our tests complete in about 7 minutes, compared to 22 minutes on the Intel runner.