### PR TITLE
Xcode 16: fix warnings for types that inherit `@unchecked Sendable`

### DIFF
--- a/Sources/Private/CoreAnimation/Animations/CombinedShapeAnimation.swift
+++ b/Sources/Private/CoreAnimation/Animations/CombinedShapeAnimation.swift
@@ -82,3 +82,10 @@ extension CombinedShapeItem {
       name: name)
   }
 }
+
+// MARK: Sendable
+
+/// `CombinedShapeItem` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension CombinedShapeItem: @unchecked Sendable { }

--- a/Sources/Private/Model/Assets/ImageAsset.swift
+++ b/Sources/Private/Model/Assets/ImageAsset.swift
@@ -131,3 +131,10 @@ extension ImageAsset {
     #endif
   }
 }
+
+// MARK: - ImageAsset + Sendable
+
+/// `ImageAsset` inherits `@unchecked Sendable` from `Asset` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension ImageAsset: @unchecked Sendable { }

--- a/Sources/Private/Model/Assets/PrecompAsset.swift
+++ b/Sources/Private/Model/Assets/PrecompAsset.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/9/19.
 //
 
+// MARK: - PrecompAsset
+
 final class PrecompAsset: Asset {
 
   // MARK: Lifecycle
@@ -36,3 +38,10 @@ final class PrecompAsset: Asset {
     try container.encode(layers, forKey: .layers)
   }
 }
+
+// MARK: Sendable
+
+/// `PrecompAsset` inherits `@unchecked Sendable` from `Asset` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension PrecompAsset: @unchecked Sendable { }

--- a/Sources/Private/Model/LayerEffects/DropShadowEffect.swift
+++ b/Sources/Private/Model/LayerEffects/DropShadowEffect.swift
@@ -1,6 +1,8 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+// MARK: - DropShadowEffect
+
 final class DropShadowEffect: LayerEffect {
 
   // MARK: Lifecycle
@@ -41,3 +43,10 @@ final class DropShadowEffect: LayerEffect {
   }
 
 }
+
+// MARK: Sendable
+
+/// `DropShadowEffect` inherits `@unchecked Sendable` from `LayerEffect` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension DropShadowEffect: @unchecked Sendable { }

--- a/Sources/Private/Model/LayerEffects/EffectValues/ColorEffectValue.swift
+++ b/Sources/Private/Model/LayerEffects/EffectValues/ColorEffectValue.swift
@@ -1,6 +1,8 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+// MARK: - ColorEffectValue
+
 final class ColorEffectValue: EffectValue {
 
   // MARK: Lifecycle
@@ -34,3 +36,10 @@ final class ColorEffectValue: EffectValue {
     case value = "v"
   }
 }
+
+// MARK: Sendable
+
+/// `ColorEffectValue` inherits `@unchecked Sendable` from `EffectValue` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension ColorEffectValue: @unchecked Sendable { }

--- a/Sources/Private/Model/LayerEffects/EffectValues/Vector1DEffectValue.swift
+++ b/Sources/Private/Model/LayerEffects/EffectValues/Vector1DEffectValue.swift
@@ -1,6 +1,8 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+// MARK: - Vector1DEffectValue
+
 final class Vector1DEffectValue: EffectValue {
 
   // MARK: Lifecycle
@@ -34,3 +36,10 @@ final class Vector1DEffectValue: EffectValue {
     case value = "v"
   }
 }
+
+// MARK: Sendable
+
+/// `Vector1DEffectValue` inherits `@unchecked Sendable` from `EffectValue` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Vector1DEffectValue: @unchecked Sendable { }

--- a/Sources/Private/Model/LayerStyles/DropShadowStyle.swift
+++ b/Sources/Private/Model/LayerStyles/DropShadowStyle.swift
@@ -1,6 +1,8 @@
 // Created by Cal Stephens on 8/14/23.
 // Copyright © 2023 Airbnb Inc. All rights reserved.
 
+// MARK: - DropShadowStyle
+
 final class DropShadowStyle: LayerStyle {
 
   // MARK: Lifecycle
@@ -68,3 +70,10 @@ final class DropShadowStyle: LayerStyle {
     case distance = "d"
   }
 }
