### PR TITLE
Update MathKit.swift

### DIFF
--- a/Sources/Private/Utility/Extensions/MathKit.swift
+++ b/Sources/Private/Utility/Extensions/MathKit.swift
@@ -272,12 +272,12 @@ extension CGPoint {
 
   /// Operator convenience to divide points with /
   static func / (lhs: CGPoint, rhs: CGFloat) -> CGPoint {
-    CGPoint(x: lhs.x / CGFloat(rhs), y: lhs.y / CGFloat(rhs))
+    CGPoint(x: lhs.x / rhs, y: lhs.y / rhs)
   }
 
   /// Operator convenience to multiply points with *
   static func * (lhs: CGPoint, rhs: CGFloat) -> CGPoint {
-    CGPoint(x: lhs.x * CGFloat(rhs), y: lhs.y * CGFloat(rhs))
+    CGPoint(x: lhs.x * rhs, y: lhs.y * rhs)
   }
 
   /// Operator convenience to add points with +


### PR DESCRIPTION
Hello. before to describe change, I want to ask about below code.

```swift
// Sources/Private/Utility/Extensions/MathKit.swift:L273~

/// Operator convenience to divide points with /
static func / (lhs: CGPoint, rhs: CGFloat) -> CGPoint {
  CGPoint(x: lhs.x / CGFloat(rhs), y: lhs.y / CGFloat(rhs))
}

/// Operator convenience to multiply points with *
static func * (lhs: CGPoint, rhs: CGFloat) -> CGPoint {
  CGPoint(x: lhs.x * CGFloat(rhs), y: lhs.y * CGFloat(rhs))
}
```

I think CGFloat.init(_ value: CGFloat) will return same value. so I don't know why use this initializer here. In this case It just copy same value, and use some CPU and Memory to do it.

If you don't have some reason, please consider it to merge this pull request. Thanks you