### PR TITLE
Update NSPrivacyAccessedAPITypeReasons in privacy manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install Lottie using [Swift Package Manager](https://github.com/apple/swift-p
 or you can add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.4.2")
+.package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.4.3")
 ```
 
 When using Swift Package Manager we recommend using the [lottie-spm](https://github.com/airbnb/lottie-spm) repo instead of the main lottie-ios repo.  The main git repository for [lottie-ios](https://github.com/airbnb/lottie-ios) is somewhat large (300+ MB), and Swift Package Manager always downloads the full repository with all git history. The [lottie-spm](https://github.com/airbnb/lottie-spm) repo is much smaller (less than 500kb), so can be downloaded much more quickly. 

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -15,7 +15,7 @@
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>3B52.1</string>
+				<string>C617.1</string>
 			</array>
 		</dict>
 	</array>

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -2,5 +2,5 @@
 // Copyright © 2024 Airbnb Inc. All rights reserved.
 
 // The version numbers used when building Lottie.xcframework
-MARKETING_VERSION = 4.4.2
-CURRENT_PROJECT_VERSION = 442 // a three-digit representation of the marketing version, without dots.
+MARKETING_VERSION = 4.4.3
+CURRENT_PROJECT_VERSION = 443 // a three-digit representation of the marketing version, without dots.

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'lottie-ios'
-  s.version          = '4.4.2'
+  s.version          = '4.4.3'
   s.summary          = 'A library to render native animations from bodymovin json'
 
   s.description = <<-DESC

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-ios",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Lottie is a mobile library for Android and iOS that parses Adobe After Effects animations exported as json with bodymovin and renders the vector animations natively on mobile and through React Native!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Following the recommendation from #2371, this updates the `NSPrivacyAccessedAPITypeReasons` in our privacy manifest from:

> [**3B52.1**](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api): Declare this reason to access the timestamps, size, or other metadata of files or directories that the user specifically granted access to, such as using a document picker view controller.

to:

> [**C617.1**](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api): Declare this reason to access the timestamps, size, or other metadata of files inside the app container, app group container, or the app’s CloudKit container.

