### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         - '16.4' # Swift 6.1
         - '26.1.1' # Swift 6.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           xcode: ${{ matrix.xcode }}
@@ -29,7 +29,7 @@ jobs:
     name: "Build Example App"
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           xcode: '26.1.1' # Swift 6.2
@@ -40,7 +40,7 @@ jobs:
     name: "Test Package"
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           xcode: '16.4' # Swift 6.1
@@ -51,7 +51,7 @@ jobs:
         run: bundle exec rake test:process
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TestArtifacts
           path: Tests/Artifacts
@@ -60,7 +60,7 @@ jobs:
     name: "Emerge Upload"
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Build Package
         run: bundle exec rake emerge:upload
@@ -76,7 +76,7 @@ jobs:
         xcode:
           - '16.4' # Swift 6.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: apple-actions/import-codesign-certs@v3
         continue-on-error: true
         with:
@@ -90,7 +90,7 @@ jobs:
       - name: Build Static XCFramework
         run: bundle exec rake build:xcframework\['static'\]
       - name: Upload XCFrameworks
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: BuildProducts
           path: .build/artifacts
@@ -103,7 +103,7 @@ jobs:
         xcode:
           - '16.4' # Swift 6.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           install-mint: false
@@ -119,7 +119,7 @@ jobs:
         xcode:
         - '16.4' # Swift 6.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           install-mint: true
@@ -131,7 +131,7 @@ jobs:
     name: "Test Carthage support"
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           install-mint: true
@@ -144,7 +144,7 @@ jobs:
     name: "Lint Swift"
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Lint Swift
         run: bundle exec rake lint:swift
@@ -153,7 +153,7 @@ jobs:
     name: "Lint Embedded Libraries"
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Lint Embedded Libraries
         run: bundle exec rake lint:EmbeddedLibraries

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v10
         with:
           only-labels: >
             can't reproduce


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | main.yml |
| `actions/stale` | [`v5`](https://github.com/actions/stale/releases/tag/v5) | [`v10`](https://github.com/actions/stale/releases/tag/v10) | [Release](https://github.com/actions/stale/releases/tag/v10) | stale_issues.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | main.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/stale** (v5 → v10):
  - ⚠️ Label handling changed - verify stale-issue-label and stale-pr-label settings

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
