### PR TITLE
Fix warning from invalid character in Cocoapods resource bundle identifier

### DIFF
--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -30,7 +30,7 @@ Lottie enables designers to create and ship beautiful animations without an engi
   s.source_files = 'Sources/**/*'
   s.exclude_files = 'Sources/**/*.md'
   s.resource_bundles = {
-    'Lottie_Privacy' => ['Sources/PrivacyInfo.xcprivacy'],
+    'LottiePrivacyInfo' => ['Sources/PrivacyInfo.xcprivacy'],
   }
   s.ios.exclude_files = 'Sources/Public/MacOS/**/*'
   s.tvos.exclude_files = 'Sources/Public/MacOS/**/*'


### PR DESCRIPTION
Apparently underscores aren't supported for these resource bundle identifiers, so we get a warning in Xcode. This change should fix https://github.com/airbnb/lottie-ios/issues/2309.