### PR TITLE
Fix: Prevent animationSpeed = 0 from blocking playback (#2549)

### DIFF
--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -728,11 +728,15 @@ public class LottieAnimationLayer: CALayer {
   }
 
   /// Sets the speed of the animation playback. Defaults to 1
-  public var animationSpeed: CGFloat = 1 {
-    didSet {
-      updateInFlightAnimation()
+    public var animationSpeed: CGFloat = 1 {
+        didSet {
+            // If a previous animation was queued but not played due to zero speed, trigger it now
+            if animationContext != nil, animationSpeed != 0, !isAnimationPlaying {
+                updateInFlightAnimation()
+            }
+        }
     }
-  }
+
 
   /// When `true` the animation will play back at the framerate encoded in the
   /// `LottieAnimation` model. When `false` the animation will play at the framerate
@@ -1439,7 +1443,10 @@ public class LottieAnimationLayer: CALayer {
     let layerAnimation = CABasicAnimation(keyPath: "currentFrame")
     layerAnimation.fromValue = playFrom
     layerAnimation.toValue = playTo
-    layerAnimation.speed = Float(animationSpeed)
+      if animationSpeed == 0 {
+          self.animationContext = animationContext
+          return
+      }
     layerAnimation.duration = TimeInterval(duration)
     layerAnimation.fillMode = CAMediaTimingFillMode.both
     layerAnimation.repeatCount = loopMode.caAnimationConfiguration.repeatCount

--- a/Tests/AnimationViewTests.swift
+++ b/Tests/AnimationViewTests.swift
@@ -70,6 +70,28 @@ final class AnimationViewTests: XCTestCase {
 
     wait(for: [expectation], timeout: 1.0)
   }
+    
+    func testPlayWithSpeedZeroThenResume() {
+        let animation = LottieAnimation.named("LottieLogo1")
+        let view = LottieAnimationView(animation: animation)
+
+        view.animationSpeed = 0
+        view.play()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            view.animationSpeed = 1
+        }
+
+        let expectation = XCTestExpectation(description: "Animation resumes after speed set to 1")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            if view.realtimeAnimationFrame > 0 {
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
 
   func testPlayFromFrameToFrame() {
     XCTExpectFailure("Realtime animation playback tests are flaky in CI", strict: false) {


### PR DESCRIPTION
## Summary

Fixes a bug where setting `animationSpeed = 0` before calling `play()` would prevent the animation from starting, even if the speed is later changed to a non-zero value.

## Problem

When `animationSpeed == 0`, Lottie tries to start a `CABasicAnimation` with zero speed, which causes the animation not to play and prevents progress.

## Solution

- Prevent scheduling the animation if `animationSpeed == 0`.
- Store the playback context and resume when the speed is later set to a valid value.
- Updated `animationSpeed`'s `didSet` to resume any pending animation.

## Testing

Tested by:
- Manually setting `animationSpeed = 0`, calling `play()`, then restoring the speed to `1.0` after a short delay. Animation now plays as expected.
