### PR TITLE
Correct comments at Archive.swift

### DIFF
--- a/Sources/Private/EmbeddedLibraries/ZipFoundation/Archive.swift
+++ b/Sources/Private/EmbeddedLibraries/ZipFoundation/Archive.swift
@@ -61,7 +61,7 @@ final class Archive: Sequence {
 
   /// Initializes a new ZIP `Archive`.
   ///
-  /// You can use this initalizer to create new archive files or to read and update existing ones.
+  /// You can use this initializer to create new archive files or to read and update existing ones.
   /// The `mode` parameter indicates the intended usage of the archive: `.read`, `.create` or `.update`.
   /// - Parameters:
   ///   - url: File URL to the receivers backing file.
@@ -176,7 +176,7 @@ final class Archive: Sequence {
 
   /// Initializes a new in-memory ZIP `Archive`.
   ///
-  /// You can use this initalizer to create new in-memory archive files or to read and update existing ones.
+  /// You can use this initializer to create new in-memory archive files or to read and update existing ones.
   ///
   /// - Parameters:
   ///   - data: `Data` object used as backing for in-memory archives.


### PR DESCRIPTION
### Description:

It seems a typo issue with **initalizer** word at `Archive.swift`.

### Modifications:
Sources/Private/EmbeddedLibraries/ZipFoundation/Archive.swift
 + initalizer => initializer

### Result:
Correct the the comment at `Archive.swift`
