### PR TITLE
Fix frame conversion in `LottieAnimationLayer.pause(at: .marker(...))`

### DIFF
--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -381,9 +381,9 @@ public class LottieAnimationLayer: CALayer {
 
       switch position {
       case .start:
-        currentTime = from.frameTime
+        currentFrame = from.frameTime
       case .end:
-        currentTime = from.frameTime + from.durationFrameTime
+        currentFrame = from.frameTime + from.durationFrameTime
       }
     }
 


### PR DESCRIPTION
This PR fixes a time conversion bug in `LottieAnimationLayer.pause(at: .marker(...))`.

We were previously setting `currentTime = from.frameTime`. `currentTime` is a value in seconds (`TimeInterval`), but `frameTime` is a value in frames (`AnimationFrameTime`). The correct implementation sets `currentFrame` instead.