### PR TITLE
do not crash if value is false

### DIFF
--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -424,9 +424,11 @@ extension CoreAnimationLayer: RootAnimationLayer {
   var respectAnimationFrameRate: Bool {
     get { false }
     set {
-      logger.assertionFailure("""
-        The Core Animation rendering engine currently doesn't support `respectAnimationFrameRate`)
-        """)
+      if newValue {
+        logger.assertionFailure("""
+            The Core Animation rendering engine currently doesn't support `respectAnimationFrameRate`)
+            """)
+      }
     }
   }
 

--- a/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
+++ b/Sources/Private/CoreAnimation/CoreAnimationLayer.swift
@@ -426,8 +426,8 @@ extension CoreAnimationLayer: RootAnimationLayer {
     set {
       if newValue {
         logger.assertionFailure("""
-            The Core Animation rendering engine currently doesn't support `respectAnimationFrameRate`)
-            """)
+          The Core Animation rendering engine currently doesn't support `respectAnimationFrameRate`)
+          """)
       }
     }
   }


### PR DESCRIPTION
Our project is using KMP (Kotlin Multiplatform) and Kottie lib for crossplatform animations, Kottie uses Lottie inside and sets property respectAnimationFrameRate to false in it's default values
It would be great not to crash app, since value is not changing and it is false