### PR TITLE
Fix for watchOS preview build issue

### DIFF
--- a/Sources/Private/CoreAnimation/Animations/CAAnimation+TimingConfiguration.swift
+++ b/Sources/Private/CoreAnimation/Animations/CAAnimation+TimingConfiguration.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/6/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CAAnimation {
@@ -79,3 +80,4 @@ extension CALayer {
     add(animation.timed(with: context, for: self), forKey: animation.keyPath)
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/CALayer+addAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CALayer+addAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/14/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CALayer {
@@ -467,3 +468,4 @@ extension RandomAccessCollection {
     return segments
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/CombinedShapeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CombinedShapeAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/28/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CAShapeLayer {
@@ -82,3 +83,4 @@ extension CombinedShapeItem {
       name: name)
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/CustomPathAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CustomPathAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/21/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CAShapeLayer {
@@ -84,3 +85,4 @@ struct BezierPathKeyframe: Interpolatable {
       cornerRadius: cornerRadius.interpolate(to: to.cornerRadius, amount: amount))
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/DropShadowAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/DropShadowAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/15/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - DropShadowModel
@@ -158,3 +159,4 @@ extension CALayer {
   }
 
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/EllipseAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/EllipseAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/21/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CAShapeLayer {
@@ -47,3 +48,4 @@ extension Ellipse {
       makeCombinedResult: Ellipse.Keyframe.init)
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/GradientAnimations.swift
+++ b/Sources/Private/CoreAnimation/Animations/GradientAnimations.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/7/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - GradientShapeItem
@@ -242,3 +243,4 @@ extension GradientShapeItem {
     }
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/LayerProperty.swift
+++ b/Sources/Private/CoreAnimation/Animations/LayerProperty.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/11/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - LayerProperty
@@ -399,3 +400,4 @@ extension CustomizableProperty {
       })
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/OpacityAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/OpacityAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 5/17/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - OpacityAnimationModel
@@ -50,3 +51,4 @@ extension CALayer {
       context: context)
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/RectangleAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/RectangleAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/21/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CAShapeLayer {
@@ -52,3 +53,4 @@ extension Rectangle {
       makeCombinedResult: Rectangle.Keyframe.init)
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/ShapeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/ShapeAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/7/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CAShapeLayer {
@@ -234,3 +235,4 @@ extension Trim {
       strokeEnd: combinedKeyframes.map { $0.end })
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/StarAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/StarAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/10/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CAShapeLayer {
@@ -114,3 +115,4 @@ extension Star {
       makeCombinedResult: Star.Keyframe.init)
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/StrokeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/StrokeAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 2/10/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - StrokeShapeItem
@@ -84,3 +85,4 @@ extension CAShapeLayer {
     }
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/TransformAnimations.swift
+++ b/Sources/Private/CoreAnimation/Animations/TransformAnimations.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/17/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - TransformModel
@@ -341,3 +342,4 @@ extension TransformModel {
     scale.keyframes.contains(where: { $0.value.x < 0 })
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Animations/VisibilityAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/VisibilityAnimation.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/21/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CALayer {
@@ -61,3 +62,4 @@ extension CALayer {
     }
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/CompatibilityTracker.swift
+++ b/Sources/Private/CoreAnimation/CompatibilityTracker.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 5/4/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - CompatibilityIssue
 
 /// A compatibility issue that was encountered while setting up an animation with the Core Animation engine
@@ -128,3 +129,4 @@ extension LayerAnimationContext: CompatibilityTrackerProviding {
     currentKeypath.fullPath
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - CoreAnimationLayer
@@ -597,3 +598,4 @@ extension CALayer {
     return numberOfSublayersWithTimeRemapping
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Extensions/CALayer+fillBounds.swift
+++ b/Sources/Private/CoreAnimation/Extensions/CALayer+fillBounds.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/15/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - CALayer + fillBoundsOfSuperlayer
@@ -33,3 +34,4 @@ extension CALayer {
 protocol CustomLayoutLayer: CALayer {
   func layout(superlayerBounds: CGRect)
 }
+#endif

--- a/Sources/Private/CoreAnimation/Extensions/KeyframeGroup+exactlyOneKeyframe.swift
+++ b/Sources/Private/CoreAnimation/Extensions/KeyframeGroup+exactlyOneKeyframe.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/11/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - KeyframeGroup + exactlyOneKeyframe
 
 extension KeyframeGroup {
@@ -27,3 +28,4 @@ extension KeyframeGroup {
     return keyframes[0].value
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Extensions/Keyframes+combined.swift
+++ b/Sources/Private/CoreAnimation/Extensions/Keyframes+combined.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/28/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - Keyframes
 
 enum Keyframes {
@@ -326,3 +327,4 @@ extension KeyframeGroup {
     }
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Extensions/Keyframes+timeRemapping.swift
+++ b/Sources/Private/CoreAnimation/Extensions/Keyframes+timeRemapping.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/8/24.
 // Copyright © 2024 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 extension Keyframes {
   /// Manually interpolates the given keyframes, and applies `context.complexTimeRemapping`.
   ///  - Since `complexTimeRemapping` is a mapping from "global time" to "local time",
@@ -44,3 +45,4 @@ extension Keyframes {
     return KeyframeGroup(keyframes: ContiguousArray(interpolatedRemappedKeyframes))
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/AnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/AnimationLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/14/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - AnimationLayer
@@ -167,3 +168,4 @@ final class LoggingState {
   /// has been logged yet for this layer.
   var hasLoggedAfterEffectsExpressionsWarning = false
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/BaseAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/BaseAnimationLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/27/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// A base `CALayer` that manages the frame and animations
@@ -31,3 +32,4 @@ class BaseAnimationLayer: CALayer, AnimationLayer {
   }
 
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/BaseCompositionLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/BaseCompositionLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/20/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - BaseCompositionLayer
@@ -108,3 +109,4 @@ class BaseCompositionLayer: BaseAnimationLayer {
   }
 
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/CALayer+setupLayerHierarchy.swift
+++ b/Sources/Private/CoreAnimation/Layers/CALayer+setupLayerHierarchy.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/11/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CALayer {
@@ -167,3 +168,4 @@ extension Collection<LayerModel> {
     return layersAndMasks
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/GradientRenderLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/GradientRenderLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/10/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - GradientRenderLayer
@@ -95,3 +96,4 @@ extension CALayer {
   ///    `CGContext.drawLinearGradient` with `[.drawsAfterEndLocation, .drawsBeforeStartLocation]` etc.
   static let veryLargeLayerPadding: CGFloat = 10_000
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/ImageLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/ImageLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/10/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - ImageLayer
@@ -78,3 +79,4 @@ extension ImageLayer: CustomLayoutLayer {
       height: CGFloat(imageAsset.height))
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/InfiniteOpaqueAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/InfiniteOpaqueAnimationLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 10/10/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - ExpandedAnimationLayer
@@ -54,3 +55,4 @@ final class InfiniteOpaqueAnimationLayer: BaseAnimationLayer {
   private let additionalPaddingLayer = CALayer()
 
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/LayerModel+makeAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/LayerModel+makeAnimationLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/20/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - LayerContext
 
 /// Context available when constructing an `AnimationLayer`
@@ -57,3 +58,4 @@ extension LayerModel {
   }
 
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/MaskCompositionLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/MaskCompositionLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/6/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - MaskCompositionLayer
@@ -136,3 +137,4 @@ extension MaskCompositionLayer.MaskLayer: AnimationLayer {
       })
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/PreCompLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/PreCompLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/14/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - PreCompLayer
@@ -103,3 +104,4 @@ extension PreCompLayer: CustomLayoutLayer {
     contentsLayer.masksToBounds = true
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/RepeaterLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/RepeaterLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/1/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - RepeaterLayer
@@ -96,3 +97,4 @@ extension RepeaterTransform: TransformModel {
   var _skew: KeyframeGroup<LottieVector1D>? { nil }
   var _skewAxis: KeyframeGroup<LottieVector1D>? { nil }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/ShapeItemLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/ShapeItemLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - ShapeItemLayer
@@ -342,3 +343,4 @@ extension LayerAnimationContext {
     return context
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/ShapeLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/ShapeLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/14/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - ShapeLayer
@@ -559,3 +560,4 @@ extension [ShapeItemLayer.Item] {
     return (validGroups: renderGroups, unusedItems: itemsNotInValidRenderGroups)
   }
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/SolidLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/SolidLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - SolidLayer
@@ -63,3 +64,4 @@ final class SolidLayer: BaseCompositionLayer {
   }
 
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/TextLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/TextLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 2/9/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// The `CALayer` type responsible for rendering `TextLayer`s
@@ -113,3 +114,4 @@ final class TextLayer: BaseCompositionLayer {
   }
 
 }
+#endif

--- a/Sources/Private/CoreAnimation/Layers/TransformLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/TransformLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/21/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 /// The CALayer type responsible for only rendering the `transform` of a `LayerModel`
 final class TransformLayer: BaseCompositionLayer {
 
@@ -9,3 +10,4 @@ final class TransformLayer: BaseCompositionLayer {
   override var renderLayerContents: Bool { false }
 
 }
+#endif

--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/13/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - ValueProviderStore
@@ -149,3 +150,4 @@ extension AnimationKeypath {
     return fullPath.range(of: regex, options: .regularExpression) != nil
   }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/Providers/MakeViewProviding.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/Providers/MakeViewProviding.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 12/1/20.
 // Copyright © 2020 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - MakeViewProviding
 
 /// The capability of constructing a `UIView`.
@@ -58,3 +59,4 @@ extension ViewEpoxyModeled where Self: MakeViewProviding {
       updateStrategy: .replace)
   }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/Providers/TraitCollectionProviding.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/Providers/TraitCollectionProviding.swift
@@ -1,7 +1,7 @@
 // Created by eric_horacek on 12/16/20.
 // Copyright © 2020 Airbnb Inc. All rights reserved.
 
-#if !os(macOS)
+#if !os(macOS) && canImport(QuartzCore)
 import UIKit
 
 /// The capability of providing a `UITraitCollection` instance.

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/Providers/ViewProviding.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/Providers/ViewProviding.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 12/16/20.
 // Copyright © 2020 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 /// The capability of providing an `View` instance
 ///
 /// Typically conformed to by the `CallbackContext` of a `CallbackContextEpoxyModeled`.
@@ -11,3 +12,4 @@ protocol ViewProviding {
   /// The `UIView` view instance provided by this type.
   var view: View { get }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/ViewEpoxyModeled.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/ViewEpoxyModeled.swift
@@ -1,6 +1,7 @@
 // Created by eric_horacek on 12/4/20.
 // Copyright © 2020 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 /// An Epoxy model with an associated `UIView` type.
 protocol ViewEpoxyModeled: EpoxyModeled {
   /// The view type associated with this model.
@@ -8,3 +9,4 @@ protocol ViewEpoxyModeled: EpoxyModeled {
   /// An instance of this view is typically configured by this model.
   associatedtype View: ViewType
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/EpoxyableView+SwiftUIView.swift
@@ -1,7 +1,7 @@
 // Created by eric_horacek on 9/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 
 // MARK: - StyledView

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringViewRepresentable.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringViewRepresentable.swift
@@ -1,7 +1,7 @@
 // Created by eric_horacek on 6/22/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 
 // MARK: - MeasuringViewRepresentable

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -1,7 +1,7 @@
 // Created by Bryn Bodayle on 1/24/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 
 // MARK: - SwiftUIMeasurementContainer

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/SwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/SwiftUIView.swift
@@ -1,7 +1,7 @@
 // Created by eric_horacek on 9/8/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 
 // MARK: - SwiftUIView

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIView+SwiftUIView.swift
@@ -1,7 +1,7 @@
 // Created by eric_horacek on 3/3/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 
 // MARK: - ViewTypeProtocol + swiftUIView

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/UIViewConfiguringSwiftUIView.swift
@@ -1,7 +1,7 @@
 // Created by eric_horacek on 3/4/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 
 // MARK: - UIViewConfiguringSwiftUIView

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/BehaviorsConfigurableView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/BehaviorsConfigurableView.swift
@@ -1,6 +1,7 @@
 // Created by Tyler Hedrick on 5/26/20.
 // Copyright © 2020 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - BehaviorsConfigurableView
 
 /// A view that can be configured with a `Behaviors` instance that contains the view's non-
@@ -43,3 +44,4 @@ extension BehaviorsConfigurableView where Behaviors == Never {
     }
   }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ContentConfigurableView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ContentConfigurableView.swift
@@ -1,6 +1,7 @@
 //  Created by Laura Skelton on 5/30/17.
 //  Copyright © 2017 Airbnb. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - ContentConfigurableView
 
 /// A view that can be configured with a `Content` instance that contains the view's `Equatable`
@@ -34,3 +35,4 @@ protocol ContentConfigurableView: ViewType {
 extension ContentConfigurableView where Content == Never {
   func setContent(_: Never, animated _: Bool) { }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/EpoxyableView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/EpoxyableView.swift
@@ -1,5 +1,7 @@
 // Created by eric_horacek on 1/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 /// A `UIView` that can be declaratively configured via a concrete `EpoxyableModel` instance.
 typealias EpoxyableView = BehaviorsConfigurableView & ContentConfigurableView & StyledView
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/StyledView.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/StyledView.swift
@@ -1,6 +1,7 @@
 //  Created by Laura Skelton on 4/14/16.
 //  Copyright © 2016 Airbnb. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - StyledView
 
 /// A view that can be initialized with a `Style` instance that contains the view's invariant
@@ -40,3 +41,4 @@ extension StyledView where Style == Never {
     switch style { }
   }
 }
+#endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ViewType.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Views/ViewType.swift
@@ -1,7 +1,7 @@
 // Created by Cal Stephens on 6/26/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 #if canImport(UIKit)
 import UIKit

--- a/Sources/Private/EmbeddedLibraries/LRUCache/LRUCache.swift
+++ b/Sources/Private/EmbeddedLibraries/LRUCache/LRUCache.swift
@@ -33,7 +33,7 @@
 
 import Foundation
 
-#if canImport(UIKit)
+#if canImport(UIKit) && canImport(QuartzCore)
 import UIKit
 
 /// Notification that cache should be cleared

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/CompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/CompositionLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/22/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - CompositionLayer
@@ -158,3 +159,4 @@ class CompositionLayer: CALayer, KeypathSearchable {
 protocol CompositionLayerDelegate: AnyObject {
   func frameUpdated(frame: CGFloat)
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/ImageCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/ImageCompositionLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 final class ImageCompositionLayer: CompositionLayer {
@@ -52,3 +53,4 @@ final class ImageCompositionLayer: CompositionLayer {
     }
   }
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/MaskContainerLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/MaskContainerLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension MaskMode {
@@ -188,3 +189,4 @@ private class MaskNodeProperties: NodePropertyMap {
   let shape: NodeProperty<BezierPath>
   let expansion: NodeProperty<LottieVector1D>
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/NullCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/NullCompositionLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 final class NullCompositionLayer: CompositionLayer {
@@ -26,3 +27,4 @@ final class NullCompositionLayer: CompositionLayer {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/PreCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/PreCompositionLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 final class PreCompositionLayer: CompositionLayer {
@@ -131,3 +132,4 @@ final class PreCompositionLayer: CompositionLayer {
 
   fileprivate var animationLayers: [CompositionLayer]
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/ShapeCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/ShapeCompositionLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/22/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -56,3 +57,4 @@ final class ShapeCompositionLayer: CompositionLayer {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/SolidCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/SolidCompositionLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 final class SolidCompositionLayer: CompositionLayer {
@@ -54,3 +55,4 @@ final class SolidCompositionLayer: CompositionLayer {
     solidShape.fillColor = colorProperty.value.cgColorValue
   }
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/CompLayers/TextCompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/TextCompositionLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 /// Needed for NSMutableParagraphStyle...
 #if os(OSX)
 import AppKit
@@ -168,3 +169,4 @@ final class TextCompositionLayer: CompositionLayer {
     textLayer.contentsScale = renderScale
   }
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/24/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - MainThreadAnimationLayer
@@ -310,3 +311,4 @@ private class BlankImageProvider: AnimationImageProvider {
     nil
   }
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CachedImageProvider.swift
@@ -1,6 +1,7 @@
 // Created by Jianjun Wu on 2022/5/12.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - CachedImageProvider
@@ -56,3 +57,4 @@ extension AnimationImageProvider {
     return CachedImageProvider(imageProvider: self)
   }
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/Utility/CompositionLayersInitializer.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CompositionLayersInitializer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -97,3 +98,4 @@ extension [LayerModel] {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/Utility/CoreTextRenderLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/CoreTextRenderLayer.swift
@@ -8,6 +8,7 @@
 import CoreGraphics
 import CoreText
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 /// Needed for NSMutableParagraphStyle...
 #if os(OSX)
@@ -346,3 +347,4 @@ extension CGContext {
     }
   }
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/Utility/InvertedMatteLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/InvertedMatteLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/28/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// A layer that inverses the alpha output of its input layer.
@@ -53,3 +54,4 @@ final class InvertedMatteLayer: CALayer, CompositionLayerDelegate {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/Utility/LayerFontProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/LayerFontProvider.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 YurtvilleProds. All rights reserved.
 //
 
+#if canImport(QuartzCore)
 /// Connects a LottieFontProvider to a group of text layers
 final class LayerFontProvider {
 
@@ -37,3 +38,4 @@ final class LayerFontProvider {
     }
   }
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/Utility/LayerImageProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/LayerImageProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 /// Connects a LottieImageProvider to a group of image layers
 final class LayerImageProvider {
 
@@ -50,3 +51,4 @@ final class LayerImageProvider {
     }
   }
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/Utility/LayerTextProvider.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/LayerTextProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Alexandr Goncharov on 07/06/2019.
 //
 
+#if canImport(QuartzCore)
 /// Connects a LottieTextProvider to a group of text layers
 final class LayerTextProvider {
 
@@ -36,3 +37,4 @@ final class LayerTextProvider {
     }
   }
 }
+#endif

--- a/Sources/Private/MainThread/LayerContainers/Utility/LayerTransformNode.swift
+++ b/Sources/Private/MainThread/LayerContainers/Utility/LayerTransformNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - LayerTransformProperties
@@ -148,3 +149,4 @@ class LayerTransformNode: AnimatorNode {
     }
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Extensions/ItemsExtension.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Extensions/ItemsExtension.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/18/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - NodeTree
 
 final class NodeTree {
@@ -105,3 +106,4 @@ extension [ShapeItem] {
     return nodeTree
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/NodeProperty.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/NodeProperty.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -53,3 +54,4 @@ class NodeProperty<T>: AnyNodeProperty {
 
   fileprivate var typedContainer: ValueContainer<T>
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/AnyNodeProperty.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/AnyNodeProperty.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -48,3 +49,4 @@ extension AnyNodeProperty {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/KeypathSearchable.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/KeypathSearchable.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// Protocol that provides keypath search functionality. Returns all node properties associated with a keypath.
@@ -21,3 +22,4 @@ protocol KeypathSearchable {
 
   var keypathLayer: CALayer? { get }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/NodePropertyMap.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/NodePropertyMap.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/21/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - NodePropertyMap
@@ -41,3 +42,4 @@ extension NodePropertyMap {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueProviders/GroupInterpolator.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueProviders/GroupInterpolator.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/22/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -37,3 +38,4 @@ final class GroupInterpolator<ValueType>: ValueProvider where ValueType: Interpo
     return updated != nil
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueProviders/SingleValueProvider.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/ValueProviders/SingleValueProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// Returns a value for every frame.
@@ -41,3 +42,4 @@ final class SingleValueProvider<ValueType: AnyInterpolatable>: ValueProvider {
 
   private var hasUpdate = true
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/ModifierNodes/RoundedCornersNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/ModifierNodes/RoundedCornersNode.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - RoundedCornersProperties
@@ -83,3 +84,4 @@ final class RoundedCornersNode: AnimatorNode {
 
   fileprivate let upstreamPaths: [PathOutputNode]
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/ModifierNodes/TrimPathNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/ModifierNodes/TrimPathNode.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - TrimPathProperties
@@ -278,3 +279,4 @@ final class TrimPathNode: AnimatorNode {
 
   fileprivate let upstreamPaths: [PathOutputNode]
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/GroupOutputNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/GroupOutputNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 class GroupOutputNode: NodeOutput {
@@ -72,3 +73,4 @@ class GroupOutputNode: NodeOutput {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/PassThroughOutputNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/PassThroughOutputNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 
 class PassThroughOutputNode: NodeOutput {
@@ -44,3 +45,4 @@ class PassThroughOutputNode: NodeOutput {
     return hasUpdate
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/PathOutputNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/PathOutputNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 
 /// A node that has an output of a BezierPath
@@ -87,3 +88,4 @@ class PathOutputNode: NodeOutput {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/FillRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/FillRenderer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension FillRule {
@@ -67,3 +68,4 @@ final class FillRenderer: PassThroughOutputNode, Renderable {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientFillRenderer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - GradientFillLayer
@@ -244,3 +245,4 @@ final class GradientFillRenderer: PassThroughOutputNode, Renderable {
   private let maskLayer = CAShapeLayer()
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientStrokeRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientStrokeRenderer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - Renderer
@@ -62,3 +63,4 @@ final class GradientStrokeRenderer: PassThroughOutputNode, Renderable {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/LegacyGradientFillRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/LegacyGradientFillRenderer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// A rendered for a Path Fill
@@ -150,3 +151,4 @@ final class LegacyGradientFillRenderer: PassThroughOutputNode, Renderable {
     }
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/StrokeRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/StrokeRenderer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension LineJoin {
@@ -163,3 +164,4 @@ final class StrokeRenderer: PassThroughOutputNode, Renderable {
     }
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/EllipseNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/EllipseNode.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - EllipseNodeProperties
@@ -137,3 +138,4 @@ extension BezierPath {
     return path
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/PolygonNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/PolygonNode.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - PolygonNodeProperties
@@ -168,3 +169,4 @@ extension BezierPath {
     return path
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/RectNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/RectNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/21/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -223,3 +224,4 @@ extension BezierPath {
     return bezierPath
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/ShapeNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/ShapeNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/16/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -72,3 +73,4 @@ final class ShapeNode: AnimatorNode, PathNode {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/StarNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/PathNodes/StarNode.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - StarNodeProperties
@@ -220,3 +221,4 @@ extension BezierPath {
     return path
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderContainers/GroupNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderContainers/GroupNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/18/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - GroupNodeProperties
@@ -163,3 +164,4 @@ final class GroupNode: AnimatorNode {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/FillNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/FillNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/17/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -88,3 +89,4 @@ final class FillNode: AnimatorNode, RenderNode {
     fillRender.fillRule = fillProperties.type
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientFillNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientFillNode.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - GradientFillProperties
@@ -103,3 +104,4 @@ final class GradientFillNode: AnimatorNode, RenderNode {
     fillRender.fillRule = fillProperties.fillRule.caFillRule
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientStrokeNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientStrokeNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/23/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -149,3 +150,4 @@ final class GradientStrokeNode: AnimatorNode, RenderNode {
     }
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/StrokeNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/StrokeNode.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - StrokeNodeProperties
@@ -178,3 +179,4 @@ extension [CGFloat] {
     !allSatisfy { $0 == 0.01 }
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/Text/TextAnimatorNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/Text/TextAnimatorNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/19/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - TextAnimatorNodeProperties
@@ -285,3 +286,4 @@ class TextAnimatorNode: AnimatorNode {
     textOutputNode.strokeWidth = textAnimatorProperties.strokeWidth?.value.cgFloatValue ?? 0
   }
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Protocols/AnimatorNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Protocols/AnimatorNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/15/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - NodeOutput
@@ -195,3 +196,4 @@ extension AnimatorNode {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Protocols/PathNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Protocols/PathNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/17/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - PathNode
 
 protocol PathNode {
@@ -18,3 +19,4 @@ extension PathNode where Self: AnimatorNode {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/Protocols/RenderNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Protocols/RenderNode.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/17/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - RenderNode
@@ -58,3 +59,4 @@ extension Renderable {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/RenderLayers/ShapeContainerLayer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/RenderLayers/ShapeContainerLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// The base layer that holds Shapes and Shape Renderers
@@ -76,3 +77,4 @@ class ShapeContainerLayer: CALayer {
   }
 
 }
+#endif

--- a/Sources/Private/MainThread/NodeRenderSystem/RenderLayers/ShapeRenderLayer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/RenderLayers/ShapeRenderLayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/18/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// The layer responsible for rendering shape objects
@@ -96,3 +97,4 @@ final class ShapeRenderLayer: ShapeContainerLayer {
     shapeLayer.contentsScale = renderScale
   }
 }
+#endif

--- a/Sources/Private/Model/Assets/AssetLibrary.swift
+++ b/Sources/Private/Model/Assets/AssetLibrary.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
+#if canImport(QuartzCore)
 final class AssetLibrary: Codable, AnyInitializable, Sendable {
 
   // MARK: Lifecycle
@@ -73,3 +74,4 @@ final class AssetLibrary: Codable, AnyInitializable, Sendable {
     try container.encode(contentsOf: Array(assets.values))
   }
 }
+#endif

--- a/Sources/Private/Model/Assets/PrecompAsset.swift
+++ b/Sources/Private/Model/Assets/PrecompAsset.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
+#if canImport(QuartzCore)
 final class PrecompAsset: Asset {
 
   // MARK: Lifecycle
@@ -36,3 +37,4 @@ final class PrecompAsset: Asset {
     try container.encode(layers, forKey: .layers)
   }
 }
+#endif

--- a/Sources/Private/Model/DotLottie/DotLottieAnimation.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieAnimation.swift
@@ -5,6 +5,7 @@
 // Created by Evandro Harrison Hoffmann on 28/06/2021.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 // MARK: - DotLottieAnimation
@@ -55,3 +56,4 @@ enum DotLottieAnimationMode: String, Codable {
   case normal
   case bounce
 }
+#endif

--- a/Sources/Private/Model/DotLottie/DotLottieImageProvider.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieImageProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Evandro Hoffmann on 20/10/22.
 //
 
+#if canImport(QuartzCore)
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -87,3 +88,4 @@ extension DotLottieImageProvider: Hashable {
   }
 
 }
+#endif

--- a/Sources/Private/Model/DotLottie/DotLottieManifest.swift
+++ b/Sources/Private/Model/DotLottie/DotLottieManifest.swift
@@ -5,6 +5,7 @@
 // Created by Evandro Harrison Hoffmann on 27/06/2020.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 /// Manifest model for .lottie File
@@ -40,3 +41,4 @@ struct DotLottieManifest: Codable {
   }
 
 }
+#endif

--- a/Sources/Private/Model/Keyframes/KeyframeData.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeData.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - KeyframeData
 
 /// A generic class used to parse and remap keyframe json.
@@ -108,3 +109,4 @@ extension KeyframeData: DictionaryInitializable where T: AnyInitializable {
       spatialOutTangent: spatialOutTangent)
   }
 }
+#endif

--- a/Sources/Private/Model/Keyframes/KeyframeGroup.swift
+++ b/Sources/Private/Model/Keyframes/KeyframeGroup.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/14/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - KeyframeGroup
 
 /// Used for coding/decoding a group of Keyframes by type.
@@ -254,3 +255,4 @@ extension KeyframeGroup: AnyKeyframeGroup where T: AnyInterpolatable {
     KeyframeInterpolator(keyframes: keyframes)
   }
 }
+#endif

--- a/Sources/Private/Model/LayerEffects/DropShadowEffect.swift
+++ b/Sources/Private/Model/LayerEffects/DropShadowEffect.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 final class DropShadowEffect: LayerEffect {
 
   // MARK: Lifecycle
@@ -41,3 +42,4 @@ final class DropShadowEffect: LayerEffect {
   }
 
 }
+#endif

--- a/Sources/Private/Model/LayerEffects/EffectValues/ColorEffectValue.swift
+++ b/Sources/Private/Model/LayerEffects/EffectValues/ColorEffectValue.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 final class ColorEffectValue: EffectValue {
 
   // MARK: Lifecycle
@@ -34,3 +35,4 @@ final class ColorEffectValue: EffectValue {
     case value = "v"
   }
 }
+#endif

--- a/Sources/Private/Model/LayerEffects/EffectValues/EffectValue.swift
+++ b/Sources/Private/Model/LayerEffects/EffectValues/EffectValue.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/15/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - EffectValueType
 
 /// https://lottiefiles.github.io/lottie-docs/schema/#/$defs/effect-values
@@ -95,3 +96,4 @@ extension [EffectValue] {
 /// All `EffectValue` subclasses are immutable `Sendable` values.
 // swiftlint:disable:next no_unchecked_sendable
 extension EffectValue: @unchecked Sendable { }
+#endif

--- a/Sources/Private/Model/LayerEffects/EffectValues/Vector1DEffectValue.swift
+++ b/Sources/Private/Model/LayerEffects/EffectValues/Vector1DEffectValue.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 final class Vector1DEffectValue: EffectValue {
 
   // MARK: Lifecycle
@@ -34,3 +35,4 @@ final class Vector1DEffectValue: EffectValue {
     case value = "v"
   }
 }
+#endif

--- a/Sources/Private/Model/LayerEffects/LayerEffect.swift
+++ b/Sources/Private/Model/LayerEffects/LayerEffect.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - LayerEffectType
 
 /// https://lottiefiles.github.io/lottie-docs/schema/#/$defs/effects
@@ -100,3 +101,4 @@ extension [LayerEffect] {
 /// All `LayerEffect` subclasses are immutable `Sendable` values.
 // swiftlint:disable:next no_unchecked_sendable
 extension LayerEffect: @unchecked Sendable { }
+#endif

--- a/Sources/Private/Model/LayerStyles/DropShadowStyle.swift
+++ b/Sources/Private/Model/LayerStyles/DropShadowStyle.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 final class DropShadowStyle: LayerStyle {
 
   // MARK: Lifecycle
@@ -68,3 +69,4 @@ final class DropShadowStyle: LayerStyle {
     case distance = "d"
   }
 }
+#endif

--- a/Sources/Private/Model/LayerStyles/LayerStyle.swift
+++ b/Sources/Private/Model/LayerStyles/LayerStyle.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - LayerStyleType
 
 enum LayerStyleType: Int, Codable, Sendable {
@@ -82,3 +83,4 @@ extension [LayerStyle] {
 /// All `LayerStyle` subclasses are immutable `Sendable` values.
 // swiftlint:disable:next no_unchecked_sendable
 extension LayerStyle: @unchecked Sendable { }
+#endif

--- a/Sources/Private/Model/Layers/ImageLayerModel.swift
+++ b/Sources/Private/Model/Layers/ImageLayerModel.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 /// A layer that holds an image.
 final class ImageLayerModel: LayerModel {
 
@@ -38,3 +39,4 @@ final class ImageLayerModel: LayerModel {
     case referenceID = "refId"
   }
 }
+#endif

--- a/Sources/Private/Model/Layers/LayerModel.swift
+++ b/Sources/Private/Model/Layers/LayerModel.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - LayerType + ClassFamily
 
 /// Used for mapping a heterogeneous list to classes for parsing.
@@ -264,3 +265,4 @@ extension [LayerModel] {
 /// All `LayerModel` subclasses are immutable `Sendable` values.
 // swiftlint:disable:next no_unchecked_sendable
 extension LayerModel: @unchecked Sendable { }
+#endif

--- a/Sources/Private/Model/Layers/PreCompLayerModel.swift
+++ b/Sources/Private/Model/Layers/PreCompLayerModel.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 /// A layer that holds another animation composition.
 final class PreCompLayerModel: LayerModel {
 
@@ -63,3 +64,4 @@ final class PreCompLayerModel: LayerModel {
     case height = "h"
   }
 }
+#endif

--- a/Sources/Private/Model/Layers/ShapeLayerModel.swift
+++ b/Sources/Private/Model/Layers/ShapeLayerModel.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 /// A layer that holds vector shape objects.
 final class ShapeLayerModel: LayerModel {
 
@@ -39,3 +40,4 @@ final class ShapeLayerModel: LayerModel {
     case items = "shapes"
   }
 }
+#endif

--- a/Sources/Private/Model/Layers/SolidLayerModel.swift
+++ b/Sources/Private/Model/Layers/SolidLayerModel.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 /// A layer that holds a solid color.
 final class SolidLayerModel: LayerModel {
 
@@ -52,3 +53,4 @@ final class SolidLayerModel: LayerModel {
     case height = "sh"
   }
 }
+#endif

--- a/Sources/Private/Model/Layers/TextLayerModel.swift
+++ b/Sources/Private/Model/Layers/TextLayerModel.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 /// A layer that holds text.
 final class TextLayerModel: LayerModel {
 
@@ -54,3 +55,4 @@ final class TextLayerModel: LayerModel {
     case animators = "a"
   }
 }
+#endif

--- a/Sources/Private/Model/Objects/DashPattern.swift
+++ b/Sources/Private/Model/Objects/DashPattern.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/22/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - DashElementType
 
 enum DashElementType: String, Codable {
@@ -40,3 +41,4 @@ final class DashElement: Codable, DictionaryInitializable {
   let value: KeyframeGroup<LottieVector1D>
 
 }
+#endif

--- a/Sources/Private/Model/Objects/Mask.swift
+++ b/Sources/Private/Model/Objects/Mask.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - MaskMode
 
 enum MaskMode: String, Codable {
@@ -78,3 +79,4 @@ final class Mask: Codable, DictionaryInitializable {
 
   let expansion: KeyframeGroup<LottieVector1D>
 }
+#endif

--- a/Sources/Private/Model/Objects/Transform.swift
+++ b/Sources/Private/Model/Objects/Transform.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
+#if canImport(QuartzCore)
 /// The animatable transform for a layer. Controls position, rotation, scale, and opacity.
 final class Transform: Codable, DictionaryInitializable {
 
@@ -258,3 +259,4 @@ final class Transform: Codable, DictionaryInitializable {
   /// Here for the CodingKeys.rotation = "r". `r` and `rz` are the same.
   private let rotation: KeyframeGroup<LottieVector1D>?
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Ellipse.swift
+++ b/Sources/Private/Model/ShapeItems/Ellipse.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - PathDirection
 
 enum PathDirection: Int, Codable {
@@ -70,3 +71,4 @@ final class Ellipse: ShapeItem {
     case size = "s"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Fill.swift
+++ b/Sources/Private/Model/ShapeItems/Fill.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - FillRule
 
 enum FillRule: Int, Codable {
@@ -70,3 +71,4 @@ final class Fill: ShapeItem {
     case fillRule = "r"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/GradientFill.swift
+++ b/Sources/Private/Model/ShapeItems/GradientFill.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - GradientType
 
 enum GradientType: Int, Codable, Sendable {
@@ -133,3 +134,4 @@ final class GradientFill: ShapeItem {
     case colors = "k"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/GradientStroke.swift
+++ b/Sources/Private/Model/ShapeItems/GradientStroke.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - LineCap
 
 enum LineCap: Int, Codable, Sendable {
@@ -234,3 +235,4 @@ final class GradientStroke: ShapeItem {
     case colors = "k"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Group.swift
+++ b/Sources/Private/Model/ShapeItems/Group.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 /// An item that define a a group of shape items
 final class Group: ShapeItem {
 
@@ -44,3 +45,4 @@ final class Group: ShapeItem {
     case items = "it"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Merge.swift
+++ b/Sources/Private/Model/ShapeItems/Merge.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - MergeMode
 
 enum MergeMode: Int, Codable, Sendable {
@@ -54,3 +55,4 @@ final class Merge: ShapeItem {
     case mode = "mm"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Rectangle.swift
+++ b/Sources/Private/Model/ShapeItems/Rectangle.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 final class Rectangle: ShapeItem {
 
   // MARK: Lifecycle
@@ -68,3 +69,4 @@ final class Rectangle: ShapeItem {
     case cornerRadius = "r"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Repeater.swift
+++ b/Sources/Private/Model/ShapeItems/Repeater.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 final class Repeater: ShapeItem {
 
   // MARK: Lifecycle
@@ -170,3 +171,4 @@ final class Repeater: ShapeItem {
     case scale = "s"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/RoundedCorners.swift
+++ b/Sources/Private/Model/ShapeItems/RoundedCorners.swift
@@ -5,6 +5,7 @@
 //  Created by Duolingo on 10/31/22.
 //
 
+#if canImport(QuartzCore)
 // MARK: - RoundedCorners
 
 final class RoundedCorners: ShapeItem {
@@ -43,3 +44,4 @@ final class RoundedCorners: ShapeItem {
     case radius = "r"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Shape.swift
+++ b/Sources/Private/Model/ShapeItems/Shape.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 /// An item that defines an custom shape
 final class Shape: ShapeItem {
 
@@ -52,3 +53,4 @@ final class Shape: ShapeItem {
     case direction = "d"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/ShapeItem.swift
+++ b/Sources/Private/Model/ShapeItems/ShapeItem.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - ShapeType
 
 enum ShapeType: String, Codable, Sendable {
@@ -169,3 +170,4 @@ extension [ShapeItem] {
 /// All `ShapeItem` subclasses are immutable `Sendable` values.
 // swiftlint:disable:next no_unchecked_sendable
 extension ShapeItem: @unchecked Sendable { }
+#endif

--- a/Sources/Private/Model/ShapeItems/ShapeTransform.swift
+++ b/Sources/Private/Model/ShapeItems/ShapeTransform.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 final class ShapeTransform: ShapeItem {
 
   // MARK: Lifecycle
@@ -191,3 +192,4 @@ final class ShapeTransform: ShapeItem {
     case skewAxis = "sa"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Star.swift
+++ b/Sources/Private/Model/ShapeItems/Star.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - StarType
 
 enum StarType: Int, Codable, Sendable {
@@ -127,3 +128,4 @@ final class Star: ShapeItem {
     case starType = "sy"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Stroke.swift
+++ b/Sources/Private/Model/ShapeItems/Stroke.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 final class Stroke: ShapeItem {
 
   // MARK: Lifecycle
@@ -132,3 +133,4 @@ final class Stroke: ShapeItem {
     case dashPattern = "d"
   }
 }
+#endif

--- a/Sources/Private/Model/ShapeItems/Trim.swift
+++ b/Sources/Private/Model/ShapeItems/Trim.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - TrimType
 
 enum TrimType: Int, Codable {
@@ -81,3 +82,4 @@ final class Trim: ShapeItem {
     case trimType = "m"
   }
 }
+#endif

--- a/Sources/Private/Model/Text/Glyph.swift
+++ b/Sources/Private/Model/Text/Glyph.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
+#if canImport(QuartzCore)
 /// A model that holds a vector character
 final class Glyph: Codable, Sendable, DictionaryInitializable {
 
@@ -92,3 +93,4 @@ final class Glyph: Codable, Sendable, DictionaryInitializable {
     case shapes
   }
 }
+#endif

--- a/Sources/Private/Model/Text/TextAnimator.swift
+++ b/Sources/Private/Model/Text/TextAnimator.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
+#if canImport(QuartzCore)
 final class TextAnimator: Codable, DictionaryInitializable {
 
   // MARK: Lifecycle
@@ -192,3 +193,4 @@ final class TextAnimator: Codable, DictionaryInitializable {
     case opacity = "o"
   }
 }
+#endif

--- a/Sources/Private/Model/Text/TextDocument.swift
+++ b/Sources/Private/Model/Text/TextDocument.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
+#if canImport(QuartzCore)
 // MARK: - TextJustification
 
 enum TextJustification: Int, Codable {
@@ -119,3 +120,4 @@ final class TextDocument: Codable, DictionaryInitializable, AnyInitializable {
     case textFrameSize = "sz"
   }
 }
+#endif

--- a/Sources/Private/RootAnimationLayer.swift
+++ b/Sources/Private/RootAnimationLayer.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - RootAnimationLayer
@@ -51,3 +52,4 @@ enum AnimationKey {
   /// The primary animation always uses the given key
   case specific(String)
 }
+#endif

--- a/Sources/Private/Utility/Debugging/AnimatorNodeDebugging.swift
+++ b/Sources/Private/Utility/Debugging/AnimatorNodeDebugging.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/18/19.
 //
 
+#if canImport(QuartzCore)
 extension AnimatorNode {
 
   func printNodeTree() {
@@ -21,3 +22,4 @@ extension AnimatorNode {
   }
 
 }
+#endif

--- a/Sources/Private/Utility/Debugging/LayerDebugging.swift
+++ b/Sources/Private/Utility/Debugging/LayerDebugging.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/24/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - LayerDebugStyle
@@ -220,3 +221,4 @@ extension [LayerModel] {
   }
 
 }
+#endif

--- a/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
+++ b/Sources/Private/Utility/Extensions/AnimationKeypathExtension.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension KeypathSearchable {
@@ -301,3 +302,4 @@ enum KeyType {
   case wildcard
   case fuzzyWildcard
 }
+#endif

--- a/Sources/Private/Utility/Extensions/BlendMode+Filter.swift
+++ b/Sources/Private/Utility/Extensions/BlendMode+Filter.swift
@@ -5,6 +5,7 @@
 //  Created by Denis Koryttsev on 10.05.2022.
 //
 
+#if canImport(QuartzCore)
 extension BlendMode {
   /// The Core Image filter name for this `BlendMode`, that can be applied to a `CALayer`'s `compositingFilter`.
   /// Supported compositing filters are defined here: https://developer.apple.com/library/archive/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/uid/TP30000136-SW71
@@ -29,3 +30,4 @@ extension BlendMode {
     }
   }
 }
+#endif

--- a/Sources/Private/Utility/Extensions/CGColor+RGB.swift
+++ b/Sources/Private/Utility/Extensions/CGColor+RGB.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/7/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CGColor {
@@ -23,3 +24,4 @@ extension CGColor {
       components: [red, green, blue, alpha])!
   }
 }
+#endif

--- a/Sources/Private/Utility/Extensions/CGFloatExtensions.swift
+++ b/Sources/Private/Utility/Extensions/CGFloatExtensions.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 extension CGFloat {
@@ -150,3 +151,4 @@ extension CGFloat {
     return -1
   }
 }
+#endif

--- a/Sources/Private/Utility/Extensions/MathKit.swift
+++ b/Sources/Private/Utility/Extensions/MathKit.swift
@@ -6,6 +6,7 @@
 //
 // From https://github.com/buba447/UIToolBox
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -448,3 +449,4 @@ extension CGPoint {
       y: y + point.y)
   }
 }
+#endif

--- a/Sources/Private/Utility/Extensions/StringExtensions.swift
+++ b/Sources/Private/Utility/Extensions/StringExtensions.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -41,3 +42,4 @@ extension String {
   }
 
 }
+#endif

--- a/Sources/Private/Utility/Helpers/AnimationContext.swift
+++ b/Sources/Private/Utility/Helpers/AnimationContext.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// A completion block for animations.
@@ -90,3 +91,4 @@ class AnimationCompletionDelegate: NSObject, CAAnimationDelegate {
 
   let completionBlock: LottieCompletionBlock?
 }
+#endif

--- a/Sources/Private/Utility/Helpers/View+ValueChanged.swift
+++ b/Sources/Private/Utility/Helpers/View+ValueChanged.swift
@@ -1,7 +1,7 @@
 // Created by miguel_jimenez on 7/26/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-#if canImport(Combine) && canImport(SwiftUI)
+#if canImport(Combine) && canImport(SwiftUI) && canImport(QuartzCore)
 import Combine
 import SwiftUI
 

--- a/Sources/Private/Utility/Interpolatable/InterpolatableExtensions.swift
+++ b/Sources/Private/Utility/Interpolatable/InterpolatableExtensions.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/14/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -138,3 +139,4 @@ extension TextDocument: Interpolatable {
     return self
   }
 }
+#endif

--- a/Sources/Private/Utility/Interpolatable/KeyframeExtensions.swift
+++ b/Sources/Private/Utility/Interpolatable/KeyframeExtensions.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/14/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -44,3 +45,4 @@ extension Keyframe {
     return progress
   }
 }
+#endif

--- a/Sources/Private/Utility/Interpolatable/KeyframeInterpolator.swift
+++ b/Sources/Private/Utility/Interpolatable/KeyframeInterpolator.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/15/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -248,3 +249,4 @@ extension ContiguousArray {
   }
 
 }
+#endif

--- a/Sources/Private/Utility/LottieAnimationSource.swift
+++ b/Sources/Private/Utility/LottieAnimationSource.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 7/26/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 // MARK: - LottieAnimationSource
 
 /// A data source for a Lottie animation.
@@ -49,3 +50,4 @@ extension DotLottieFile {
     .dotLottieFile(self)
   }
 }
+#endif

--- a/Sources/Private/Utility/Primitives/BezierPath.swift
+++ b/Sources/Private/Utility/Primitives/BezierPath.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 
 // MARK: - BezierPath
@@ -484,3 +485,4 @@ extension BezierPath {
   }
 
 }
+#endif

--- a/Sources/Private/Utility/Primitives/BezierPathRoundExtension.swift
+++ b/Sources/Private/Utility/Primitives/BezierPathRoundExtension.swift
@@ -5,6 +5,7 @@
 //  Created by Duolingo on 11/1/22.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -156,3 +157,4 @@ extension BezierPath {
     return newPath
   }
 }
+#endif

--- a/Sources/Private/Utility/Primitives/ColorExtension.swift
+++ b/Sources/Private/Utility/Primitives/ColorExtension.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/14/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 
 // MARK: - LottieColor + Codable
@@ -99,3 +100,4 @@ extension LottieColor {
     .rgba(CGFloat(r), CGFloat(g), CGFloat(b), CGFloat(a))
   }
 }
+#endif

--- a/Sources/Private/Utility/Primitives/CompoundBezierPath.swift
+++ b/Sources/Private/Utility/Primitives/CompoundBezierPath.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/14/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -165,3 +166,4 @@ struct CompoundBezierPath {
   }
 
 }
+#endif

--- a/Sources/Private/Utility/Primitives/CurveVertex.swift
+++ b/Sources/Private/Utility/Primitives/CurveVertex.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/11/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -182,3 +183,4 @@ struct CurveVertex {
     return distance
   }
 }
+#endif

--- a/Sources/Private/Utility/Primitives/PathElement.swift
+++ b/Sources/Private/Utility/Primitives/PathElement.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/11/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -73,3 +74,4 @@ struct PathElement {
   }
 
 }
+#endif

--- a/Sources/Private/Utility/Primitives/VectorsExtensions.swift
+++ b/Sources/Private/Utility/Primitives/VectorsExtensions.swift
@@ -7,6 +7,7 @@
 
 import CoreGraphics
 import Foundation
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - LottieVector1D + Codable
@@ -361,3 +362,4 @@ extension CATransform3D {
   }
 
 }
+#endif

--- a/Sources/Public/Animation/LottieAnimation.swift
+++ b/Sources/Public/Animation/LottieAnimation.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/7/19.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 // MARK: - CoordinateSpace
@@ -177,3 +178,4 @@ public final class LottieAnimation: Codable, Sendable, DictionaryInitializable {
     })
   }
 }
+#endif

--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/5/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -318,3 +319,4 @@ extension LottieAnimation {
 ///
 // swiftlint:disable:next no_unchecked_sendable
 extension Foundation.Bundle: @unchecked Sendable { }
+#endif

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -3,6 +3,7 @@
 //  Lottie
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - LottieAnimationLayer
@@ -1520,3 +1521,4 @@ extension LottieLoopMode {
     }
   }
 }
+#endif

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/23/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - LottieBackgroundBehavior
@@ -1052,3 +1053,4 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   private let logger: LottieLogger
 }
+#endif

--- a/Sources/Public/Animation/LottieAnimationViewInitializers.swift
+++ b/Sources/Public/Animation/LottieAnimationViewInitializers.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/6/19.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 extension LottieAnimationView {
@@ -224,3 +225,4 @@ extension LottieAnimationView {
 enum LottieDownloadError: Error {
   case downloadFailed
 }
+#endif

--- a/Sources/Public/Animation/LottiePlaybackMode.swift
+++ b/Sources/Public/Animation/LottiePlaybackMode.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/3/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import Foundation
 
 // MARK: - LottiePlaybackMode
@@ -258,3 +259,4 @@ extension LottiePlaybackMode.PlaybackMode {
     }
   }
 }
+#endif

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -1,7 +1,7 @@
 // Created by Bryn Bodayle on 1/20/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 
 // MARK: - LottieView

--- a/Sources/Public/AnimationCache/AnimationCacheProvider.swift
+++ b/Sources/Public/AnimationCache/AnimationCacheProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/5/19.
 //
 
+#if canImport(QuartzCore)
 /// `AnimationCacheProvider` is a protocol that describes an Animation Cache.
 /// Animation Cache is used when loading `LottieAnimation` models. Using an Animation Cache
 /// can increase performance when loading an animation multiple times.
@@ -19,3 +20,4 @@ public protocol AnimationCacheProvider: AnyObject, Sendable {
   func clearCache()
 
 }
+#endif

--- a/Sources/Public/AnimationCache/DefaultAnimationCache.swift
+++ b/Sources/Public/AnimationCache/DefaultAnimationCache.swift
@@ -5,6 +5,7 @@
 //  Created by Marcelo Fabri on 10/18/22.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 // MARK: - DefaultAnimationCache
@@ -65,3 +66,4 @@ public class DefaultAnimationCache: AnimationCacheProvider {
 // making breaking changes.
 // swiftlint:disable:next no_unchecked_sendable
 extension DefaultAnimationCache: @unchecked Sendable { }
+#endif

--- a/Sources/Public/AnimationCache/LRUAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LRUAnimationCache.swift
@@ -5,7 +5,9 @@
 //  Created by Brandon Withrow on 2/5/19.
 //
 
+#if canImport(QuartzCore)
 @available(*, deprecated, message: """
   Use DefaultAnimationCache instead, which is thread-safe and automatically responds to memory pressure.
   """)
 public typealias LRUAnimationCache = DefaultAnimationCache
+#endif

--- a/Sources/Public/AnimationCache/LottieAnimationCache.swift
+++ b/Sources/Public/AnimationCache/LottieAnimationCache.swift
@@ -5,6 +5,7 @@
 //  Created by Marcelo Fabri on 10/17/22.
 //
 
+#if canImport(QuartzCore)
 /// A customization point to configure which `AnimationCacheProvider` will be used.
 public enum LottieAnimationCache {
 
@@ -13,3 +14,4 @@ public enum LottieAnimationCache {
   /// Defaults to DefaultAnimationCache.sharedCache.
   public static var shared: AnimationCacheProvider? = DefaultAnimationCache.sharedCache
 }
+#endif

--- a/Sources/Public/Configuration/LottieConfiguration.swift
+++ b/Sources/Public/Configuration/LottieConfiguration.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 12/13/21.
 // Copyright © 2021 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 /// Global configuration options for Lottie animations
@@ -45,3 +46,4 @@ public struct LottieConfiguration: Hashable {
   ///  - Defaults to `CGColorSpaceCreateDeviceRGB()`
   public var colorSpace: CGColorSpace
 }
+#endif

--- a/Sources/Public/Configuration/ReducedMotionOption.swift
+++ b/Sources/Public/Configuration/ReducedMotionOption.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 7/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -112,3 +113,4 @@ public struct SystemReducedMotionOptionProvider: ReducedMotionOptionProvider {
     #endif
   }
 }
+#endif

--- a/Sources/Public/Controls/AnimatedButton.swift
+++ b/Sources/Public/Controls/AnimatedButton.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -125,3 +126,4 @@ open class AnimatedButton: AnimatedControl {
     from: 0,
     to: 1)]
 }
+#endif

--- a/Sources/Public/Controls/AnimatedControl.swift
+++ b/Sources/Public/Controls/AnimatedControl.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -243,3 +244,4 @@ open class AnimatedControl: LottieControlType {
     animationView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
   }
 }
+#endif

--- a/Sources/Public/Controls/AnimatedSwitch.swift
+++ b/Sources/Public/Controls/AnimatedSwitch.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -268,4 +269,5 @@ class HapticGenerator: ImpactGenerator {
 class NullHapticGenerator: ImpactGenerator {
   func generateImpact() { }
 }
+#endif
 #endif

--- a/Sources/Public/Controls/LottieButton.swift
+++ b/Sources/Public/Controls/LottieButton.swift
@@ -1,7 +1,7 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 
 /// A wrapper which exposes Lottie's `AnimatedButton` to SwiftUI

--- a/Sources/Public/Controls/LottieSwitch.swift
+++ b/Sources/Public/Controls/LottieSwitch.swift
@@ -1,7 +1,7 @@
 // Created by Cal Stephens on 8/11/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && canImport(QuartzCore)
 import SwiftUI
 
 /// A wrapper which exposes Lottie's `AnimatedSwitch` to SwiftUI

--- a/Sources/Public/Controls/LottieViewType.swift
+++ b/Sources/Public/Controls/LottieViewType.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 8/11/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 #if canImport(UIKit)
 import UIKit
 
@@ -76,4 +77,5 @@ public struct LottieNSControlEvent: Equatable, Sendable {
     [AnyHashable(event.rawValue), AnyHashable(inside)]
   }
 }
+#endif
 #endif

--- a/Sources/Public/DotLottie/Cache/DotLottieCache.swift
+++ b/Sources/Public/DotLottie/Cache/DotLottieCache.swift
@@ -5,6 +5,7 @@
 //  Created by Evandro Hoffmann on 20/10/22.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 // MARK: - DotLottieCache
@@ -64,3 +65,4 @@ public class DotLottieCache: DotLottieCacheProvider {
 // redesign DotLottieCache to be properly Sendable without making breaking changes.
 // swiftlint:disable:next no_unchecked_sendable
 extension DotLottieCache: @unchecked Sendable { }
+#endif

--- a/Sources/Public/DotLottie/Cache/DotLottieCacheProvider.swift
+++ b/Sources/Public/DotLottie/Cache/DotLottieCacheProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Evandro Hoffmann on 20/10/22.
 //
 
+#if canImport(QuartzCore)
 /// `DotLottieCacheProvider` is a protocol that describes a DotLottie Cache.
 /// DotLottie Cache is used when loading `DotLottie` models. Using a DotLottie Cache
 /// can increase performance when loading an animation multiple times.
@@ -19,3 +20,4 @@ public protocol DotLottieCacheProvider: Sendable {
   func clearCache()
 
 }
+#endif

--- a/Sources/Public/DotLottie/DotLottieConfiguration.swift
+++ b/Sources/Public/DotLottie/DotLottieConfiguration.swift
@@ -5,6 +5,7 @@
 // Created by Evandro Hoffmann on 19/10/22.
 //
 
+#if canImport(QuartzCore)
 // MARK: - DotLottieConfiguration
 
 /// The `DotLottieConfiguration` model holds the presets extracted from DotLottieAnimation
@@ -70,3 +71,4 @@ public struct DotLottieConfigurationComponents: OptionSet {
   public let rawValue: Int
 
 }
+#endif

--- a/Sources/Public/DotLottie/DotLottieFile.swift
+++ b/Sources/Public/DotLottie/DotLottieFile.swift
@@ -5,6 +5,7 @@
 // Created by Evandro Harrison Hoffmann on 27/06/2020.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 // MARK: - DotLottieFile
@@ -152,3 +153,4 @@ extension String {
 // to make it truly thread-safe.
 // swiftlint:disable:next no_unchecked_sendable
 extension DotLottieFile: @unchecked Sendable { }
+#endif

--- a/Sources/Public/DotLottie/DotLottieFileHelpers.swift
+++ b/Sources/Public/DotLottie/DotLottieFileHelpers.swift
@@ -5,6 +5,7 @@
 //  Created by Evandro Hoffmann on 20/10/22.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 extension DotLottieFile {
@@ -371,3 +372,4 @@ extension DispatchQueue {
     label: "com.airbnb.lottie.dot-lottie",
     qos: .userInitiated)
 }
+#endif

--- a/Sources/Public/DynamicProperties/AnyValueProvider.swift
+++ b/Sources/Public/DynamicProperties/AnyValueProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/30/19.
 //
 
+#if canImport(QuartzCore)
 import Foundation
 
 // MARK: - AnyValueProvider
@@ -129,3 +130,4 @@ public enum AnyValueProviderStorage {
     }
   }
 }
+#endif

--- a/Sources/Public/DynamicProperties/ValueProviders/ColorValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/ColorValueProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -96,3 +97,4 @@ extension ColorValueProvider: Equatable {
     lhs.identity == rhs.identity
   }
 }
+#endif

--- a/Sources/Public/DynamicProperties/ValueProviders/FloatValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/FloatValueProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -81,3 +82,4 @@ extension FloatValueProvider: Equatable {
     lhs.identity == rhs.identity
   }
 }
+#endif

--- a/Sources/Public/DynamicProperties/ValueProviders/GradientValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/GradientValueProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Enrique Bermúdez on 10/27/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -138,3 +139,4 @@ extension GradientValueProvider: Equatable {
     lhs.identity == rhs.identity
   }
 }
+#endif

--- a/Sources/Public/DynamicProperties/ValueProviders/PointValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/PointValueProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -81,3 +82,4 @@ extension PointValueProvider: Equatable {
     lhs.identity == rhs.identity
   }
 }
+#endif

--- a/Sources/Public/DynamicProperties/ValueProviders/SizeValueProvider.swift
+++ b/Sources/Public/DynamicProperties/ValueProviders/SizeValueProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
+#if canImport(QuartzCore)
 import CoreGraphics
 import Foundation
 
@@ -81,3 +82,4 @@ extension SizeValueProvider: Equatable {
     lhs.identity == rhs.identity
   }
 }
+#endif

--- a/Sources/Public/ImageProvider/AnimationImageProvider.swift
+++ b/Sources/Public/ImageProvider/AnimationImageProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
+#if canImport(QuartzCore)
 import QuartzCore
 
 // MARK: - AnimationImageProvider
@@ -41,3 +42,4 @@ extension AnimationImageProvider {
     .resize
   }
 }
+#endif

--- a/Sources/Public/Keyframes/Interpolatable.swift
+++ b/Sources/Public/Keyframes/Interpolatable.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/24/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import CoreGraphics
 
 // MARK: - Interpolatable
@@ -277,3 +278,4 @@ struct Hold<T>: Interpolatable {
     }
   }
 }
+#endif

--- a/Sources/Public/Keyframes/Keyframe.swift
+++ b/Sources/Public/Keyframes/Keyframe.swift
@@ -1,6 +1,7 @@
 // Created by Cal Stephens on 1/24/22.
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
+#if canImport(QuartzCore)
 import CoreFoundation
 
 // MARK: - Keyframe
@@ -96,3 +97,4 @@ extension Keyframe: Hashable where T: Hashable {
 // MARK: Sendable
 
 extension Keyframe: Sendable where T: Sendable { }
+#endif

--- a/Sources/Public/TextProvider/AnimationTextProvider.swift
+++ b/Sources/Public/TextProvider/AnimationTextProvider.swift
@@ -5,6 +5,7 @@
 //  Created by Alexandr Goncharov on 07/06/2019.
 //
 
+#if canImport(QuartzCore)
 // MARK: - AnimationKeypathTextProvider
 
 /// Protocol for providing dynamic text to for a Lottie animation.
@@ -122,3 +123,4 @@ extension DefaultTextProvider: Equatable {
     true
   }
 }
+#endif

--- a/Sources/Public/iOS/AnimationSubview.swift
+++ b/Sources/Public/iOS/AnimationSubview.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Withrow on 2/4/19.
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && canImport(QuartzCore)
 import UIKit
 
 /// A view that can be added to a keypath of an AnimationView

--- a/Sources/Public/iOS/BundleImageProvider.swift
+++ b/Sources/Public/iOS/BundleImageProvider.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Withrow on 1/25/19.
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && canImport(QuartzCore)
 import UIKit
 
 /// An `AnimationImageProvider` that provides images by name from a specific bundle.

--- a/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
+++ b/Sources/Public/iOS/Compatibility/CompatibleAnimationView.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if canImport(UIKit) && canImport(QuartzCore)
 import UIKit
 
 /// An Objective-C compatible wrapper around Lottie's Animation class.

--- a/Sources/Public/iOS/FilepathImageProvider.swift
+++ b/Sources/Public/iOS/FilepathImageProvider.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-#if canImport(UIKit)
+#if canImport(UIKit) && canImport(QuartzCore)
 import UIKit
 
 /// Provides an image for a lottie animation from a provided Bundle.

--- a/Sources/Public/iOS/LottieAnimationViewBase.swift
+++ b/Sources/Public/iOS/LottieAnimationViewBase.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Withrow on 2/6/19.
 //
 
-#if canImport(UIKit)
+#if canImport(UIKit) && canImport(QuartzCore)
 import UIKit
 
 /// The base view for `LottieAnimationView` on iOS, tvOS, watchOS, and macCatalyst.

--- a/Tests/Utils/HardcodedFontProvider.swift
+++ b/Tests/Utils/HardcodedFontProvider.swift
@@ -2,6 +2,7 @@
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
 import Lottie
+#if canImport(QuartzCore)
 import QuartzCore
 #if os(iOS)
 import UIKit
@@ -17,3 +18,4 @@ struct HardcodedFontProvider: AnimationFontProvider {
     font
   }
 }
+#endif

--- a/Tests/Utils/HardcodedImageProvider.swift
+++ b/Tests/Utils/HardcodedImageProvider.swift
@@ -2,6 +2,7 @@
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
 import Lottie
+#if canImport(QuartzCore)
 import QuartzCore
 #if os(iOS)
 import UIKit
@@ -25,3 +26,4 @@ struct HardcodedImageProvider: AnimationImageProvider {
     .resizeAspectFill
   }
 }
+#endif


### PR DESCRIPTION
For some reason Xcode watchOS SwiftUI preview attempts to build this package against watchOS SDK.

Fixed by adding `canImport(QuartzCore)` check to all files, it also might be replaced with `!os(watchOS)`.

Tested with:
- iOS Preview
- watchOS Preview
- iOS build
- watchOS build

Additional info: https://developer.apple.com/forums/thread/731732

[Here is](https://github.com/sergeirr/WatchOSLottie) an example project to reproduce the issue.
You can try to build this package to "Any watchOS" target as well.
CI check step also can be added to build this package to watchOS target.