### PR TITLE
Fix issue where animation size could be incorrect after loading async animation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         xcode:
         - '15.2' # Swift 5.9
+        - '15.3' # Swift 5.10
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -49,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
         with:
-          xcode: '15.2' # Swift 5.9
+          xcode: '15.3' # Swift 5.10
       - name: Build Example
         run: bundle exec rake build:example:all
 
@@ -60,7 +61,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
         with:
-          xcode: '15.2' # Swift 5.9
+          xcode: '15.3' # Swift 5.10
       - name: Test Package
         run: bundle exec rake test:package
       - name: Process test artifacts
@@ -150,7 +151,7 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - '15.2' # Swift 5.9, first Xcode version with visionOS
+          - '15.3' # Swift 5.10
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -166,7 +167,7 @@ jobs:
     strategy:
       matrix:
         xcode:
-        - '15.2' # Swift 5.9
+        - '15.3' # Swift 5.10
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup
@@ -185,7 +186,7 @@ jobs:
         with:
           install-mint: true
           install-carthage: true
-          xcode: '15.2' # Swift 5.9
+          xcode: '15.3' # Swift 5.10
       - name: Test Carthage support
         run: bundle exec rake test:carthage
 

--- a/Example/Example/AnimationListView.swift
+++ b/Example/Example/AnimationListView.swift
@@ -35,7 +35,7 @@ struct AnimationListView: View {
               Text(item.name)
             }
 
-          case .animationList, .controlsDemo, .swiftUIInteroperability:
+          case .animationList, .controlsDemo, .swiftUIInteroperability, .lottieViewLayoutDemo:
             Text(item.name)
               .frame(height: 50)
           }
@@ -52,6 +52,8 @@ struct AnimationListView: View {
             ControlsDemoView()
           case .swiftUIInteroperability:
             SwiftUIInteroperabilityDemoView()
+          case .lottieViewLayoutDemo:
+            LottieViewLayoutDemoView()
           }
         }
       }
@@ -72,7 +74,7 @@ struct AnimationListView: View {
       guard let url = urls.first else { return nil }
       return await LottieAnimation.loadedFrom(url: url)?.animationSource
 
-    case .animationList, .controlsDemo, .swiftUIInteroperability:
+    case .animationList, .controlsDemo, .swiftUIInteroperability, .lottieViewLayoutDemo:
       return nil
     }
   }
@@ -104,6 +106,7 @@ extension AnimationListView {
     case remoteAnimations(name: String, urls: [URL])
     case controlsDemo
     case swiftUIInteroperability
+    case lottieViewLayoutDemo
   }
 
   var items: [Item] {
@@ -159,6 +162,7 @@ extension AnimationListView {
       .animationList(.remoteAnimationsDemo),
       .controlsDemo,
       .swiftUIInteroperability,
+      .lottieViewLayoutDemo,
     ]
   }
 }
@@ -174,6 +178,8 @@ extension AnimationListView.Item {
       return "Controls Demo"
     case .swiftUIInteroperability:
       return "SwiftUI Interoperability Demo"
+    case .lottieViewLayoutDemo:
+      return "LottieView Layout Demo"
     }
   }
 }

--- a/Example/Example/LottieViewLayoutDemoView.swift
+++ b/Example/Example/LottieViewLayoutDemoView.swift
@@ -4,7 +4,7 @@
 import Lottie
 import SwiftUI
 
-struct ContentView: View {
+struct LottieViewLayoutDemoView: View {
   var body: some View {
     HStack {
       VStack {

--- a/Example/Example/LottieViewLayoutDemoView.swift
+++ b/Example/Example/LottieViewLayoutDemoView.swift
@@ -35,7 +35,18 @@ struct LottieViewLayoutDemoView: View {
         LottieView(animation: .named("Samples/LottieLogo1"))
           .looping()
 
-        Text("intrinsic content size")
+        Text("automatic size")
+      }
+
+      VStack {
+        LottieView {
+          try await Task.sleep(for: .seconds(1))
+          return LottieAnimation.named("Samples/LottieLogo1")
+        }
+        .intrinsicSize()
+        .looping()
+
+        Text("intrinsic size, async")
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
This PR fixes an issue where the view's size could be incorrect after loading an async animation.

I believe this issue was introduced by #2289, when we changed the lifecycle of the `LottieAnimationView`. Previously it was only added to the view hierarchy after the animation finished loading. Now it's always present, so can have an intrinsic size of zero if measured before the async animation finishes loading.

Here's the sample code I added to test this case. The async case was broken before. Now both work as expected.

```swift
VStack {
  LottieView(animation: .named("Samples/LottieLogo1"))
    .intrinsicSize()
    .looping()

  Text("intrinsic size")
}

VStack {
  LottieView {
    try await Task.sleep(for: .seconds(1))
    return LottieAnimation.named("Samples/LottieLogo1")
  }
  .intrinsicSize()
  .looping()

  Text("intrinsic size, async")
}
```



#### Before

<img width="885" alt="Screenshot 2024-04-15 at 12 09 25 PM" src="https://github.com/airbnb/lottie-ios/assets/1811727/6740980a-29ba-4efe-9ebe-3cdd9df39210">

### After

<img width="885" alt="Screenshot 2024-04-15 at 12 09 50 PM" src="https://github.com/airbnb/lottie-ios/assets/1811727/1999ef49-5f32-4c96-ac5d-6155c2a313d2">
