### PR TITLE
Division by zero in LottieAnimationHelpers causes crash

### DIFF
--- a/Sources/Public/Animation/LottieAnimationHelpers.swift
+++ b/Sources/Public/Animation/LottieAnimationHelpers.swift
@@ -294,7 +294,14 @@ extension LottieAnimation {
     clamped: Bool = true)
     -> AnimationProgressTime
   {
-    let progressTime = ((frameTime - startFrame) / (endFrame - startFrame))
+    let progressTime: AnimationFrameTime
+    let frameDuration = endFrame - startFrame
+    
+    if frameDuration == 0.0 {
+      progressTime = 0.0
+    } else {
+      progressTime = ((frameTime - startFrame) / frameDuration)
+    }
 
     if clamped {
       return progressTime.clamp(0, 1)


### PR DESCRIPTION
We have an animation that has no time duration which is used as a static placeholder. Its "op" and "ip" values are both 0, so this line in LottieAnimationHelpers.swift:
```
let progressTime = ((frameTime - startFrame) / (endFrame - startFrame))
```
results in division by 0 which later causes a crash. This issue is not present in the UIKit version of `LottieAnimationView` but when we migrated to the SwiftUI `LottieView` it started happening. The UIKit and SwiftUI views follow different code paths, it seems the UIKit version doesn't call the progressTime function where the bug occurs. 

This PR makes sure that `progressTime` does not become the `nan` value as a result of division by 0. If it is nan then a crash occurs on line 1374 of `LottieAnimationLayer.swift`:
```
if (lowerBoundTime ..< upperBoundTime).contains(round(currentFrame)) {
```
with a crash message:
```
Swift/arm64-apple-ios-simulator.swiftinterface:16934: Fatal error: Range requires lowerBound <= upperBound
```