### PR TITLE
Update minimum deployment target to iOS 13.0 / macOS 10.15

### DIFF
--- a/Lottie.xcodeproj/project.pbxproj
+++ b/Lottie.xcodeproj/project.pbxproj
@@ -4087,7 +4087,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4120,7 +4120,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4197,7 +4197,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
@@ -4231,7 +4231,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
@@ -4274,7 +4274,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Debug;
 		};
@@ -4308,7 +4308,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Release;
 		};

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
   name: "Lottie",
   // Minimum platform versions should be kept in sync with the per-platform targets in Lottie.xcodeproj, lottie-ios.podspec, and lottie-spm's Package.swift
-  platforms: [.iOS("11.0"), .macOS("10.11"), .tvOS("11.0"), .custom("visionOS", versionString: "1.0")],
+  platforms: [.iOS("13.0"), .macOS("10.15"), .tvOS("13.0"), .custom("visionOS", versionString: "1.0")],
   products: [.library(name: "Lottie", targets: ["Lottie"])],
   dependencies: [
     .package(url: "https://github.com/airbnb/swift", .upToNextMajor(from: "1.0.1")),

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/README.md
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/README.md
@@ -23,9 +23,6 @@ When doing this, follow these steps:
  3. Change all of the `public` symbols defined in this module to instead be `internal`
     to prevent Lottie from exposing any EpoxyCore APIs.
     
- 4. Add `@available` annotations as necessary so the library compiles
-    (Lottie has a lower minimum iOS version than EpoxyCore). 
-    
- 5. Namespace any types that conflict with other existing types.
+ 4. Namespace any types that conflict with other existing types.
     For example, the EpoxyCore `Entry` type conflicts with the ZipFoundation `Entry` type,
     so the EpoxyCore type has been renamed to `EpoxyEntry`.

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIHostingController.swift
@@ -13,7 +13,6 @@ import SwiftUI
 /// collection view cells out of automated view controller impression tracking.
 ///
 /// - SeeAlso: `EpoxySwiftUIHostingView`
-@available(iOS 13.0, tvOS 13.0, *)
 open class EpoxySwiftUIHostingController<Content: View>: UIHostingController<Content> {
 
   // MARK: Lifecycle

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIHostingView.swift
@@ -21,7 +21,6 @@ enum SwiftUIHostingViewReuseBehavior: Hashable {
 
 // MARK: - CallbackContextEpoxyModeled
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension CallbackContextEpoxyModeled
   where
   Self: WillDisplayProviding & DidEndDisplayingProviding,
@@ -57,7 +56,6 @@ extension CallbackContextEpoxyModeled
 /// the API is private and 3) the `_UIHostingView` doesn't not accept setting a new `View` instance.
 ///
 /// - SeeAlso: `EpoxySwiftUIHostingController`
-@available(iOS 13.0, tvOS 13.0, *)
 final class EpoxySwiftUIHostingView<RootView: View>: UIView, EpoxyableView {
 
   // MARK: Lifecycle
@@ -347,7 +345,6 @@ extension UIResponder {
 
 /// The object that is used to communicate changes in the root view to the
 /// `EpoxySwiftUIHostingController`.
-@available(iOS 13.0, tvOS 13.0, *)
 final class EpoxyHostingContent<RootView: View>: ObservableObject {
 
   // MARK: Lifecycle
@@ -365,7 +362,6 @@ final class EpoxyHostingContent<RootView: View>: ObservableObject {
 
 /// The object that is used to communicate values to SwiftUI views within an
 /// `EpoxySwiftUIHostingController`, e.g. layout margins.
-@available(iOS 13.0, tvOS 13.0, *)
 final class EpoxyHostingEnvironment: ObservableObject {
   @Published var layoutMargins = EdgeInsets()
   @Published var intrinsicContentSizeInvalidator = EpoxyIntrinsicContentSizeInvalidator(invalidate: { })
@@ -375,7 +371,6 @@ final class EpoxyHostingEnvironment: ObservableObject {
 
 /// The wrapper view that is used to communicate values to SwiftUI views within an
 /// `EpoxySwiftUIHostingController`, e.g. layout margins.
-@available(iOS 13.0, tvOS 13.0, *)
 struct EpoxyHostingWrapper<Content: View>: View {
   @ObservedObject var content: EpoxyHostingContent<Content>
   @ObservedObject var environment: EpoxyHostingEnvironment

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIIntrinsicContentSizeInvalidator.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUIIntrinsicContentSizeInvalidator.swift
@@ -29,7 +29,6 @@ struct EpoxyIntrinsicContentSizeInvalidator {
 
 // MARK: - EnvironmentValues
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension EnvironmentValues {
   /// A means of invalidating the intrinsic content size of the parent `EpoxySwiftUIHostingView`.
   var epoxyIntrinsicContentSizeInvalidator: EpoxyIntrinsicContentSizeInvalidator {

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUILayoutMargins.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxySwiftUILayoutMargins.swift
@@ -6,7 +6,6 @@ import SwiftUI
 
 // MARK: - View
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension View {
   /// Applies the layout margins from the parent `EpoxySwiftUIHostingView` to this `View`, if there
   /// are any.
@@ -22,7 +21,6 @@ extension View {
 
 // MARK: - EnvironmentValues
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension EnvironmentValues {
   /// The layout margins of the parent `EpoxySwiftUIHostingView`, else zero if there is none.
   var epoxyLayoutMargins: EdgeInsets {
@@ -33,7 +31,6 @@ extension EnvironmentValues {
 
 // MARK: - EpoxyLayoutMarginsKey
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 private struct EpoxyLayoutMarginsKey: EnvironmentKey {
   static let defaultValue = EdgeInsets()
 }
@@ -42,7 +39,6 @@ private struct EpoxyLayoutMarginsKey: EnvironmentKey {
 
 /// A view modifier that applies the layout margins from an enclosing `EpoxySwiftUIHostingView` to
 /// the modified `View`.
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 private struct EpoxyLayoutMarginsPadding: ViewModifier {
   @Environment(\.epoxyLayoutMargins) var epoxyLayoutMargins
 

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 
 // MARK: - StyledView
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurableView {
   /// Returns a SwiftUI `View` representing this `EpoxyableView`.
   ///
@@ -52,7 +51,6 @@ extension StyledView where Self: ContentConfigurableView & BehaviorsConfigurable
   }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension StyledView
   where
   Self: ContentConfigurableView & BehaviorsConfigurableView,
@@ -96,7 +94,6 @@ extension StyledView
   }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension StyledView
   where
   Self: ContentConfigurableView & BehaviorsConfigurableView,
@@ -138,7 +135,6 @@ extension StyledView
   }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension StyledView
   where
   Self: ContentConfigurableView & BehaviorsConfigurableView,

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringViewRepresentable.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringViewRepresentable.swift
@@ -13,7 +13,6 @@ import SwiftUI
 /// `sizeThatFits(…)` method.
 ///
 /// - SeeAlso: ``SwiftUIMeasurementContainer``
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 protocol MeasuringViewRepresentable: ViewRepresentableType
   where
   RepresentableViewType == SwiftUIMeasurementContainer<Content>
@@ -32,7 +31,6 @@ protocol MeasuringViewRepresentable: ViewRepresentableType
 
 // MARK: Extensions
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension MeasuringViewRepresentable {
   /// Returns a copy of this view with its sizing strategy updated to the given `sizing` value.
   func sizing(_ strategy: SwiftUIMeasurementContainerStrategy) -> Self {
@@ -45,7 +43,6 @@ extension MeasuringViewRepresentable {
 // MARK: Defaults
 
 #if os(iOS) || os(tvOS)
-@available(iOS 13.0, tvOS 13.0, *)
 extension MeasuringViewRepresentable {
   func _overrideSizeThatFits(
     _ size: inout CGSize,
@@ -87,7 +84,6 @@ extension MeasuringViewRepresentable {
 }
 
 #elseif os(macOS)
-@available(macOS 10.15, *)
 extension MeasuringViewRepresentable {
   func _overrideSizeThatFits(
     _ size: inout CGSize,

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -13,7 +13,6 @@ import SwiftUI
 /// height through the `SwiftUISizingContext` binding.
 ///
 /// - SeeAlso: ``MeasuringViewRepresentable``
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 final class SwiftUIMeasurementContainer<Content: ViewType>: ViewType {
 
   // MARK: Lifecycle

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/SwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/SwiftUIView.swift
@@ -12,7 +12,6 @@ import SwiftUI
 ///
 /// Includes an optional generic `Storage` value, which can be used to compare old and new values
 /// across state changes to prevent redundant view updates.
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 struct SwiftUIView<Content: ViewType, Storage>: MeasuringViewRepresentable,
   UIViewConfiguringSwiftUIView
 {
@@ -51,7 +50,6 @@ struct SwiftUIView<Content: ViewType, Storage>: MeasuringViewRepresentable,
 
 // MARK: UIViewRepresentable
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension SwiftUIView {
   func makeCoordinator() -> Coordinator {
     Coordinator(storage: storage)
@@ -98,7 +96,6 @@ extension SwiftUIView {
 
 // MARK: SwiftUIView.ConfigurationContext
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension SwiftUIView {
   /// The configuration context that's available to configure the `Content` view whenever the
   /// `updateUIView()` method is invoked via a configuration closure.
@@ -130,7 +127,6 @@ extension SwiftUIView {
 
 // MARK: SwiftUIView.Coordinator
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension SwiftUIView {
   /// A coordinator that stores the `storage` associated with this view, enabling the old storage
   /// value to be accessed during the `updateUIView(…)`.

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 
 // MARK: - ViewTypeProtocol + swiftUIView
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension ViewTypeProtocol {
   /// Returns a SwiftUI `View` representing this `UIView`, constructed with the given `makeView`
   /// closure and sized with the given sizing configuration.

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
@@ -8,7 +8,6 @@ import SwiftUI
 
 /// A protocol describing a SwiftUI `View` that can configure its `UIView` content via an array of
 /// `configuration` closures.
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 protocol UIViewConfiguringSwiftUIView: View {
   /// The context available to this configuration, which provides the `UIView` instance at a minimum
   /// but can include additional context as needed.
@@ -24,7 +23,6 @@ protocol UIViewConfiguringSwiftUIView: View {
 
 // MARK: Extensions
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension UIViewConfiguringSwiftUIView {
   /// Returns a copy of this view updated to have the given closure applied to its represented view
   /// whenever it is updated via the `updateUIView(…)` method.

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ViewType.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ViewType.swift
@@ -12,14 +12,12 @@ typealias ViewType = UIView
 
 /// The platform's SwiftUI view representable type.
 /// Either `UIViewRepresentable` on iOS/tvOS or `NSViewRepresentable` on macOS.
-@available(iOS 13.0, tvOS 13.0, *)
 typealias ViewRepresentableType = UIViewRepresentable
 
 /// The platform's layout constraint priority type.
 /// Either `UILayoutPriority` on iOS/tvOS or `NSLayoutConstraint.Priority` on macOS.
 typealias LayoutPriorityType = UILayoutPriority
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ViewRepresentableType {
   /// The platform's view type for `ViewRepresentableType`.
   /// Either `UIViewType` on iOS/tvOS or `NSViewType` on macOS.
@@ -35,14 +33,12 @@ typealias ViewType = NSView
 
 /// The platform's SwiftUI view representable type.
 /// Either `UIViewRepresentable` on iOS/tvOS, or `NSViewRepresentable` on macOS.
-@available(macOS 10.15, *)
 typealias ViewRepresentableType = NSViewRepresentable
 
 /// The platform's layout constraint priority type.
 /// Either `UILayoutPriority` on iOS/tvOS, or `NSLayoutConstraint.Priority` on macOS.
 typealias LayoutPriorityType = NSLayoutConstraint.Priority
 
-@available(macOS 10.15, *)
 extension ViewRepresentableType {
   /// The platform's view type for `ViewRepresentableType`.
   /// Either `UIViewType` on iOS/tvOS or `NSViewType` on macOS.

--- a/Sources/Private/MainThread/LayerContainers/Utility/CoreTextRenderLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CoreTextRenderLayer.swift
@@ -184,7 +184,6 @@ final class CoreTextRenderLayer: CALayer {
   private var needsContentUpdate = false
 
   // Draws Debug colors for the font alignment.
-  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   private func drawDebug(_ ctx: CGContext) {
     if let font {
       let ascent = CTFontGetAscent(font)

--- a/Sources/Private/Model/DotLottie/DotLottieUtils.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieUtils.swift
@@ -15,10 +15,7 @@ enum DotLottieUtils {
 
   /// Temp folder to app directory
   static var tempDirectoryURL: URL {
-    if #available(iOS 10.0, macOS 10.12, *) {
-      return FileManager.default.temporaryDirectory
-    }
-    return URL(fileURLWithPath: NSTemporaryDirectory())
+    FileManager.default.temporaryDirectory
   }
 }
 
@@ -56,7 +53,8 @@ public enum DotLottieError: Error {
   case noDataLoaded
   /// Asset with this name was not found in the provided bundle.
   case assetNotFound(name: String, bundle: Bundle?)
-  /// Animation loading from asset is not supported on macOS 10.10.
+  /// Animation loading from asset was not supported on macOS 10.10,
+  /// but this error is no longer used.
   case loadingFromAssetNotSupported
 
   @available(*, deprecated, message: "Unused")

--- a/Sources/Private/Utility/Extensions/DataExtension.swift
+++ b/Sources/Private/Utility/Extensions/DataExtension.swift
@@ -22,15 +22,12 @@ extension Data {
       throw DotLottieError.assetNotFound(name: assetName, bundle: bundle)
     }
     #else
-    if #available(macOS 10.11, *) {
-      if let asset = NSDataAsset(name: assetName, bundle: bundle) {
-        self = asset.data
-        return
-      } else {
-        throw DotLottieError.assetNotFound(name: assetName, bundle: bundle)
-      }
+    if let asset = NSDataAsset(name: assetName, bundle: bundle) {
+      self = asset.data
+      return
+    } else {
+      throw DotLottieError.assetNotFound(name: assetName, bundle: bundle)
     }
-    throw DotLottieError.loadingFromAssetNotSupported
     #endif
   }
 }

--- a/Sources/Private/Utility/Helpers/Binding+Map.swift
+++ b/Sources/Private/Utility/Helpers/Binding+Map.swift
@@ -4,7 +4,6 @@
 #if canImport(SwiftUI)
 import SwiftUI
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension Binding {
 
   /// Helper to transform a `Binding` from one `Value` type to another.

--- a/Sources/Private/Utility/Helpers/View+ValueChanged.swift
+++ b/Sources/Private/Utility/Helpers/View+ValueChanged.swift
@@ -5,7 +5,6 @@
 import Combine
 import SwiftUI
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension View {
   /// A backwards compatible wrapper for iOS 14 `onChange`
   @ViewBuilder

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -171,7 +171,6 @@ extension LottieAnimation {
   /// - Parameter url: The url to load the animation from.
   /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LottieAnimationCache.shared`. Optional.
   ///
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   public static func loadedFrom(
     url: URL,
     session: URLSession = .shared,

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -7,7 +7,6 @@ import SwiftUI
 // MARK: - LottieView
 
 /// A wrapper which exposes Lottie's `LottieAnimationView` to SwiftUI
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
 
   // MARK: Lifecycle
@@ -564,7 +563,6 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   }
 }
 
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 extension View {
 
   /// The `.overlay` modifier that uses a `ViewBuilder` is available in iOS 15+, this helper function helps us to use the same API in older OSs

--- a/Sources/Public/Controls/LottieButton.swift
+++ b/Sources/Public/Controls/LottieButton.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 
 /// A wrapper which exposes Lottie's `AnimatedButton` to SwiftUI
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 public struct LottieButton: UIViewConfiguringSwiftUIView {
 
   // MARK: Lifecycle

--- a/Sources/Public/Controls/LottieSwitch.swift
+++ b/Sources/Public/Controls/LottieSwitch.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 
 /// A wrapper which exposes Lottie's `AnimatedSwitch` to SwiftUI
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, *)
 public struct LottieSwitch: UIViewConfiguringSwiftUIView {
 
   // MARK: Lifecycle

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -118,7 +118,6 @@ extension DotLottieFile {
   /// - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
   /// - Parameter subdirectory: A subdirectory in the bundle in which the lottie is located. Optional.
   /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   public static func named(
     _ name: String,
     bundle: Bundle = Bundle.main,
@@ -165,7 +164,6 @@ extension DotLottieFile {
   /// Loads an DotLottie from a specific filepath.
   /// - Parameter filepath: The absolute filepath of the lottie to load. EG "/User/Me/starAnimation.lottie"
   /// - Parameter dotLottieCache: A cache for holding loaded lotties. Defaults to `LRUDotLottieCache.sharedCache`. Optional.
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   public static func loadedFrom(
     filepath: String,
     dotLottieCache: DotLottieCacheProvider? = DotLottieCache.sharedCache)
@@ -204,7 +202,6 @@ extension DotLottieFile {
   /// - Parameter name: The name of the lottie file in the asset catalog. EG "StarAnimation"
   /// - Parameter bundle: The bundle in which the lottie is located. Defaults to `Bundle.main`
   /// - Parameter dotLottieCache: A cache for holding loaded lottie files. Defaults to `LRUDotLottieCache.sharedCache` Optional.
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   public static func asset(
     named name: String,
     bundle: Bundle = Bundle.main,
@@ -270,7 +267,6 @@ extension DotLottieFile {
   ///
   /// - Parameter url: The url to load the animation from.
   /// - Parameter animationCache: A cache for holding loaded animations. Defaults to `LRUAnimationCache.sharedCache`. Optional.
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   public static func loadedFrom(
     url: URL,
     session: URLSession = .shared,
@@ -354,7 +350,6 @@ extension DotLottieFile {
   ///   - data: The data(`Foundation.Data`) object to load DotLottie from
   ///   - filename: The name of the lottie file without the lottie extension. eg. "StarAnimation"
   ///   - dispatchQueue: A dispatch queue used to load animations. Defaults to `DispatchQueue.global()`. Optional.
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   public static func loadedFrom(
     data: Data,
     filename: String,

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -39,11 +39,7 @@ open class LottieAnimationViewBase: UIView {
 
   var screenScale: CGFloat {
     #if os(iOS) || os(tvOS)
-    if #available(iOS 13.0, tvOS 13.0, *) {
-      return max(UITraitCollection.current.displayScale, 1)
-    } else {
-      return UIScreen.main.scale
-    }
+    max(UITraitCollection.current.displayScale, 1)
     #else // if os(visionOS)
     // We intentionally don't check `#if os(visionOS)`, because that emits
     // a warning when building on Xcode 14 and earlier.

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -23,9 +23,9 @@ Lottie enables designers to create and ship beautiful animations without an engi
   s.source           = { :git => 'https://github.com/airbnb/lottie-ios.git', :tag => s.version.to_s }
 
   s.swift_version = '5.7'
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.12'
-  s.tvos.deployment_target = '11.0'
+  s.ios.deployment_target = '13.0'
+  s.osx.deployment_target = '10.15'
+  s.tvos.deployment_target = '13.0'
 
   s.source_files = 'Sources/**/*.swift'
   s.resource_bundles = {


### PR DESCRIPTION
This PR updates Lottie's minimum deployment target to iOS 13.0 / macOS 10.15.

Our current deployment target is iOS 11.0. Xcode emits this warning when we build the project:

>  The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 17.2.99.

It seems like a good idea to fix that by at least updating to iOS 12.0+.

iOS 13 seems like a good minimum for us because:
 - it's five years old and has high adoption according to https://iosref.com/ios-usage
 - it's the minimum version for many important APIs we use so simplifies the codebase
   - iOS 13 is the minimum version requirement for SwiftUI and Swift `async` / `await`, which we use heavily, and currently results in a lot of `@available` annotations

I'll release a new version with all of the existing changes on master before merging this change. 

Any consumer with a deployment target lower than iOS 13.0 will still be able to use Lottie 4.4.1 and earlier.