### PR TITLE
Fix Incorect InitialValue Usage in SwiftUI Wrapper

### DIFF
--- a/Example/Example/AnimationPreviewView.swift
+++ b/Example/Example/AnimationPreviewView.swift
@@ -44,7 +44,10 @@ struct AnimationPreviewView: View {
   var body: some View {
     VStack {
       LottieView {
-        try await loadAnimation()
+        try await Self.loadAnimation(
+          from: animationSource,
+          urls: urls,
+          currentURLIndex: currentURLIndex)
       } placeholder: {
         LoadingIndicator()
           .frame(width: 50, height: 50)
@@ -172,7 +175,12 @@ struct AnimationPreviewView: View {
     #endif
   }
 
-  private func loadAnimation() async throws -> LottieAnimationSource? {
+  private static func loadAnimation(
+    from animationSource: AnimationSource,
+    urls: [URL],
+    currentURLIndex: Int)
+    async throws -> LottieAnimationSource?
+  {
     switch animationSource {
     case .local(let name):
       if name.hasSuffix(".lottie") {

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -13,7 +13,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
 
   /// Creates a `LottieView` that displays the given animation
   public init(animation: LottieAnimation?) where Placeholder == EmptyView {
-    _animationSource = State(initialValue: animation.map(LottieAnimationSource.lottieAnimation))
+    localAnimation = animation.map(LottieAnimationSource.lottieAnimation)
     placeholder = nil
   }
 
@@ -28,7 +28,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   /// }
   /// ```
   public init(dotLottieFile: DotLottieFile?) where Placeholder == EmptyView {
-    _animationSource = State(initialValue: dotLottieFile.map(LottieAnimationSource.dotLottieFile))
+    localAnimation = dotLottieFile.map(LottieAnimationSource.dotLottieFile)
     placeholder = nil
   }
 
@@ -106,9 +106,10 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     _ loadAnimation: @escaping () async throws -> LottieAnimationSource?,
     @ViewBuilder placeholder: @escaping () -> Placeholder)
   {
+
     self.loadAnimation = loadAnimation
+    self.localAnimation = nil
     self.placeholder = placeholder
-    _animationSource = State(initialValue: nil)
   }
 
   // MARK: Public
@@ -453,7 +454,8 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
 
   // MARK: Private
 
-  @State private var animationSource: LottieAnimationSource?
+  private let localAnimation: LottieAnimationSource?
+  @State private var remoteAnimation: LottieAnimationSource?
   private var playbackMode: LottiePlaybackMode?
   private var animationSpeed: Double?
   private var reloadAnimationTrigger: AnyEquatable?
@@ -473,12 +475,16 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     imageProvider: AnimationImageProvider,
     imageProvidersAreEqual: (AnimationImageProvider, AnimationImageProvider) -> Bool)?
 
+  private var animationSource: LottieAnimationSource? {
+    localAnimation ?? remoteAnimation
+  }
+
   private func loadAnimationIfNecessary() {
     guard let loadAnimation else { return }
 
     Task {
       do {
-        animationSource = try await loadAnimation()
+        remoteAnimation = try await loadAnimation()
       } catch {
         logger.warn("Failed to load asynchronous Lottie animation with error: \(error)")
       }
@@ -489,7 +495,7 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     guard loadAnimation != nil else { return }
 
     if showPlaceholderWhileReloading {
-      animationSource = nil
+      remoteAnimation = nil
     }
 
     loadAnimationIfNecessary()

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -106,9 +106,8 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     _ loadAnimation: @escaping () async throws -> LottieAnimationSource?,
     @ViewBuilder placeholder: @escaping () -> Placeholder)
   {
-
+    localAnimation = nil
     self.loadAnimation = loadAnimation
-    self.localAnimation = nil
     self.placeholder = placeholder
   }
 

--- a/Sources/Public/Controls/LottieViewType.swift
+++ b/Sources/Public/Controls/LottieViewType.swift
@@ -44,7 +44,7 @@ public enum LottieNSControlState: UInt, RawRepresentable {
 ///  - `UIControl.Event` on iOS / tvOS and `LottieNSControlEvent` on macOS.
 public typealias LottieControlEvent = LottieNSControlEvent
 
-public struct LottieNSControlEvent: Equatable {
+public struct LottieNSControlEvent: Equatable, Sendable {
 
   // MARK: Lifecycle
 


### PR DESCRIPTION
- Fixes an issue where someone is unable to update a LottieView's animation in SwiftUI due to internal usage of the `State(initialValue:)` initializer which only is run once
- Fixes for new Xcode version concurrency warnings