### PR TITLE
Lottie 2.5.3 not use any file timestamp APIs, so remove it form PrivacyInfo.xcprivacy

### DIFF
--- a/Lottie/PrivacyInfo.xcprivacy
+++ b/Lottie/PrivacyInfo.xcprivacy
@@ -9,15 +9,6 @@
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>3B52.1</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 </dict>
 </plist>

--- a/lottie-ios.podspec
+++ b/lottie-ios.podspec
@@ -36,9 +36,7 @@ For the first time, designers can create and ship beautiful animations without a
                           'lottie-ios/Classes/Private/LOTAnimatedSwitch.m',
                           'lottie-ios/Classes/PublicHeaders/LOTAnimatedControl.h',
                           'lottie-ios/Classes/Private/LOTAnimatedControl.m']
-  s.resource_bundles = {
-'LottiePrivacyInfo' => ['Lottie/PrivacyInfo.xcprivacy']
-}
+  s.resource_bundles = {'Lottie' => ['Lottie/PrivacyInfo.xcprivacy']}
 
   s.public_header_files = 'lottie-ios/Classes/PublicHeaders/*.h'
   s.ios.frameworks = 'UIKit'


### PR DESCRIPTION
Lottie 2.5.3 not use any file timestamp APIs, so remove it form PrivacyInfo.xcprivacy, keep PrivacyInfo empty is ok.