### PR TITLE
LottieAnimationView: update `getValue(for:atFrame:)` docs.

### DIFF
--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -677,8 +677,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Returns nil if no property is found.
   ///
   /// Note: This method isn't supported by the Core Animation rendering engine and will always return `nil` if used.
-  /// It is still supported by the Main Thread rendering engine. You can read more about it at ``currentRenderingEngine``,
-  /// and it can be set through the view's ``configuration``.
+  /// It is still supported by the Main Thread rendering engine.
   ///
   /// - Parameter for: The keypath used to search for the property.
   /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -676,6 +676,10 @@ open class LottieAnimationView: LottieAnimationViewBase {
   /// Reads the value of a property specified by the Keypath.
   /// Returns nil if no property is found.
   ///
+  /// Note: This method isn't supported by the Core Animation rendering engine and will always return `nil` if used.
+  /// It is still supported by the Main Thread rendering engine. You can read more about it at ``currentRenderingEngine``,
+  /// and it can be set through the view's ``configuration``.
+  ///
   /// - Parameter for: The keypath used to search for the property.
   /// - Parameter atFrame: The Frame Time of the value to query. If nil then the current frame is used.
   public func getValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any? {


### PR DESCRIPTION
The docs of this method weren't updated, this method will not work as expected when the Core Animation rendering engine is used. You can read more about it at the associated discussion: https://github.com/airbnb/lottie-ios/discussions/2398 .