### PR TITLE
Add final keyword

### DIFF
--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -13,7 +13,7 @@ import UIKit
 // MARK: - SnapshotTests
 
 @MainActor
-class SnapshotTests: XCTestCase {
+final class SnapshotTests: XCTestCase {
 
   // MARK: Internal
 


### PR DESCRIPTION
## Description

Currently, the `final` keyword is missing in `SnapshotTests`, while it is applied in other test cases.

## Changes

Added the `final` keyword to methods within the snapshotTests class.

---

This change is a small adjustment necessary for performance and code stability. Looking forward to the reviews from collaborators. 🙏 







