### PR TITLE
Omit privacy manifest from source files in podspec

### DIFF
--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -27,7 +27,7 @@ Lottie enables designers to create and ship beautiful animations without an engi
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '11.0'
 
-  s.source_files = 'Sources/**/*'
+  s.source_files = 'Sources/**/*.swift'
   s.exclude_files = 'Sources/**/*.md'
   s.resource_bundles = {
     'Lottie_Privacy' => ['Sources/PrivacyInfo.xcprivacy'],

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -28,7 +28,6 @@ Lottie enables designers to create and ship beautiful animations without an engi
   s.tvos.deployment_target = '11.0'
 
   s.source_files = 'Sources/**/*.swift'
-  s.exclude_files = 'Sources/**/*.md'
   s.resource_bundles = {
     'Lottie_Privacy' => ['Sources/PrivacyInfo.xcprivacy'],
   }


### PR DESCRIPTION
Raised in [this issue](https://github.com/airbnb/lottie-ios/issues/2297), the privacy manifest was being added to the source files due to the wildcard in the podspec which resulted in this warning:

<img width="1187" alt="image" src="https://github.com/airbnb/lottie-ios/assets/47733004/a9bc5c30-8c7a-4a58-8c41-5da74f614f00">

I've just updated the `s.source_files` to only include swift files.