### PR TITLE
Adds static framework generation on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,18 +111,13 @@ jobs:
           xcode: ${{ matrix.xcode }}
       - name: Build Dynamic XCFramework
         run: bundle exec rake build:xcframework\['dynamic'\]
-      - name: Upload Dynamic XCFramework
-        uses: actions/upload-artifact@v4
-        with:
-          name: BuildProducts
-          path: .build/archives
       - name: Build Static XCFramework
         run: bundle exec rake build:xcframework\['static'\]
-      - name: Upload Static XCFramework
+      - name: Upload XCFrameworks
         uses: actions/upload-artifact@v4
         with:
           name: BuildProducts
-          path: .build/archives
+          path: .build
 
   cocoapod:
     name: "Lint CocoaPods podspec"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: BuildProducts
-          path: .build
+          path: .build/artifacts
 
   cocoapod:
     name: "Lint CocoaPods podspec"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,9 +109,16 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           xcode: ${{ matrix.xcode }}
-      - name: Build XCFramework
-        run: bundle exec rake build:xcframework
-      - name: Upload XCFramework
+      - name: Build Dynamic XCFramework
+        run: bundle exec rake build:xcframework\['dynamic'\]
+      - name: Upload Dynamic XCFramework
+        uses: actions/upload-artifact@v4
+        with:
+          name: BuildProducts
+          path: .build/archives
+      - name: Build Static XCFramework
+        run: bundle exec rake build:xcframework\['static'\]
+      - name: Upload Static XCFramework
         uses: actions/upload-artifact@v4
         with:
           name: BuildProducts

--- a/Rakefile
+++ b/Rakefile
@@ -105,11 +105,11 @@ namespace :build do
       xcframeworkInvocation.push('-archive .build/archives/Lottie_visionOS_Simulator.xcarchive -framework Lottie.framework')
     }
 
-    xcframeworkInvocation.push("-output .build/#{xcframework_name}.xcframework")
+    xcframeworkInvocation.push("-output .build/artifacts/#{xcframework_name}.xcframework")
 
     xcodebuild(xcframeworkInvocation.join(" "))
 
-    Dir.chdir('.build') do
+    Dir.chdir('.build/artifacts') do
       # Codesign the XCFramework using the "Lottie iOS" certificate, which should be installed in the keychain.
       #  - Check to make sure the certificate is installed before attemtping to codesign.
       #  - In GitHub actions CI, only jobs run by contibutors have access to repo secrets,
@@ -129,11 +129,9 @@ namespace :build do
       # error when validating macOS apps (#1948)
       sh "zip -r --symlinks #{xcframework_name}.xcframework.zip #{xcframework_name}.xcframework"
       sh "rm -rf #{xcframework_name}.xcframework"
-      # Remove unnecessary xcarchive files
-      sh 'rm -rf ./archives'
     end
 
-    sh "swift package compute-checksum .build/#{xcframework_name}.xcframework.zip"
+    sh "swift package compute-checksum .build/artifacts/#{xcframework_name}.xcframework.zip"
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -62,22 +62,31 @@ namespace :build do
   end
 
   desc 'Builds an xcframework for all supported platforms'
-  task :xcframework, [:zip_archive_name] do |_t, args|
-    args.with_defaults(:zip_archive_name => 'Lottie')
+  task :xcframework, [:framework_type] do |_t, args|
+    args.with_defaults(:framework_type => 'dynamic')
+ 
+    case args[:framework_type]
+    when 'dynamic'
+      mach_o_type = 'mh_dylib'
+      xcframework_name = 'Lottie' # Backward compatibility
+    when 'static'
+      mach_o_type = 'staticlib'
+      xcframework_name = 'Lottie-Static'
+    end
 
     sh 'rm -rf .build/archives'
 
     # Build the framework for each supported platform, including simulators
