### PR TITLE
Fix CoreAnimation issues in iOS 18 Patch

### DIFF
--- a/Sources/Public/Configuration/LottieConfiguration.swift
+++ b/Sources/Public/Configuration/LottieConfiguration.swift
@@ -24,7 +24,15 @@ public struct LottieConfiguration: Hashable {
 
   /// The global configuration of Lottie,
   /// which applies to all `LottieAnimationView`s by default.
-  public static var shared = LottieConfiguration()
+    ///
+    public static var shared: LottieConfiguration = {
+        var configuration: LottieConfiguration = .init()
+        /// Override the default engine to avoid CoreAnimation regressions on IOS 18
+        if #available(iOS 18.0, *) {
+            configuration.renderingEngine = .mainThread
+        }
+        return configuration
+    }()
 
   /// The rendering engine implementation to use when displaying an animation
   ///  - Defaults to `RenderingEngineOption.automatic`, which uses the

--- a/Sources/Public/Configuration/LottieConfiguration.swift
+++ b/Sources/Public/Configuration/LottieConfiguration.swift
@@ -26,7 +26,7 @@ public struct LottieConfiguration: Hashable {
   /// which applies to all `LottieAnimationView`s by default.
     ///
     public static var shared: LottieConfiguration = {
-        var configuration: LottieConfiguration = .init()
+        var configuration = LottieConfiguration()
         /// Override the default engine to avoid CoreAnimation regressions on IOS 18
         if #available(iOS 18.0, *) {
             configuration.renderingEngine = .mainThread


### PR DESCRIPTION
This PR addresses any iOS 18 CoreAnimation regression issues which result in slow/dropped frames and buggy animations. 
Fixes:  #2546  ,  #2548 

**Context:**
   iOS 18 CAKeyFrameAnimation no longer advances beyond certain frames due to an apple compositor bug. Setting to the .mainThread render engine will do a manual frame by frame pass via CADisplayLink and avoids the broken GPU path. 
   
 **Changes**
  A specific version check for iOS 18 will serve as a temporary patch to resolve all animation latencies, this is done by setting the render engine explicitly to .mainThread
  
 **Impact**
 On iOS 18 animations use CPU driven fallback and improved animation renders, on versions before **no change.**
 
 
 **MEDIA**
 
 BUG VIDEO (iOS 18): 
 

https://github.com/user-attachments/assets/f632f9f0-270b-4085-8082-04a16b56ba40




FIX VIDEO (iOS 18):



https://github.com/user-attachments/assets/08fe9312-d9cc-427c-93cf-9bf5959c672c


 