### PR TITLE
Add possibility to remove ValueProvider

### DIFF
--- a/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "570a44d70ad213b218bf7f5ebda4b1039c8fcc9f31854902e91f484af1d6cfc3",
   "pins" : [
     {
       "identity" : "difference",
@@ -10,24 +11,6 @@
       }
     },
     {
-      "identity" : "swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/swift",
-      "state" : {
-        "revision" : "6900f5ab7ab7394ac85eb9da52b2528ee329b206",
-        "version" : "1.0.4"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
-      "state" : {
-        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
-        "version" : "1.2.0"
-      }
-    },
-    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
@@ -36,5 +19,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lottie.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "570a44d70ad213b218bf7f5ebda4b1039c8fcc9f31854902e91f484af1d6cfc3",
   "pins" : [
     {
       "identity" : "difference",
@@ -11,6 +10,24 @@
       }
     },
     {
+      "identity" : "swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/swift",
+      "state" : {
+        "revision" : "6900f5ab7ab7394ac85eb9da52b2528ee329b206",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
@@ -19,5 +36,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -495,6 +495,14 @@ extension CoreAnimationLayer: RootAnimationLayer {
     rebuildCurrentAnimation()
   }
 
+  func removeValueProvider(keypath: AnimationKeypath) {
+    valueProviderStore.removeValueProvider(keypath: keypath)
+
+    // We need to rebuild the current animation after removing a value provider,
+    // since any existing `CAAnimation`s could now be out of date.
+    rebuildCurrentAnimation()
+  }
+
   func getValue(for _: AnimationKeypath, atFrame _: AnimationFrameTime?) -> Any? {
     logger.assertionFailure("""
       The Core Animation rendering engine doesn't support querying values for individual frames

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -495,8 +495,8 @@ extension CoreAnimationLayer: RootAnimationLayer {
     rebuildCurrentAnimation()
   }
 
-  func removeValueProvider(keypath: AnimationKeypath) {
-    valueProviderStore.removeValueProvider(keypath: keypath)
+  func removeValueProvider(for keypath: AnimationKeypath) {
+    valueProviderStore.removeValueProvider(for: keypath)
 
     // We need to rebuild the current animation after removing a value provider,
     // since any existing `CAAnimation`s could now be out of date.

--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -41,7 +41,7 @@ final class ValueProviderStore {
   }
 
   /// Removes all ValueProviders for the given `AnimationKeypath`
-  func removeValueProvider(keypath: AnimationKeypath) {
+  func removeValueProvider(for keypath: AnimationKeypath) {
       valueProviders.removeAll(where: { $0.keypath == keypath })
   }
 

--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -40,6 +40,11 @@ final class ValueProviderStore {
     valueProviders.append((keypath: keypath, valueProvider: valueProvider))
   }
 
+  /// Removes all ValueProviders for the given `AnimationKeypath`
+  func removeValueProvider(keypath: AnimationKeypath) {
+      valueProviders.removeAll(where: { $0.keypath == keypath })
+  }
+
   /// Retrieves the custom value keyframes for the given property,
   /// if an `AnyValueProvider` was registered for the given keypath.
   func customKeyframes<Value>(

--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -42,7 +42,7 @@ final class ValueProviderStore {
 
   /// Removes all ValueProviders for the given `AnimationKeypath`
   func removeValueProvider(for keypath: AnimationKeypath) {
-    valueProviders.removeAll(where: { $0.keypath == keypath })
+    valueProviders.removeAll(where: { $0.keypath.matches(keypath) })
   }
 
   /// Retrieves the custom value keyframes for the given property,

--- a/Sources/Private/CoreAnimation/ValueProviderStore.swift
+++ b/Sources/Private/CoreAnimation/ValueProviderStore.swift
@@ -42,7 +42,7 @@ final class ValueProviderStore {
 
   /// Removes all ValueProviders for the given `AnimationKeypath`
   func removeValueProvider(for keypath: AnimationKeypath) {
-      valueProviders.removeAll(where: { $0.keypath == keypath })
+    valueProviders.removeAll(where: { $0.keypath == keypath })
   }
 
   /// Retrieves the custom value keyframes for the given property,

--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -241,7 +241,7 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
     }
   }
 
-  func removeValueProvider(keypath: AnimationKeypath) {
+  func removeValueProvider(for keypath: AnimationKeypath) {
     for layer in animationLayers {
       if let foundProperties = layer.nodeProperties(for: keypath) {
         for property in foundProperties {

--- a/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/MainThreadAnimationLayer.swift
@@ -241,6 +241,17 @@ final class MainThreadAnimationLayer: CALayer, RootAnimationLayer {
     }
   }
 
+  func removeValueProvider(keypath: AnimationKeypath) {
+    for layer in animationLayers {
+      if let foundProperties = layer.nodeProperties(for: keypath) {
+        for property in foundProperties {
+          property.removeProvider()
+        }
+        layer.displayWithFrame(frame: presentation()?.currentFrame ?? currentFrame, forceUpdates: true)
+      }
+    }
+  }
+
   func getValue(for keypath: AnimationKeypath, atFrame: CGFloat?) -> Any? {
     for layer in animationLayers {
       if

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/NodeProperty.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/NodeProperty.swift
@@ -45,6 +45,11 @@ class NodeProperty<T>: AnyNodeProperty {
     valueContainer.setNeedsUpdate()
   }
 
+  func removeProvider() {
+    valueProvider = originalValueProvider
+    valueContainer.setNeedsUpdate()
+  }
+
   func update(frame: CGFloat) {
     typedContainer.setValue(valueProvider.value(frame: frame), forFrame: frame)
   }

--- a/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/AnyNodeProperty.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/NodeProperties/Protocols/AnyNodeProperty.swift
@@ -33,6 +33,9 @@ protocol AnyNodeProperty {
 
   /// Sets the value provider for the property.
   func setProvider(provider: AnyValueProvider)
+
+  /// Removes the value provider for the property.
+  func removeProvider()
 }
 
 extension AnyNodeProperty {

--- a/Sources/Private/RootAnimationLayer.swift
+++ b/Sources/Private/RootAnimationLayer.swift
@@ -36,6 +36,7 @@ protocol RootAnimationLayer: CALayer {
   func logHierarchyKeypaths()
   func allHierarchyKeypaths() -> [String]
   func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath)
+  func removeValueProvider(keypath: AnimationKeypath)
   func getValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any?
   func getOriginalValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any?
 

--- a/Sources/Private/RootAnimationLayer.swift
+++ b/Sources/Private/RootAnimationLayer.swift
@@ -36,7 +36,7 @@ protocol RootAnimationLayer: CALayer {
   func logHierarchyKeypaths()
   func allHierarchyKeypaths() -> [String]
   func setValueProvider(_ valueProvider: AnyValueProvider, keypath: AnimationKeypath)
-  func removeValueProvider(keypath: AnimationKeypath)
+  func removeValueProvider(for keypath: AnimationKeypath)
   func getValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any?
   func getOriginalValue(for keypath: AnimationKeypath, atFrame: AnimationFrameTime?) -> Any?
 

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -854,11 +854,11 @@ public class LottieAnimationLayer: CALayer {
     animationLayer.setValueProvider(valueProvider, keypath: keypath)
   }
 
-  public func removeValueProvider(keypath: AnimationKeypath) {
+  public func removeValueProvider(for keypath: AnimationKeypath) {
     guard let animationLayer = rootAnimationLayer else { return }
 
     valueProviders[keypath] = nil
-    animationLayer.removeValueProvider(keypath: keypath)
+    animationLayer.removeValueProvider(for: keypath)
   }
 
   /// Reads the value of a property specified by the Keypath.

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -857,7 +857,10 @@ public class LottieAnimationLayer: CALayer {
   public func removeValueProvider(for keypath: AnimationKeypath) {
     guard let animationLayer = rootAnimationLayer else { return }
 
-    valueProviders[keypath] = nil
+    valueProviders.forEach {
+      guard $0.key.matches(keypath) else { return }
+      valueProviders[$0.key] = nil
+    }
     animationLayer.removeValueProvider(for: keypath)
   }
 

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -854,6 +854,13 @@ public class LottieAnimationLayer: CALayer {
     animationLayer.setValueProvider(valueProvider, keypath: keypath)
   }
 
+  public func removeValueProvider(keypath: AnimationKeypath) {
+    guard let animationLayer = rootAnimationLayer else { return }
+
+    valueProviders[keypath] = nil
+    animationLayer.removeValueProvider(keypath: keypath)
+  }
+
   /// Reads the value of a property specified by the Keypath.
   /// Returns nil if no property is found.
   ///

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -675,8 +675,8 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   /// Sets a ValueProvider for the specified keypath. The value provider will be removed
   /// on all properties that match the keypath.
-  public func removeValueProvider(keypath: AnimationKeypath) {
-    lottieAnimationLayer.removeValueProvider(keypath: keypath)
+  public func removeValueProvider(for keypath: AnimationKeypath) {
+    lottieAnimationLayer.removeValueProvider(for: keypath)
   }
 
   /// Reads the value of a property specified by the Keypath.

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -673,6 +673,12 @@ open class LottieAnimationView: LottieAnimationViewBase {
     lottieAnimationLayer.setValueProvider(valueProvider, keypath: keypath)
   }
 
+  /// Sets a ValueProvider for the specified keypath. The value provider will be removed
+  /// on all properties that match the keypath.
+  public func removeValueProvider(keypath: AnimationKeypath) {
+    lottieAnimationLayer.removeValueProvider(keypath: keypath)
+  }
+
   /// Reads the value of a property specified by the Keypath.
   /// Returns nil if no property is found.
   ///

--- a/Sources/Public/Controls/AnimatedControl.swift
+++ b/Sources/Public/Controls/AnimatedControl.swift
@@ -190,6 +190,11 @@ open class AnimatedControl: LottieControlType {
     animationView.setValueProvider(valueProvider, keypath: keypath)
   }
 
+  /// Removes a ValueProvider for the specified keypath
+  public func removeValueProvider(keypath: AnimationKeypath) {
+    animationView.removeValueProvider(keypath: keypath)
+  }
+
   // MARK: Internal
 
   var stateMap: [UInt: String] = [:]

--- a/Sources/Public/Controls/AnimatedControl.swift
+++ b/Sources/Public/Controls/AnimatedControl.swift
@@ -191,8 +191,8 @@ open class AnimatedControl: LottieControlType {
   }
 
   /// Removes a ValueProvider for the specified keypath
-  public func removeValueProvider(keypath: AnimationKeypath) {
-    animationView.removeValueProvider(keypath: keypath)
+  public func removeValueProvider(for keypath: AnimationKeypath) {
+    animationView.removeValueProvider(for: keypath)
   }
 
   // MARK: Internal

--- a/Tests/ValueProvidersTests.swift
+++ b/Tests/ValueProvidersTests.swift
@@ -76,5 +76,15 @@ final class ValueProvidersTests: XCTestCase {
       for: "Layer.Shape Group.Stroke 1.Color",
       context: animationContext)
     XCTAssertEqual(keyFramesQuery4?.keyframes.map(\.value.components), [[0, 0, 0, 1]])
+
+      // Test removing specific keypath
+      let keypathToRemove: AnimationKeypath = "**.Color"
+      store.setValueProvider(ColorValueProvider(.black), keypath: keypathToRemove)
+      store.removeValueProvider(for: keypathToRemove)
+      let keyFramesQuery5 = try store.customKeyframes(
+        of: .color,
+        for: "Layer.Shape Group.Stroke 1.Color",
+        context: animationContext)
+      XCTAssertNil(keyFramesQuery5)
   }
 }

--- a/Tests/ValueProvidersTests.swift
+++ b/Tests/ValueProvidersTests.swift
@@ -77,14 +77,14 @@ final class ValueProvidersTests: XCTestCase {
       context: animationContext)
     XCTAssertEqual(keyFramesQuery4?.keyframes.map(\.value.components), [[0, 0, 0, 1]])
 
-      // Test removing specific keypath
-      let keypathToRemove: AnimationKeypath = "**.Color"
-      store.setValueProvider(ColorValueProvider(.black), keypath: keypathToRemove)
-      store.removeValueProvider(for: keypathToRemove)
-      let keyFramesQuery5 = try store.customKeyframes(
-        of: .color,
-        for: "Layer.Shape Group.Stroke 1.Color",
-        context: animationContext)
-      XCTAssertNil(keyFramesQuery5)
+    // Test removing specific keypath
+    let keypathToRemove: AnimationKeypath = "**.Color"
+    store.setValueProvider(ColorValueProvider(.black), keypath: keypathToRemove)
+    store.removeValueProvider(for: keypathToRemove)
+    let keyFramesQuery5 = try store.customKeyframes(
+      of: .color,
+      for: "Layer.Shape Group.Stroke 1.Color",
+      context: animationContext)
+    XCTAssertNil(keyFramesQuery5)
   }
 }

--- a/Tests/ValueProvidersTests.swift
+++ b/Tests/ValueProvidersTests.swift
@@ -86,5 +86,14 @@ final class ValueProvidersTests: XCTestCase {
       for: "Layer.Shape Group.Stroke 1.Color",
       context: animationContext)
     XCTAssertNil(keyFramesQuery5)
+
+    // Test removing wildcard keypath
+    store.setValueProvider(ColorValueProvider(.black), keypath: "**1.Color")
+    store.removeValueProvider(for: "**.Color")
+    let keyFramesQuery6 = try store.customKeyframes(
+      of: .color,
+      for: "Layer.Shape Group.Stroke 1.Color",
+      context: animationContext)
+    XCTAssertNil(keyFramesQuery6)
   }
 }


### PR DESCRIPTION
### Summary
Previously, when the `animation` property was set, all ValueProviders for AnimatioView were reset (see https://github.com/airbnb/lottie-ios/issues/920). Now it's not so (see https://github.com/airbnb/lottie-ios/discussions/2390)