### PR TITLE
Add debug check

### DIFF
--- a/Sources/Private/Utility/Debugging/LayerDebugging.swift
+++ b/Sources/Private/Utility/Debugging/LayerDebugging.swift
@@ -5,6 +5,8 @@
 //  Created by Brandon Withrow on 1/24/19.
 //
 
+#if DEBUG
+
 import QuartzCore
 
 // MARK: - LayerDebugStyle
@@ -220,3 +222,5 @@ extension [LayerModel] {
   }
 
 }
+
+#endif


### PR DESCRIPTION
I noticed from some [Reaper](https://docs.emergetools.com/docs/reaper) reports that the `DebugLayer` class was unused in production apps. Seems like it's not needed outside of debug builds and could use this conditional compilation check.