### PR TITLE
Invoke `animationDidLoad` on next run loop

### DIFF
--- a/Sources/Public/Animation/LottieView.swift
+++ b/Sources/Public/Animation/LottieView.swift
@@ -587,11 +587,17 @@ public struct LottieView<Placeholder: View>: UIViewConfiguringSwiftUIView {
     // prohibitive to do so on every state update.
     if animationSource.animation !== view.animation {
       view.loadAnimation(animationSource)
-      animationDidLoad?(animationSource)
 
       // Invalidate the intrinsic size of the SwiftUI measurement container,
       // since any cached measurements will be out of date after updating the animation.
       container.invalidateIntrinsicContentSize()
+
+      // Call the `animationDidLoad` asynchronously
+      // to prevent consumers that update state in that callback from
+      // causing SwiftUI to emit warnings about modifying state during view updates.
+      DispatchQueue.main.async {
+        animationDidLoad?(animationSource)
+      }
     }
 
     if


### PR DESCRIPTION
I notice an issue where a consumer of `LottieView` will update a SwiftUI `@State` variable in the `animationDidLoad` closure. 

```swift
@State var animationLoaded = false

LottieView {
 ...
}
.animationDidLoad { _ in
 // triggers a "Modifying state during view update, this will cause undefined behavior"
 animationLoaded = true
}
```
Updating state is a common pattern so we should fix it in the view