### PR TITLE
Fix: Remove unused variable always set to false

### DIFF
--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1023,9 +1023,11 @@ public class LottieAnimationLayer: CALayer {
     }
   }
 
-  public func updateAnimationForForegroundState() {
-    if let _ = animationContext {
-      if backgroundBehavior == .pauseAndRestore {
+  public func updateAnimationForForegroundState(wasWaitingToPlayAnimation: Bool) {
+    if let currentContext = animationContext {
+      if wasWaitingToPlayAnimation {
+        addNewAnimationForContext(currentContext)
+      } else if backgroundBehavior == .pauseAndRestore {
         /// Restore animation from saved state
         updateInFlightAnimation()
       }

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1023,11 +1023,9 @@ public class LottieAnimationLayer: CALayer {
     }
   }
 
-  public func updateAnimationForForegroundState(wasWaitingToPlayAnimation: Bool) {
+  public func updateAnimationForForegroundState() {
     if let currentContext = animationContext {
-      if wasWaitingToPlayAnimation {
-        addNewAnimationForContext(currentContext)
-      } else if backgroundBehavior == .pauseAndRestore {
+      if backgroundBehavior == .pauseAndRestore {
         /// Restore animation from saved state
         updateInFlightAnimation()
       }

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1024,7 +1024,7 @@ public class LottieAnimationLayer: CALayer {
   }
 
   public func updateAnimationForForegroundState() {
-    if let currentContext = animationContext {
+    if let _ = animationContext {
       if backgroundBehavior == .pauseAndRestore {
         /// Restore animation from saved state
         updateInFlightAnimation()

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -1049,7 +1049,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
   }
 
   fileprivate func updateAnimationForForegroundState() {
-    lottieAnimationLayer.updateAnimationForForegroundState()
+    lottieAnimationLayer.updateAnimationForForegroundState(wasWaitingToPlayAnimation: false)
   }
 
   // MARK: Private

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -479,7 +479,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   /// Returns `true` if the animation will start playing when this view is added to a window.
   public var isAnimationQueued: Bool {
-    lottieAnimationLayer.hasAnimationContext && waitingToPlayAnimation
+    lottieAnimationLayer.hasAnimationContext
   }
 
   /// Sets the loop behavior for `play` calls. Defaults to `playOnce`
@@ -1043,18 +1043,12 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   // MARK: Fileprivate
 
-  fileprivate var waitingToPlayAnimation = false
-
   fileprivate func updateAnimationForBackgroundState() {
     lottieAnimationLayer.updateAnimationForBackgroundState()
   }
 
   fileprivate func updateAnimationForForegroundState() {
-    let wasWaitingToPlayAnimation = waitingToPlayAnimation
-    if waitingToPlayAnimation {
-      waitingToPlayAnimation = false
-    }
-    lottieAnimationLayer.updateAnimationForForegroundState(wasWaitingToPlayAnimation: wasWaitingToPlayAnimation)
+    lottieAnimationLayer.updateAnimationForForegroundState()
   }
 
   // MARK: Private

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -1043,6 +1043,7 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   // MARK: Fileprivate
 
+
   fileprivate func updateAnimationForBackgroundState() {
     lottieAnimationLayer.updateAnimationForBackgroundState()
   }


### PR DESCRIPTION
This PR removes the `waitingToPlayAnimation` variable.  
The variable's default value was `false`, and there were no places in the code where it was ever set to `true`.  