+
+// MARK: Sendable
+
+/// `DropShadowStyle` inherits `@unchecked Sendable` from `LayerStyle` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension DropShadowStyle: @unchecked Sendable { }

--- a/Sources/Private/Model/Layers/ImageLayerModel.swift
+++ b/Sources/Private/Model/Layers/ImageLayerModel.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - ImageLayerModel
+
 /// A layer that holds an image.
 final class ImageLayerModel: LayerModel {
 
@@ -38,3 +40,10 @@ final class ImageLayerModel: LayerModel {
     case referenceID = "refId"
   }
 }
+
+// MARK: Sendable
+
+/// `ImageLayerModel` inherits `@unchecked Sendable` from `LayerModel` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension ImageLayerModel: @unchecked Sendable { }

--- a/Sources/Private/Model/Layers/PreCompLayerModel.swift
+++ b/Sources/Private/Model/Layers/PreCompLayerModel.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - PreCompLayerModel
+
 /// A layer that holds another animation composition.
 final class PreCompLayerModel: LayerModel {
 
@@ -63,3 +65,10 @@ final class PreCompLayerModel: LayerModel {
     case height = "h"
   }
 }
+
+// MARK: Sendable
+
+/// `PreCompLayerModel` inherits `@unchecked Sendable` from `LayerModel` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension PreCompLayerModel: @unchecked Sendable { }

--- a/Sources/Private/Model/Layers/ShapeLayerModel.swift
+++ b/Sources/Private/Model/Layers/ShapeLayerModel.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - ShapeLayerModel
+
 /// A layer that holds vector shape objects.
 final class ShapeLayerModel: LayerModel {
 
@@ -39,3 +41,10 @@ final class ShapeLayerModel: LayerModel {
     case items = "shapes"
   }
 }
+
+// MARK: Sendable
+
+/// `ShapeLayerModel` inherits `@unchecked Sendable` from `LayerModel` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension ShapeLayerModel: @unchecked Sendable { }

--- a/Sources/Private/Model/Layers/SolidLayerModel.swift
+++ b/Sources/Private/Model/Layers/SolidLayerModel.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - SolidLayerModel
+
 /// A layer that holds a solid color.
 final class SolidLayerModel: LayerModel {
 
@@ -52,3 +54,10 @@ final class SolidLayerModel: LayerModel {
     case height = "sh"
   }
 }
+
+// MARK: Sendable
+
+/// `SolidLayerModel` inherits `@unchecked Sendable` from `LayerModel` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension SolidLayerModel: @unchecked Sendable { }

--- a/Sources/Private/Model/Layers/TextLayerModel.swift
+++ b/Sources/Private/Model/Layers/TextLayerModel.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - TextLayerModel
+
 /// A layer that holds text.
 final class TextLayerModel: LayerModel {
 
@@ -54,3 +56,10 @@ final class TextLayerModel: LayerModel {
     case animators = "a"
   }
 }
+
+// MARK: Sendable
+
+/// `TextLayerModel` inherits `@unchecked Sendable` from `LayerModel` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension TextLayerModel: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Ellipse.swift
+++ b/Sources/Private/Model/ShapeItems/Ellipse.swift
@@ -70,3 +70,10 @@ final class Ellipse: ShapeItem {
     case size = "s"
   }
 }
+
+// MARK: Sendable
+
+/// `Ellipse` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Ellipse: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Fill.swift
+++ b/Sources/Private/Model/ShapeItems/Fill.swift
@@ -70,3 +70,10 @@ final class Fill: ShapeItem {
     case fillRule = "r"
   }
 }
+
+// MARK: Sendable
+
+/// `Fill` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Fill: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/GradientFill.swift
+++ b/Sources/Private/Model/ShapeItems/GradientFill.swift
@@ -133,3 +133,10 @@ final class GradientFill: ShapeItem {
     case colors = "k"
   }
 }
+
+// MARK: Sendable
+
+/// `GradientFill` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension GradientFill: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/GradientStroke.swift
+++ b/Sources/Private/Model/ShapeItems/GradientStroke.swift
@@ -234,3 +234,10 @@ final class GradientStroke: ShapeItem {
     case colors = "k"
   }
 }