-    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (iOS)" -destination generic/platform=iOS -archivePath ".build/archives/Lottie_iOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO')
-    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (iOS)" -destination "generic/platform=iOS Simulator" -archivePath ".build/archives/Lottie_iOS_Simulator" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO')
-    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (iOS)" -destination "generic/platform=macOS,variant=Mac Catalyst" -archivePath ".build/archives/Lottie_Mac_Catalyst" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO')
-    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (macOS)" -destination generic/platform=macOS -archivePath ".build/archives/Lottie_macOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO')
-    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (tvOS)" -destination generic/platform=tvOS -archivePath ".build/archives/Lottie_tvOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO')
-    xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (tvOS)" -destination "generic/platform=tvOS Simulator" -archivePath ".build/archives/Lottie_tvOS_Simulator" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO')
+    xcodebuild("archive -workspace Lottie.xcworkspace -scheme \"Lottie (iOS)\" -destination generic/platform=iOS -archivePath \".build/archives/Lottie_iOS\" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO MACH_O_TYPE=\"#{mach_o_type}\"")
+    xcodebuild("archive -workspace Lottie.xcworkspace -scheme \"Lottie (iOS)\" -destination \"generic/platform=iOS Simulator\" -archivePath \".build/archives/Lottie_iOS_Simulator\" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO MACH_O_TYPE=\"#{mach_o_type}\"")
+    xcodebuild("archive -workspace Lottie.xcworkspace -scheme \"Lottie (iOS)\" -destination \"generic/platform=macOS,variant=Mac Catalyst\" -archivePath \".build/archives/Lottie_Mac_Catalyst\" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO MACH_O_TYPE=\"#{mach_o_type}\"")
+    xcodebuild("archive -workspace Lottie.xcworkspace -scheme \"Lottie (macOS)\" -destination generic/platform=macOS -archivePath \".build/archives/Lottie_macOS\" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO MACH_O_TYPE=\"#{mach_o_type}\"")
+    xcodebuild("archive -workspace Lottie.xcworkspace -scheme \"Lottie (tvOS)\" -destination generic/platform=tvOS -archivePath \".build/archives/Lottie_tvOS\" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO MACH_O_TYPE=\"#{mach_o_type}\"")
+    xcodebuild("archive -workspace Lottie.xcworkspace -scheme \"Lottie (tvOS)\" -destination \"generic/platform=tvOS Simulator\" -archivePath \".build/archives/Lottie_tvOS_Simulator\" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO MACH_O_TYPE=\"#{mach_o_type}\"")
 
     ifVisionOSEnabled {
-      xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (visionOS)" -destination generic/platform=visionOS -archivePath ".build/archives/Lottie_visionOS" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO')
-      xcodebuild('archive -workspace Lottie.xcworkspace -scheme "Lottie (visionOS)" -destination "generic/platform=visionOS Simulator" -archivePath ".build/archives/Lottie_visionOS_Simulator" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO')
+      xcodebuild("archive -workspace Lottie.xcworkspace -scheme \"Lottie (visionOS)\" -destination generic/platform=visionOS -archivePath \".build/archives/Lottie_visionOS\" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO MACH_O_TYPE=\"#{mach_o_type}\"")
+      xcodebuild("archive -workspace Lottie.xcworkspace -scheme \"Lottie (visionOS)\" -destination \"generic/platform=visionOS Simulator\" -archivePath \".build/archives/Lottie_visionOS_Simulator\" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES ENABLE_BITCODE=NO SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO MACH_O_TYPE=\"#{mach_o_type}\"")
     }
 
     # Combine all of the platforms into a single XCFramework
@@ -96,7 +105,7 @@ namespace :build do
       xcframeworkInvocation.push('-archive .build/archives/Lottie_visionOS_Simulator.xcarchive -framework Lottie.framework')
     }
 
-    xcframeworkInvocation.push('-output .build/archives/Lottie.xcframework')
+    xcframeworkInvocation.push("-output .build/archives/#{xcframework_name}.xcframework")
 
     xcodebuild(xcframeworkInvocation.join(" "))
 
@@ -110,19 +119,21 @@ namespace :build do
       `security find-certificate -c 'Lottie iOS'`
       if $?.success?
         puts "Signing certificate is installed. Code signing Lottie.xcframework."
-        sh 'codesign --timestamp -v --sign "Lottie iOS" Lottie.xcframework'
+        sh "codesign --timestamp -v --sign \"Lottie iOS\" #{xcframework_name}.xcframework"
       else
-        puts "Signing certificate is not installed. Lottie.xcframework will not be code signed."
+        puts "Signing certificate is not installed. #{xcframework_name}.xcframework will not be code signed."
       end
 
       # Archive the XCFramework into a zip file
       # Use --symlinks to avoid "Multiple binaries share the same codesign path. This can happen if your build process copies frameworks by following symlinks." 
       # error when validating macOS apps (#1948)
-      sh "zip -r --symlinks #{args[:zip_archive_name]}.xcframework.zip Lottie.xcframework"
-      sh 'rm -rf Lottie.xcframework'
+      sh "zip -r --symlinks #{xcframework_name}.xcframework.zip #{xcframework_name}.xcframework"
+      sh "rm -rf #{xcframework_name}.xcframework"
+      # Remove unnecessary xcarchive files
+      sh 'rm -rf *.xcarchive'
     end
 
