### PR TITLE
Allow configuring specific LottieView properties

### DIFF
--- a/Example/Example/LottieViewLayoutDemoView.swift
+++ b/Example/Example/LottieViewLayoutDemoView.swift
@@ -9,10 +9,11 @@ struct LottieViewLayoutDemoView: View {
     HStack {
       VStack {
         LottieView(animation: .named("Samples/LottieLogo1"))
+          .configure(\.contentMode, value: .scaleAspectFit)
           .looping()
           .frame(maxWidth: 100)
 
-        Text("maxWidth: 100")
+        Text("maxWidth: 100, contentMode: .scaleAspectFit")
       }
 
       VStack {

--- a/Example/Example/LottieViewLayoutDemoView.swift
+++ b/Example/Example/LottieViewLayoutDemoView.swift
@@ -9,7 +9,7 @@ struct LottieViewLayoutDemoView: View {
     HStack {
       VStack {
         LottieView(animation: .named("Samples/LottieLogo1"))
-          .configure(\.contentMode, value: .scaleAspectFit)
+          .configure(\.contentMode, to: .scaleAspectFit)
           .looping()
           .frame(maxWidth: 100)
 

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -141,6 +141,16 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     }
   }
 
+  /// Returns a copy of this `LottieView` updated to have the specific configuration property
+  /// applied to its represented `LottieAnimationView` whenever it is updated via the `updateUIView(...)`
+  /// or `updateNSView(...)` methods.
+  public func configure<Property>(
+    _ property: ReferenceWritableKeyPath<LottieAnimationView, Property>,
+    value: Property
+  ) -> Self {
+    configure { $0[keyPath: property] = value }
+  }
+
   /// Returns a copy of this `LottieView` updated to have the given closure applied to its
   /// represented `LottieAnimationView` whenever it is updated via the `updateUIView(…)`
   /// or `updateNSView(…)` method.

--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -144,16 +144,39 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
   /// Returns a copy of this `LottieView` updated to have the specific configuration property
   /// applied to its represented `LottieAnimationView` whenever it is updated via the `updateUIView(...)`
   /// or `updateNSView(...)` methods.
+  ///
+  /// - note: This configuration will be applied on every SwiftUI render pass.
+  ///         Be wary of applying heavy side-effects as configuration values.
   public func configure<Property>(
     _ property: ReferenceWritableKeyPath<LottieAnimationView, Property>,
-    value: Property
-  ) -> Self {
+    to value: Property)
+    -> Self
+  {
     configure { $0[keyPath: property] = value }
+  }
+
+  /// Returns a copy of this `LottieView` updated to have the specific configuration property
+  /// applied to its represented `LottieAnimationView` whenever it is updated via the `updateUIView(...)`
+  /// or `updateNSView(...)` methods.
+  ///
+  /// - note: If the `value` is already the currently-applied configuration value, it won't be applied
+  public func configure<Property: Equatable>(
+    _ property: ReferenceWritableKeyPath<LottieAnimationView, Property>,
+    to value: Property)
+    -> Self
+  {
+    configure {
+      guard $0[keyPath: property] != value else { return }
+      $0[keyPath: property] = value
+    }
   }
 
   /// Returns a copy of this `LottieView` updated to have the given closure applied to its
   /// represented `LottieAnimationView` whenever it is updated via the `updateUIView(…)`
   /// or `updateNSView(…)` method.
+  ///
+  /// - note: This configuration closure will be executed on every SwiftUI render pass.
+  ///         Be wary of applying heavy side-effects inside it.
   public func configure(_ configure: @escaping (LottieAnimationView) -> Void) -> Self {
     var copy = self
     copy.configurations.append { context in


### PR DESCRIPTION
This is just a tiny helper method that makes configuring specific properties on the internal LottieAnimationView a bit nicer.

It means you can directly do:
```swift
LottieView(...)
    .configure(\.contentMode, .scaleAspectFit)
```

Without opening up an entire closure, which feels a bit more ergonomic and clean in most use-cases.

Let me know your thoughts :) 