### PR TITLE
Add JSON load error callback to ObjC Lottie URL initializer

### DIFF
--- a/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
+++ b/lottie-ios/Classes/PublicHeaders/LOTAnimationView.h
@@ -13,6 +13,7 @@
 #import "LOTValueDelegate.h"
 
 typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
+typedef void (^LOTInitializationErrorBlock)(NSError *error);
 
 @interface LOTAnimationView : LOTView
 
@@ -36,6 +37,11 @@ typedef void (^LOTAnimationCompletionBlock)(BOOL animationFinished);
 
 /// Loads animation asynchronously from the specified URL
 - (nonnull instancetype)initWithContentsOfURL:(nonnull NSURL *)url;
+
+/// Loads animation asynchronously from the specified URL. Calls the specified errorBlock if the
+/// animation cannot be initialized from the contents of the URL.
+- (nonnull instancetype)initWithContentsOfURL:(NSURL *)url
+                                   errorBlock:(nullable LOTInitializationErrorBlock)errorBlock;
 
 /// Set animation name from Interface Builder
 @property (nonatomic, strong) IBInspectable NSString * _Nullable animation;


### PR DESCRIPTION
This change adds an initializer to LOTAnimationView that allows passing an error-handling block when initializing the view with a URL. If there are any errors retrieving the contents of the URL or parsing the contents as JSON, the error-handling block is called with the error.