### PR TITLE
 Fix Navigation Issue in AnimationListView in the Sample Project

### DIFF
--- a/Example/Example/AnimationListView.swift
+++ b/Example/Example/AnimationListView.swift
@@ -40,25 +40,25 @@ struct AnimationListView: View {
               .frame(height: 50)
           }
         }
-        .navigationDestination(for: Item.self) { item in
-          switch item {
-          case .animation(_, let animationPath):
-            AnimationPreviewView(animationSource: .local(animationPath: animationPath))
-          case .remoteAnimations(let name, let urls):
-            AnimationPreviewView(animationSource: .remote(urls: urls, name: name))
-          case .animationList(let listContent):
-            AnimationListView(content: listContent)
-          case .controlsDemo:
-            ControlsDemoView()
-          case .swiftUIInteroperability:
-            SwiftUIInteroperabilityDemoView()
-          case .lottieViewLayoutDemo:
-            LottieViewLayoutDemoView()
-          }
-        }
       }
     }
     .navigationTitle(content.name)
+    .navigationDestination(for: Item.self) { item in
+      switch item {
+      case .animation(_, let animationPath):
+        AnimationPreviewView(animationSource: .local(animationPath: animationPath))
+      case .remoteAnimations(let name, let urls):
+        AnimationPreviewView(animationSource: .remote(urls: urls, name: name))
+      case .animationList(let listContent):
+        AnimationListView(content: listContent)
+      case .controlsDemo:
+        ControlsDemoView()
+      case .swiftUIInteroperability:
+        SwiftUIInteroperabilityDemoView()
+      case .lottieViewLayoutDemo:
+        LottieViewLayoutDemoView()
+      }
+    }
   }
 
   func makeThumbnailAnimation(for item: Item) async throws -> LottieAnimationSource? {


### PR DESCRIPTION
I fixed the navigation issue in the AnimationListView in the sample, which was not working on iOS 18.

Additionally, the following warning was occurring:

> Do not put a navigation destination modifier inside a "lazy” container, like List or LazyVStack. These containers create child views only when needed to render on screen. Add the navigation destination modifier outside these containers so that the navigation stack can always see the destination. There's a misplaced navigationDestination(for:destination:) modifier for type Item. It will be ignored.

## Attachments
|Before|After|After(iPad)| 
|----|----|----|  
|<video src="https://github.com/user-attachments/assets/8dbd8050-da87-420a-be94-fb1a091a44ee">|<video src="https://github.com/user-attachments/assets/1176daa5-257f-4df3-877b-a56d5dabdaec">|<video src="https://github.com/user-attachments/assets/a4d73587-fdb0-4312-9857-b4ad2bd3cddd">|

