### PR TITLE
Fix Haiku URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Lottie is a cross-platform library for iOS, macOS, tvOS, visionOS, [Android](https://github.com/airbnb/lottie-android), and [Web](https://github.com/airbnb/lottie-web) that natively renders vector-based animations and art in realtime with minimal code.
 
-Lottie loads and renders animations and vectors exported in the bodymovin JSON format. Bodymovin JSON can be created and exported from After Effects with [bodymovin](https://github.com/bodymovin/bodymovin), Sketch with [Lottie Sketch Export](https://github.com/buba447/Lottie-Sketch-Export), and from [Haiku](https://www.haiku.ai).
+Lottie loads and renders animations and vectors exported in the bodymovin JSON format. Bodymovin JSON can be created and exported from After Effects with [bodymovin](https://github.com/bodymovin/bodymovin), Sketch with [Lottie Sketch Export](https://github.com/buba447/Lottie-Sketch-Export), and from [Haiku](https://www.haikuanimator.com).
 
 Designers can create **and ship** beautiful animations without an engineer painstakingly recreating them by hand.
 Since the animations are backed by JSON, they are extremely small in size but can be large in complexity!


### PR DESCRIPTION
The current URL in the README points to a domain for sale. This updates it to the project's current website. That said, it does look like the project has been inactive for some time, so removing it entirely would also be an option.