+
+// MARK: Sendable
+
+/// `GradientStroke` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension GradientStroke: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Group.swift
+++ b/Sources/Private/Model/ShapeItems/Group.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - Group
+
 /// An item that define a a group of shape items
 final class Group: ShapeItem {
 
@@ -44,3 +46,10 @@ final class Group: ShapeItem {
     case items = "it"
   }
 }
+
+// MARK: Sendable
+
+/// `Group` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Group: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Merge.swift
+++ b/Sources/Private/Model/ShapeItems/Merge.swift
@@ -54,3 +54,10 @@ final class Merge: ShapeItem {
     case mode = "mm"
   }
 }
+
+// MARK: Sendable
+
+/// `Merge` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Merge: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Rectangle.swift
+++ b/Sources/Private/Model/ShapeItems/Rectangle.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - Rectangle
+
 final class Rectangle: ShapeItem {
 
   // MARK: Lifecycle
@@ -68,3 +70,10 @@ final class Rectangle: ShapeItem {
     case cornerRadius = "r"
   }
 }
+
+// MARK: Sendable
+
+/// `Rectangle` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Rectangle: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Repeater.swift
+++ b/Sources/Private/Model/ShapeItems/Repeater.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - Repeater
+
 final class Repeater: ShapeItem {
 
   // MARK: Lifecycle
@@ -170,3 +172,10 @@ final class Repeater: ShapeItem {
     case scale = "s"
   }
 }
+
+// MARK: Sendable
+
+/// `Repeater` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Repeater: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/RoundedCorners.swift
+++ b/Sources/Private/Model/ShapeItems/RoundedCorners.swift
@@ -43,3 +43,10 @@ final class RoundedCorners: ShapeItem {
     case radius = "r"
   }
 }
+
+// MARK: Sendable
+
+/// `RoundedCorners` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension RoundedCorners: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Shape.swift
+++ b/Sources/Private/Model/ShapeItems/Shape.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - Shape
+
 /// An item that defines an custom shape
 final class Shape: ShapeItem {
 
@@ -52,3 +54,10 @@ final class Shape: ShapeItem {
     case direction = "d"
   }
 }
+
+// MARK: Sendable
+
+/// `Shape` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Shape: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/ShapeTransform.swift
+++ b/Sources/Private/Model/ShapeItems/ShapeTransform.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - ShapeTransform
+
 final class ShapeTransform: ShapeItem {
 
   // MARK: Lifecycle
@@ -191,3 +193,10 @@ final class ShapeTransform: ShapeItem {
     case skewAxis = "sa"
   }
 }
+
+// MARK: Sendable
+
+/// `ShapeTransform` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension ShapeTransform: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Star.swift
+++ b/Sources/Private/Model/ShapeItems/Star.swift
@@ -127,3 +127,10 @@ final class Star: ShapeItem {
     case starType = "sy"
   }
 }
+
+// MARK: Sendable
+
+/// `Star` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Star: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Stroke.swift
+++ b/Sources/Private/Model/ShapeItems/Stroke.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/8/19.
 //
 
+// MARK: - Stroke
+
 final class Stroke: ShapeItem {
 
   // MARK: Lifecycle
@@ -132,3 +134,10 @@ final class Stroke: ShapeItem {
     case dashPattern = "d"
   }
 }
+
+// MARK: Sendable
+
+/// `Stroke` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Stroke: @unchecked Sendable { }

--- a/Sources/Private/Model/ShapeItems/Trim.swift
+++ b/Sources/Private/Model/ShapeItems/Trim.swift
@@ -81,3 +81,10 @@ final class Trim: ShapeItem {
     case trimType = "m"
   }
 }
+
+// MARK: Sendable
+
+/// `Trim` inherits `@unchecked Sendable` from `ShapeItem` and
+/// we need to restate that here to avoid a warning in Xcode 16
+// swiftlint:disable:next no_unchecked_sendable
+extension Trim: @unchecked Sendable { }


### PR DESCRIPTION
Fixes 26 warnings in Xcode 16 by restating inherited conformances to `@unchecked Sendable`.  An example:

```
Sources/Private/CoreAnimation/Animations/CombinedShapeAnimation.swift:32:13 Class 'CombinedShapeItem' must restate inherited '@unchecked Sendable' conformance
```

The unchecked conformances were originally added in https://github.com/airbnb/lottie-ios/pull/2126.