### PR TITLE
Update links for repositories moved to the swiftlang org on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can pull the [Lottie Github Repo](https://github.com/airbnb/lottie-ios/) and
 
 ### Swift Package Manager
 
-To install Lottie using [Swift Package Manager](https://github.com/apple/swift-package-manager) you can follow the [tutorial published by Apple](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app) using the URL for the Lottie repo with the current version:
+To install Lottie using [Swift Package Manager](https://github.com/swiftlang/swift-package-manager) you can follow the [tutorial published by Apple](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app) using the URL for the Lottie repo with the current version:
 
 1. In Xcode, select “File” → “Add Packages...”
 1. Enter https://github.com/airbnb/lottie-spm.git

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Logging/EpoxyLogger.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Logging/EpoxyLogger.swift
@@ -11,14 +11,14 @@ final class EpoxyLogger {
     assert: @escaping Assert = { condition, message, file, line in
       // If we default to `Swift.assert` directly with `assert: Assert = Swift.assert`,
       // the call will unexpectedly not respect the -O flag and will crash in release
-      // https://github.com/apple/swift/issues/60249
+      // https://github.com/swiftlang/swift/issues/60249
       Swift.assert(condition(), message(), file: file, line: line)
     },
     assertionFailure: @escaping AssertionFailure = { message, file, line in
       // If we default to `Swift.assertionFailure` directly with
       // `assertionFailure: AssertionFailure = Swift.assertionFailure`,
       // the call will unexpectedly not respect the -O flag and will crash in release
-      // https://github.com/apple/swift/issues/60249
+      // https://github.com/swiftlang/swift/issues/60249
       Swift.assertionFailure(message(), file: file, line: line)
     },
     warn: @escaping Warn = { message, _, _ in

--- a/Sources/Public/Logging/LottieLogger.swift
+++ b/Sources/Public/Logging/LottieLogger.swift
@@ -13,14 +13,14 @@ public final class LottieLogger {
     assert: @escaping Assert = { condition, message, file, line in
       // If we default to `Swift.assert` directly with `assert: Assert = Swift.assert`,
       // the call will unexpectedly not respect the -O flag and will crash in release
-      // https://github.com/apple/swift/issues/60249
+      // https://github.com/swiftlang/swift/issues/60249
       Swift.assert(condition(), message(), file: file, line: line)
     },
     assertionFailure: @escaping AssertionFailure = { message, file, line in
       // If we default to `Swift.assertionFailure` directly with
       // `assertionFailure: AssertionFailure = Swift.assertionFailure`,
       // the call will unexpectedly not respect the -O flag and will crash in release
-      // https://github.com/apple/swift/issues/60249
+      // https://github.com/swiftlang/swift/issues/60249
       Swift.assertionFailure(message(), file: file, line: line)
     },
     warn: @escaping Warn = { message, _, _ in


### PR DESCRIPTION
### Summary:

Update links for repositories moved to the swiftlang org on GitHub

### Modifications:

Update the link
+ https://github.com/apple/swift/ => https://github.com/swiftlang/swift/
+ https://github.com/apple/swift-package-manager  =>  https://github.com/swiftlang/swift-package-manager

### Result:

Correct the reference
+ https://github.com/apple/swift/ => https://github.com/swiftlang/swift/
+ https://github.com/apple/swift-package-manager  =>  https://github.com/swiftlang/swift-package-manager
