### PR TITLE
Simplify contains(where:) with Key Paths

### DIFF
--- a/Sources/Private/CoreAnimation/Layers/ShapeItemLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/ShapeItemLayer.swift
@@ -24,7 +24,7 @@ final class ShapeItemLayer: BaseAnimationLayer {
       "`ShapeItemLayer` must contain exactly one `ShapeItem` that draws a `GPPath`")
 
     try context.compatibilityAssert(
-      !otherItems.contains(where: { $0.item.drawsCGPath }),
+      !otherItems.contains(where: \.item.drawsCGPath),
       "`ShapeItemLayer` must contain exactly one `ShapeItem` that draws a `GPPath`")
 
     super.init()

--- a/Sources/Private/CoreAnimation/Layers/ShapeLayer.swift
+++ b/Sources/Private/CoreAnimation/Layers/ShapeLayer.swift
@@ -259,7 +259,7 @@ extension CALayer {
     // but in practice can be any combination of items. The implementation expects all path-drawing
     // shape items to be managed by a `GroupLayer`, so if there's a top-level path item we
     // have to create a placeholder group.
-    if parentGroup == nil, otherItems.contains(where: { $0.item.drawsCGPath }) {
+    if parentGroup == nil, otherItems.contains(where: \.item.drawsCGPath) {
       groupItems = [Group(items: items.map { $0.item }, name: "")]
       otherItems = []
     }

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -65,7 +65,7 @@ final class SnapshotTests: XCTestCase {
 
       XCTAssert(
         Samples.sampleAnimationURLs.contains(where: { $0.absoluteString.hasSuffix("\(animationName).json") })
-        || Samples.sampleAnimationURLs.contains(where: { $0.absoluteString.hasSuffix("\(animationName).lottie") }),
+          || Samples.sampleAnimationURLs.contains(where: { $0.absoluteString.hasSuffix("\(animationName).lottie") }),
         "Snapshot \"\(snapshotURL.lastPathComponent)\" has no corresponding sample animation. Expecting \(animationName).json|.lottie")
     }
   }

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -64,8 +64,8 @@ final class SnapshotTests: XCTestCase {
       animationName = animationName.replacingOccurrences(of: "-", with: "/")
 
       XCTAssert(
-        Samples.sampleAnimationURLs.contains(where: { $0.absoluteString.hasSuffix("\(animationName).json") })
-          || Samples.sampleAnimationURLs.contains(where: { $0.absoluteString.hasSuffix("\(animationName).lottie") }),
+        Samples.sampleAnimationURLs.contains(where: \.absoluteString.hasSuffix("\(animationName).json"))
+          || Samples.sampleAnimationURLs.contains(where: \.absoluteString.hasSuffix("\(animationName).lottie")),
         "Snapshot \"\(snapshotURL.lastPathComponent)\" has no corresponding sample animation. Expecting \(animationName).json|.lottie")
     }
   }

--- a/Tests/SnapshotTests.swift
+++ b/Tests/SnapshotTests.swift
@@ -64,8 +64,8 @@ final class SnapshotTests: XCTestCase {
       animationName = animationName.replacingOccurrences(of: "-", with: "/")
 
       XCTAssert(
-        Samples.sampleAnimationURLs.contains(where: \.absoluteString.hasSuffix("\(animationName).json"))
-          || Samples.sampleAnimationURLs.contains(where: \.absoluteString.hasSuffix("\(animationName).lottie")),
+        Samples.sampleAnimationURLs.contains(where: { $0.absoluteString.hasSuffix("\(animationName).json") })
+        || Samples.sampleAnimationURLs.contains(where: { $0.absoluteString.hasSuffix("\(animationName).lottie") }),
         "Snapshot \"\(snapshotURL.lastPathComponent)\" has no corresponding sample animation. Expecting \(animationName).json|.lottie")
     }
   }


### PR DESCRIPTION
Swapped out a few `contains(where:)` calls with key path syntax for cleaner code.