-    sh "swift package compute-checksum .build/archives/#{args[:zip_archive_name]}.xcframework.zip"
+    sh "swift package compute-checksum .build/archives/#{xcframework_name}.xcframework.zip"
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -105,11 +105,11 @@ namespace :build do
       xcframeworkInvocation.push('-archive .build/archives/Lottie_visionOS_Simulator.xcarchive -framework Lottie.framework')
     }
 
-    xcframeworkInvocation.push("-output .build/archives/#{xcframework_name}.xcframework")
+    xcframeworkInvocation.push("-output .build/#{xcframework_name}.xcframework")
 
     xcodebuild(xcframeworkInvocation.join(" "))
 
-    Dir.chdir('.build/archives') do
+    Dir.chdir('.build') do
       # Codesign the XCFramework using the "Lottie iOS" certificate, which should be installed in the keychain.
       #  - Check to make sure the certificate is installed before attemtping to codesign.
       #  - In GitHub actions CI, only jobs run by contibutors have access to repo secrets,
@@ -130,10 +130,10 @@ namespace :build do
       sh "zip -r --symlinks #{xcframework_name}.xcframework.zip #{xcframework_name}.xcframework"
       sh "rm -rf #{xcframework_name}.xcframework"
       # Remove unnecessary xcarchive files
-      sh 'rm -rf *.xcarchive'
+      sh 'rm -rf ./archives'
     end
 
-    sh "swift package compute-checksum .build/archives/#{xcframework_name}.xcframework.zip"
+    sh "swift package compute-checksum .build/#{xcframework_name}.xcframework.zip"
   end
 end
 

--- a/script/ReleaseInstructions.md
+++ b/script/ReleaseInstructions.md
@@ -8,10 +8,10 @@ Lottie is made available through multiple package managers, each of which has to
  2. Publish the new release in the [lottie-ios](https://github.com/airbnb/lottie-ios) repo
  3. Update the [Cocoapod](https://cocoapods.org/pods/lottie-ios) by running `pod trunk push lottie-ios.podspec`
  4. Update the [npm package](https://www.npmjs.com/package/lottie-ios) by running `npm publish`
- 5. Attach `Lottie.xframework.zip` to the GitHub release
-   - For every PR / commit, `Lottie.xcframework.zip` is built by CI and uploaded to the job summary once all jobs are completed.
-   - Make sure to use the `Lottie.xcframework.zip` from the CI job for the commit on master / the specific release tag and not from a PR CI job.
+ 5. Attach `Lottie.xframework.zip` and `Lottie-Static.xframework.zip` to the GitHub release
+   - For every PR / commit, `Lottie.xcframework.zip` and `Lottie-Static.xcframework.zip` are built by CI and uploaded to the job summary once all jobs are completed.
+   - Make sure to use the `Lottie.xcframework.zip` and `Lottie-Static.xcframework.zip` from the CI job for the commit on master / the specific release tag and not from a PR CI job.
  6. Update the [lottie-spm](https://github.com/airbnb/lottie-spm) [Package.swift](https://github.com/airbnb/lottie-spm/blob/main/Package.swift) manifest to reference the new version's XCFramework.
-   - You can compute the checksum by running `swift package compute-checksum Lottie.xcframework.zip`.
+   - You can compute the checksum by running `swift package compute-checksum Lottie.xcframework.zip` and `swift package compute-checksum Lottie-Static.xcframework.zip`.
    - Optionally, consider updating the version number in `README.md` as well.
  7. Publish the new release in the [lottie-spm](https://github.com/airbnb/lottie-spm) repo


### PR DESCRIPTION
This pull-request adds static framework generation on CI.

Fixes: https://github.com/airbnb/lottie-ios/issues/2485 and https://github.com/airbnb/lottie-ios/discussions/2486

Additionally later, can be added to https://github.com/airbnb/lottie-spm

I would be grateful if you could double-check the code, I don't work with ruby that often.

Example output of a type of framework for dynamic linking:
<img width="600" alt="Screenshot 2025-05-09 at 18 51 49" src="https://github.com/user-attachments/assets/c7f9673e-3d97-4376-a343-9bb6d91bf021" />

Example of framework type output for static linking:
<img width="600" alt="Screenshot 2025-05-09 at 18 52 17" src="https://github.com/user-attachments/assets/2c011858-2b67-40ff-b488-cfce2b90e991" />
