### PR TITLE
Fix typo in WillDisplayProviding.swift

### DIFF
--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/Providers/WillDisplayProviding.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/Model/Providers/WillDisplayProviding.swift
@@ -17,11 +17,11 @@ extension CallbackContextEpoxyModeled where Self: WillDisplayProviding {
   // MARK: Internal
 
   /// A closure that's called when a view is about to be displayed, before it has been added to the
-  /// view hierarcy.
+  /// view hierarchy.
   typealias WillDisplay = (_ context: CallbackContext) -> Void
 
   /// A closure that's called when the view is about to be displayed, before it has been added to
-  /// the view hierarcy.
+  /// the view hierarchy.
   var willDisplay: WillDisplay? {
     get { self[willDisplayProperty] }
     set { self[willDisplayProperty] = newValue }


### PR DESCRIPTION
Hi, I fixed a documentation typo in `WillDisplayProviding.swift`.

- `hierarcy` → `hierarchy`

Please check out the changes. Thanks!