### PR TITLE
Add additional dynamic library product to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,10 @@ let package = Package(
   name: "Lottie",
   // Minimum platform versions should be kept in sync with the per-platform targets in Lottie.xcodeproj, lottie-ios.podspec, and lottie-spm's Package.swift
   platforms: [.iOS("13.0"), .macOS("10.15"), .tvOS("13.0"), .custom("visionOS", versionString: "1.0")],
-  products: [.library(name: "Lottie", targets: ["Lottie"])],
+  products: [
+    .library(name: "Lottie", targets: ["Lottie"]),
+    .library(name: "Lottie-Dynamic", type: .dynamic, targets: ["Lottie"]),
+  ],
   dependencies: [
     .package(url: "https://github.com/airbnb/swift", .upToNextMajor(from: "1.0.1")),
   ],


### PR DESCRIPTION
Hi Lottie-Team,

I would like to link the Lottie framework dynamically to use it inside another framework. 
To avoid duplicate symbols the library should not embedded in the framework target and only embedded in the app target.

To solve this issue (since SPM Dependencies are automatically built statically) another product has been added to the `Package.swift` file allowing to build a dynamic framework. This seems to be a common practice as it is used by the SnapKit and RxSwift framework.