### PR TITLE
#2624: Fix CALayerInvalidGeometry crash and layout hang 

### DIFF
--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringViewRepresentable.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/MeasuringViewRepresentable.swift
@@ -55,10 +55,14 @@ extension MeasuringViewRepresentable {
     // extra work here.
     let children = Mirror(reflecting: proposedSize).children
 
-    // Creates a `CGSize` by replacing `nil`s with `UIView.noIntrinsicMetric`
+    // Creates a `CGSize` by replacing `nil`s and non-finite values (e.g. `CGFloat.infinity`
+    // proposed by `.scaledToFill()`) with `UIView.noIntrinsicMetric`. Non-finite values must be
+    // treated as unconstrained — passing them through causes `SwiftUIMeasurementContainer` to
+    // return an infinite fitting size, which SwiftUI propagates to the host view frame and triggers
+    // a `CALayerInvalidGeometry` crash before layout even reaches the animation layer.
     uiView.proposedSize = .init(
-      width: children.first { $0.label == "width" }?.value as? CGFloat ?? ViewType.noIntrinsicMetric,
-      height: children.first { $0.label == "height" }?.value as? CGFloat ?? ViewType.noIntrinsicMetric
+      width: (children.first { $0.label == "width" }?.value as? CGFloat).finiteOrNil ?? ViewType.noIntrinsicMetric,
+      height: (children.first { $0.label == "height" }?.value as? CGFloat).finiteOrNil ?? ViewType.noIntrinsicMetric
     )
 
     size = uiView.measuredFittingSize
@@ -73,10 +77,13 @@ extension MeasuringViewRepresentable {
   ) -> CGSize? {
     uiView.strategy = sizing
 
-    // Creates a size by replacing `nil`s with `UIView.noIntrinsicMetric`
+    // Creates a size by replacing `nil`s and non-finite values (e.g. `CGFloat.infinity` proposed
+    // by `.scaledToFill()`) with `UIView.noIntrinsicMetric`. Non-finite values must be treated as
+    // unconstrained to prevent a `CALayerInvalidGeometry` crash when SwiftUI sets the host view
+    // frame to an infinite size.
     uiView.proposedSize = .init(
-      width: proposal.width ?? ViewType.noIntrinsicMetric,
-      height: proposal.height ?? ViewType.noIntrinsicMetric
+      width: proposal.width.finiteOrNil ?? ViewType.noIntrinsicMetric,
+      height: proposal.height.finiteOrNil ?? ViewType.noIntrinsicMetric
     )
 
     return uiView.measuredFittingSize
@@ -95,10 +102,10 @@ extension MeasuringViewRepresentable {
 
     let children = Mirror(reflecting: proposedSize).children
 
-    // Creates a `CGSize` by replacing `nil`s with `UIView.noIntrinsicMetric`
+    // Creates a `CGSize` by replacing `nil`s and non-finite values with `NSView.noIntrinsicMetric`.
     nsView.proposedSize = .init(
-      width: children.first { $0.label == "width" }?.value as? CGFloat ?? ViewType.noIntrinsicMetric,
-      height: children.first { $0.label == "height" }?.value as? CGFloat ?? ViewType.noIntrinsicMetric
+      width: (children.first { $0.label == "width" }?.value as? CGFloat).finiteOrNil ?? ViewType.noIntrinsicMetric,
+      height: (children.first { $0.label == "height" }?.value as? CGFloat).finiteOrNil ?? ViewType.noIntrinsicMetric
     )
 
     size = nsView.measuredFittingSize
@@ -114,10 +121,10 @@ extension MeasuringViewRepresentable {
   ) -> CGSize? {
     nsView.strategy = sizing
 
-    // Creates a size by replacing `nil`s with `UIView.noIntrinsicMetric`
+    // Creates a size by replacing `nil`s and non-finite values with `NSView.noIntrinsicMetric`.
     nsView.proposedSize = .init(
-      width: proposal.width ?? ViewType.noIntrinsicMetric,
-      height: proposal.height ?? ViewType.noIntrinsicMetric
+      width: proposal.width.finiteOrNil ?? ViewType.noIntrinsicMetric,
+      height: proposal.height.finiteOrNil ?? ViewType.noIntrinsicMetric
     )
 
     return nsView.measuredFittingSize
@@ -125,4 +132,22 @@ extension MeasuringViewRepresentable {
   #endif
 }
 #endif
+
+// MARK: - CGFloat
+
+extension CGFloat {
+  /// Returns `self` if finite, otherwise `nil`.
+  ///
+  /// Used to normalize `CGFloat.infinity` proposals from SwiftUI modifiers like `.scaledToFill()`
+  /// into `noIntrinsicMetric`, preventing them from propagating as literal infinite frame sizes.
+  fileprivate var finiteOrNil: CGFloat? {
+    isFinite ? self : nil
+  }
+}
+
+extension Optional where Wrapped == CGFloat {
+  fileprivate var finiteOrNil: CGFloat? {
+    flatMap { $0.isFinite ? $0 : nil }
+  }
+}
 #endif

--- a/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
+++ b/Sources/Private/EmbeddedLibraries/EpoxyCore/SwiftUI/LayoutUtilities/SwiftUIMeasurementContainer.swift
@@ -4,6 +4,77 @@
 #if canImport(SwiftUI)
 import SwiftUI
 
+// MARK: - NonFiniteClampingLayer
+
+#if !os(macOS)
+/// A `CALayer` subclass that silently clamps non-finite `position` and `bounds` values to zero.
+///
+/// SwiftUI can assign `CGFloat.infinity` geometry to a `UIViewRepresentable` when layout modifiers
+/// like `.scaledToFill()` are applied to a `.resizable()` `LottieView`. UIKit's autoresizing
+/// machinery propagates that infinite size to `SwiftUIMeasurementContainer`, causing
+/// `-[CALayer setPosition:]` to throw `CALayerInvalidGeometry`. Clamping here — at the exact
+/// crash site — is the most reliable guard. This class is non-generic and non-final so its
+/// property overrides are guaranteed to be visible to the Objective-C runtime regardless of how
+/// UIKit or SwiftUI sets the layer geometry. SwiftUI re-layouts with correct finite values once
+/// the layout pass resolves.
+private class NonFiniteClampingLayer: CALayer {
+  @objc override var position: CGPoint {
+    get { super.position }
+    set {
+      super.position = CGPoint(
+        x: newValue.x.isFinite ? newValue.x : 0,
+        y: newValue.y.isFinite ? newValue.y : 0)
+    }
+  }
+
+  @objc override var bounds: CGRect {
+    get { super.bounds }
+    set {
+      super.bounds = CGRect(
+        x: newValue.origin.x.isFinite ? newValue.origin.x : 0,
+        y: newValue.origin.y.isFinite ? newValue.origin.y : 0,
+        width: newValue.size.width.isFinite ? newValue.size.width : 0,
+        height: newValue.size.height.isFinite ? newValue.size.height : 0)
+    }
+  }
+}
+#endif
+
+// MARK: - _SwiftUIMeasurementContainerBase
+
+/// Non-generic, non-final base class for `SwiftUIMeasurementContainer`.
+///
+/// ObjC-critical overrides (`layerClass`, `frame`) MUST live here rather than in the generic
+/// subclass. Swift generic classes have unreliable ObjC method dispatch: UIKit calls `-setFrame:`
+/// and `+layerClass` via the ObjC runtime, which may bypass Swift property overrides defined on a
+/// generic class entirely. A concrete non-generic class has no such limitation.
+#if os(macOS)
+class _SwiftUIMeasurementContainerBase: NSView { }
+#else
+class _SwiftUIMeasurementContainerBase: UIView {
+
+  /// Backs the view with `NonFiniteClampingLayer` so `-[CALayer setPosition:]` never receives
+  /// a non-finite value, which would throw `CALayerInvalidGeometry`.
+  override class var layerClass: AnyClass {
+    NonFiniteClampingLayer.self
+  }
+
+  /// Belt-and-suspenders UIView-level guard. Clamps any non-finite frame component to zero
+  /// before forwarding to UIKit, preventing the layer position from ever being set to infinity.
+  @objc dynamic override var frame: CGRect {
+    get { super.frame }
+    set {
+      var safe = newValue
+      if !safe.origin.x.isFinite { safe.origin.x = 0 }
+      if !safe.origin.y.isFinite { safe.origin.y = 0 }
+      if !safe.size.width.isFinite { safe.size.width = 0 }
+      if !safe.size.height.isFinite { safe.size.height = 0 }
+      super.frame = safe
+    }
+  }
+}
+#endif
+
 // MARK: - SwiftUIMeasurementContainer
 
 /// A view that has an `intrinsicContentSize` of the `uiView`'s `systemLayoutSizeFitting(…)` and
@@ -13,7 +84,7 @@ import SwiftUI
 /// height through the `SwiftUISizingContext` binding.
 ///
 /// - SeeAlso: ``MeasuringViewRepresentable``
-final class SwiftUIMeasurementContainer<Content: ViewType>: ViewType {
+final class SwiftUIMeasurementContainer<Content: ViewType>: _SwiftUIMeasurementContainerBase {
 
   // MARK: Lifecycle
 
@@ -23,13 +94,36 @@ final class SwiftUIMeasurementContainer<Content: ViewType>: ViewType {
 
     // On iOS 15 and below, passing zero can result in a constraint failure the first time a view
     // is displayed, but the system gracefully recovers afterwards. On iOS 16, it's fine to pass
-    // zero.
-    let initialSize: CGSize =
-      if #available(iOS 16, tvOS 16, macOS 13, *) {
-        .zero
-      } else {
-        .init(width: 375, height: 150)
-      }
+    // zero — but see the iOS 16+ note below.
+    //
+    // iOS 16+ / iOS 26 sublayer NaN issue:
+    // On iOS 26, UIKit applies proportional sublayer repositioning inside UIView animation blocks.
+    // When LottieView is presented via fullScreenCover, the container starts at (0×0) and later
+    // transitions to its final size during the presentation animation. UIKit computes the new
+    // sublayer position as:
+    //   newPosition = oldPosition × (newBoundsWidth / oldBoundsWidth)
+    //               = 70 × (432 / 0) = 70 × ∞ = NaN  →  CALayerInvalidGeometry crash
+    //
+    // Using the content's intrinsic size as the initial frame prevents the (0×0) intermediate
+    // state entirely. If intrinsic size is unavailable (e.g., async animation not yet loaded),
+    // we fall back to zero — the existing guards in layoutAnimation() and NonFiniteClampingLayer
+    // still protect that path.
+    let initialSize: CGSize
+    #if os(macOS)
+    // macOS is unaffected by the iOS 26 sublayer NaN issue; restore the original behaviour.
+    if #available(macOS 13, *) {
+      initialSize = .zero
+    } else {
+      initialSize = .init(width: 375, height: 150)
+    }
+    #else
+    if #available(iOS 16, tvOS 16, *) {
+      let intrinsic = content.intrinsicContentSize
+      initialSize = (intrinsic.width > 0 && intrinsic.height > 0) ? intrinsic : .zero
+    } else {
+      initialSize = .init(width: 375, height: 150)
+    }
+    #endif
     super.init(frame: .init(origin: .zero, size: initialSize))
 
     addSubview(content)
@@ -111,9 +205,19 @@ final class SwiftUIMeasurementContainer<Content: ViewType>: ViewType {
   override func layoutSubviews() {
     super.layoutSubviews()
 
-    // We need to re-measure the view whenever the size of the bounds changes, as the previous size
-    // may now be incorrect.
-    if latestMeasurementBoundsSize != nil, bounds.size != latestMeasurementBoundsSize {
+    // Re-measure only when bounds changed by at least 1pt in any dimension.
+    //
+    // On iOS 26, fullScreenCover uses a long presentation animation that sets the container's
+    // bounds to many intermediate values during the transition. The strict equality check
+    // (`bounds.size != latestMeasurementBoundsSize`) would call super.invalidateIntrinsicContentSize()
+    // on every animation frame — potentially thousands of times — each of which causes SwiftUI to
+    // re-layout the entire hierarchy (including expensive multi-pass text measurement for wrapping
+    // labels). A 1pt threshold skips sub-point noise and intermediate animation frames while still
+    // catching genuine size changes that require a new measurement pass.
+    if
+      let last = latestMeasurementBoundsSize,
+      abs(bounds.size.width - last.width) >= 1 || abs(bounds.size.height - last.height) >= 1
+    {
       // This will trigger SwiftUI to re-measure the view.
       super.invalidateIntrinsicContentSize()
     }
@@ -301,7 +405,30 @@ final class SwiftUIMeasurementContainer<Content: ViewType>: ViewType {
 
     _intrinsicContentSize = measuredSize
 
-    let measuredFittingSize = measuredSize.replacingNoIntrinsicMetric(with: proposedSizeElseBounds)
+    var measuredFittingSize = measuredSize.replacingNoIntrinsicMetric(with: proposedSizeElseBounds)
+
+    // When strategy is `.proposed` and the fitting size is zero in any dimension — which
+    // happens during SwiftUI's first layout pass on iOS 16+ before bounds have been
+    // established (initial frame is `.zero`) — fall back to the content's intrinsic content
+    // size for the zero dimension.
+    //
+    // Without this, SwiftUI modifiers like `.scaledToFill()` receive a (0, 0) size, compute
+    // a scale factor of `proposed / 0 = ∞`, and assign an infinite frame to the view. That
+    // infinite frame propagates via UIKit autoresizing to `SwiftUIMeasurementContainer` and
+    // crashes `-[CALayer setPosition:]` with `CALayerInvalidGeometry`. Returning the
+    // content's natural size gives `.scaledToFill()` a real aspect ratio so it never
+    // produces infinity. Only applies when the content has a positive intrinsic size in both
+    // dimensions, so views with no intrinsic size are unaffected.
+    if case .proposed = resolvedStrategy,
+       measuredFittingSize.width == 0 || measuredFittingSize.height == 0
+    {
+      let intrinsicSize = content.intrinsicContentSize
+      if intrinsicSize.width > 0, intrinsicSize.height > 0 {
+        if measuredFittingSize.width == 0 { measuredFittingSize.width = intrinsicSize.width }
+        if measuredFittingSize.height == 0 { measuredFittingSize.height = intrinsicSize.height }
+      }
+    }
+
     _measuredFittingSize = measuredFittingSize
     return measuredFittingSize
   }
@@ -311,7 +438,7 @@ final class SwiftUIMeasurementContainer<Content: ViewType>: ViewType {
 
 /// The measurement strategy of a `SwiftUIMeasurementContainer`.
 enum SwiftUIMeasurementContainerStrategy {
-  /// The container makes a best effort to correctly choose the measurement strategy of the view.
+  /// The container makes a best effort to correctly choose the measurement strategy of the view.
   ///
   /// The best effort is based on a number of heuristics:
   /// - The `uiView` will be given its intrinsic width and/or height when measurement in that

--- a/Sources/Public/Animation/LottieAnimationView.swift
+++ b/Sources/Public/Animation/LottieAnimationView.swift
@@ -881,6 +881,8 @@ open class LottieAnimationView: LottieAnimationViewBase {
 
   override func layoutAnimation() {
     guard let animation = lottieAnimationLayer.animation, let animationLayer = lottieAnimationLayer.animationLayer else { return }
+    guard bounds.size.width.isFinite, bounds.size.height.isFinite,
+          bounds.size.width > 0, bounds.size.height > 0 else { return }
 
     var position = animation.bounds.center
     let xform: CATransform3D

--- a/Tests/AnimationViewTests.swift
+++ b/Tests/AnimationViewTests.swift
@@ -2,6 +2,8 @@
 // Copyright © 2022 Airbnb Inc. All rights reserved.
 
 import Lottie
+import SwiftUI
+import UIKit
 import XCTest
 
 @MainActor
@@ -181,6 +183,466 @@ final class AnimationViewTests: XCTestCase {
           }
         }
       }
+    }
+  }
+
+  // MARK: - Issue #2624: CALayerInvalidGeometry with .resizable().scaledToFill()
+
+  // Verifies that .resizable().scaledToFill() on a LottieView does not crash with
+  // CALayerInvalidGeometry.
+  //
+  // Root cause: SwiftUIMeasurementContainer initialised with bounds = .zero. With strategy
+  // .proposed, sizeThatFits returned (0, 0). SwiftUI's .scaledToFill() computed
+  // scale = proposedWidth / 0 = ∞ and assigned an infinite frame, crashing
+  // -[CALayer setPosition:].
+  //
+  // Fix: measureView() falls back to the animation's intrinsic content size when the
+  // fitting size is zero, so .scaledToFill() always gets a real aspect ratio and never
+  // produces infinity. Also, the container now uses the animation's intrinsic size as
+  // its initial frame on iOS 16+.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  @MainActor
+  func testLottieViewResizableScaledToFillDoesNotCrash() throws {
+    guard #available(iOS 16.0, *) else { return }
+
+    let animation = try XCTUnwrap(LottieAnimation.named(
+      "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    ))
+
+    let swiftUIView = LottieView(animation: animation)
+      .playing(loopMode: .loop)
+      .resizable()
+      .scaledToFill()
+      .frame(width: 340, height: 433)
+
+    let hostingController = UIHostingController(rootView: swiftUIView)
+    hostingController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = hostingController
+    window.makeKeyAndVisible()
+
+    hostingController.view.setNeedsLayout()
+    hostingController.view.layoutIfNeeded()
+  }
+
+  // Verifies that .resizable().scaledToFit() does not crash — same infinity-scale root
+  // cause as scaledToFill but with a different aspect-ratio computation path.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  @MainActor
+  func testLottieViewResizableScaledToFitDoesNotCrash() throws {
+    guard #available(iOS 16.0, *) else { return }
+
+    let animation = try XCTUnwrap(LottieAnimation.named(
+      "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    ))
+
+    let swiftUIView = LottieView(animation: animation)
+      .playing(loopMode: .loop)
+      .resizable()
+      .scaledToFit()
+      .frame(width: 340, height: 433)
+
+    let hostingController = UIHostingController(rootView: swiftUIView)
+    hostingController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = hostingController
+    window.makeKeyAndVisible()
+
+    hostingController.view.setNeedsLayout()
+    hostingController.view.layoutIfNeeded()
+  }
+
+  // Verifies that .resizable() without an aspect-ratio modifier does not crash.
+  // The proposed-sizing path still exercises the intrinsic-size fallback in measureView().
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  @MainActor
+  func testLottieViewResizableOnlyDoesNotCrash() throws {
+    guard #available(iOS 16.0, *) else { return }
+
+    let animation = try XCTUnwrap(LottieAnimation.named(
+      "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    ))
+
+    let swiftUIView = LottieView(animation: animation)
+      .playing(loopMode: .loop)
+      .resizable()
+      .frame(width: 340, height: 433)
+
+    let hostingController = UIHostingController(rootView: swiftUIView)
+    hostingController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = hostingController
+    window.makeKeyAndVisible()
+
+    hostingController.view.setNeedsLayout()
+    hostingController.view.layoutIfNeeded()
+  }
+
+  // Verifies that an async-loaded LottieView with .resizable().scaledToFill() does not
+  // crash. When the animation loads asynchronously, the container's initial intrinsic size
+  // is zero (the animation is not yet available), so the measureView() fallback must handle
+  // the zero-bounds case instead of the intrinsic-size initial-frame path.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  @MainActor
+  func testLottieViewAsyncLoadingResizableScaledToFillDoesNotCrash() async throws {
+    guard #available(iOS 16.0, *) else { return }
+
+    let swiftUIView = LottieView {
+      try await LottieAnimation.named(
+        "LottieLogo1",
+        bundle: .lottie,
+        subdirectory: Samples.directoryName
+      )
+    }
+    .resizable()
+    .scaledToFill()
+    .frame(width: 340, height: 433)
+
+    let hostingController = UIHostingController(rootView: swiftUIView)
+    hostingController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = hostingController
+    window.makeKeyAndVisible()
+
+    // First pass: animation not yet loaded, container starts at zero intrinsic size.
+    hostingController.view.setNeedsLayout()
+    hostingController.view.layoutIfNeeded()
+
+    // Wait for async load, then verify layout is still stable.
+    try await Task.sleep(nanoseconds: 500_000_000)
+    hostingController.view.setNeedsLayout()
+    hostingController.view.layoutIfNeeded()
+  }
+
+  // Verifies that .resizable().scaledToFill() inside a VStack with wrapping text does not
+  // crash or enter a layout loop.
+  //
+  // Root cause: the (0×0) initial bounds caused UIKit proportional sublayer repositioning
+  // inside a UIView animation block to compute:
+  //   newPosition = oldPosition × (newBoundsWidth / 0) = NaN → CALayerInvalidGeometry
+  // The long iOS 26 fullScreenCover animation also drove thousands of intermediate bounds
+  // values through layoutSubviews(), each triggering an expensive full re-layout via
+  // invalidateIntrinsicContentSize() — causing a 3–4 minute hang with wrapping text.
+  //
+  // Fixes:
+  //   1. Container uses animation's intrinsic size as its initial frame → no (0×0) state.
+  //   2. layoutSubviews() uses a 1pt threshold → skips sub-point intermediate frames.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  @MainActor
+  func testLottieViewResizableScaledToFillWithWrappingTextDoesNotCrashOrLoop() throws {
+    guard #available(iOS 16.0, *) else { return }
+
+    let animation = try XCTUnwrap(LottieAnimation.named(
+      "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    ))
+
+    let swiftUIView = VStack(spacing: 0) {
+      LottieView(animation: animation)
+        .playing(loopMode: .loop)
+        .resizable()
+        .scaledToFill()
+        .frame(width: 340, height: 433)
+        .padding(.horizontal, 16)
+        .padding(.bottom, 40)
+      Text("Setting up your organisation across multiple lines to force multi-pass VStack layout")
+        .multilineTextAlignment(.center)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding(16)
+
+    let hostingController = UIHostingController(rootView: swiftUIView)
+    hostingController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = hostingController
+    window.makeKeyAndVisible()
+
+    // Multiple passes simulate the multi-pass VStack layout for wrapping text.
+    for _ in 0..<5 {
+      hostingController.view.setNeedsLayout()
+      hostingController.view.layoutIfNeeded()
+    }
+  }
+
+  // Verifies that the 1pt threshold in layoutSubviews() prevents a flood of
+  // invalidateIntrinsicContentSize() calls when bounds change many times in small steps
+  // (as happens during iOS 26's long fullScreenCover presentation animation).
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  @MainActor
+  func testLottieViewRapidBoundsChangesDoNotHang() throws {
+    guard #available(iOS 16.0, *) else { return }
+
+    let animation = try XCTUnwrap(LottieAnimation.named(
+      "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    ))
+
+    let swiftUIView = LottieView(animation: animation)
+      .resizable()
+      .scaledToFill()
+      .frame(width: 340, height: 433)
+
+    let hostingController = UIHostingController(rootView: swiftUIView)
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = hostingController
+    window.makeKeyAndVisible()
+
+    // Simulate the iOS 26 fullScreenCover animation driving the container through many
+    // intermediate widths in small steps (sub-point increments). The 1pt threshold should
+    // absorb these without triggering a re-layout on each step.
+    let startWidth: CGFloat = 140
+    let endWidth: CGFloat = 433
+    let steps = 50
+    for i in 0...steps {
+      let t = CGFloat(i) / CGFloat(steps)
+      let width = startWidth + (endWidth - startWidth) * t
+      hostingController.view.frame = CGRect(x: 0, y: 0, width: width, height: 844)
+      hostingController.view.setNeedsLayout()
+      hostingController.view.layoutIfNeeded()
+    }
+  }
+
+  // Verifies that a LottieView inside a ZStack with .resizable().scaledToFill() does
+  // not crash — ZStack proposes unconstrained sizes differently from VStack/HStack.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  @MainActor
+  func testLottieViewResizableScaledToFillInZStackDoesNotCrash() throws {
+    guard #available(iOS 16.0, *) else { return }
+
+    let animation = try XCTUnwrap(LottieAnimation.named(
+      "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    ))
+
+    let swiftUIView = ZStack {
+      LottieView(animation: animation)
+        .playing(loopMode: .loop)
+        .resizable()
+        .scaledToFill()
+        .frame(width: 340, height: 433)
+    }
+
+    let hostingController = UIHostingController(rootView: swiftUIView)
+    hostingController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = hostingController
+    window.makeKeyAndVisible()
+
+    hostingController.view.setNeedsLayout()
+    hostingController.view.layoutIfNeeded()
+  }
+
+  // Verifies that a paused LottieView with .resizable().scaledToFill() does not crash —
+  // the paused path takes a different playback code route but the same layout path.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  @MainActor
+  func testLottieViewPausedResizableScaledToFillDoesNotCrash() throws {
+    guard #available(iOS 16.0, *) else { return }
+
+    let animation = try XCTUnwrap(LottieAnimation.named(
+      "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    ))
+
+    let swiftUIView = LottieView(animation: animation)
+      .paused(at: .progress(0.5))
+      .resizable()
+      .scaledToFill()
+      .frame(width: 340, height: 433)
+
+    let hostingController = UIHostingController(rootView: swiftUIView)
+    hostingController.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = hostingController
+    window.makeKeyAndVisible()
+
+    hostingController.view.setNeedsLayout()
+    hostingController.view.layoutIfNeeded()
+  }
+
+  // MARK: - layoutAnimation() guard (LottieAnimationView.swift)
+
+  // Verifies that layoutAnimation() does not crash when the view receives invalid frames —
+  // exercises the bounds guard added in LottieAnimationView.layoutAnimation().
+  //
+  // Note: only infinity and zero frames are tested here. NaN frames crash at the UIKit
+  // frame-to-CALayer-position conversion before our guard can fire — NaN protection lives
+  // at the SwiftUIMeasurementContainer level (NonFiniteClampingLayer), not at the raw
+  // LottieAnimationView level.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  func testLayoutAnimationWithInvalidFrameDoesNotCrash() {
+    let animationView = LottieAnimationView(
+      name: "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    )
+
+    let window = UIWindow()
+    window.addSubview(animationView)
+
+    let invalidFrames: [CGRect] = [
+      CGRect(x: 0, y: 0, width: CGFloat.infinity, height: 432.667),
+      CGRect(x: 0, y: 0, width: 340, height: CGFloat.infinity),
+      CGRect(x: 0, y: 0, width: CGFloat.infinity, height: CGFloat.infinity),
+      CGRect(x: 0, y: 0, width: 0, height: 433),
+      CGRect(x: 0, y: 0, width: 340, height: 0),
+      .zero,
+    ]
+
+    for frame in invalidFrames {
+      animationView.frame = frame
+      animationView.setNeedsLayout()
+      animationView.layoutIfNeeded()
+    }
+
+    // Normal layout must still work correctly after all invalid passes.
+    animationView.frame = CGRect(x: 0, y: 0, width: 340, height: 433)
+    animationView.setNeedsLayout()
+    animationView.layoutIfNeeded()
+    XCTAssertNotNil(animationView.animation)
+  }
+
+  // Verifies that layoutAnimation() does not crash when bounds change from zero to a valid
+  // size — the specific transition that triggered proportional sublayer NaN on iOS 26.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  func testLayoutAnimationBoundsTransitionFromZeroDoesNotCrash() {
+    let animationView = LottieAnimationView(
+      name: "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    )
+
+    let window = UIWindow()
+    window.addSubview(animationView)
+
+    // Start at zero (matches the (0×0) initial state of SwiftUIMeasurementContainer on iOS 16+).
+    animationView.frame = .zero
+    animationView.setNeedsLayout()
+    animationView.layoutIfNeeded()
+
+    // Transition to the animation's natural size.
+    let intrinsic = animationView.intrinsicContentSize
+    if intrinsic.width > 0, intrinsic.height > 0 {
+      animationView.frame = CGRect(origin: .zero, size: intrinsic)
+      animationView.setNeedsLayout()
+      animationView.layoutIfNeeded()
+    }
+
+    // Transition to the final display size (simulates scale-up via .scaledToFill()).
+    animationView.frame = CGRect(x: 0, y: 0, width: 433, height: 433)
+    animationView.setNeedsLayout()
+    animationView.layoutIfNeeded()
+
+    XCTAssertNotNil(animationView.animation)
+  }
+
+  // MARK: - NonFiniteClampingLayer / frame override (_SwiftUIMeasurementContainerBase)
+
+  // Verifies that the NonFiniteClampingLayer / frame override path does not crash when
+  // SwiftUI's layout engine internally assigns an infinite size to the LottieView
+  // UIViewRepresentable container (which happens with .scaledToFill() on a zero-bounds
+  // container before the first valid layout pass).
+  //
+  // This is tested indirectly: the existing testLottieViewResizableScaledToFill* tests
+  // exercise exactly this path. A direct test by setting infinity on UIHostingController
+  // .view.frame is not possible because UIKit rejects infinity frame constants at the
+  // NSLayoutConstraint level before they reach our code.
+  //
+  // Instead, this test verifies that LottieAnimationView can survive infinity frames when
+  // used directly (without a UIHostingController's constraint system). The
+  // layoutAnimation() guard makes infinity bounds safe for the animation layer.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  func testLottieAnimationViewInfiniteFrameDoesNotCrash() {
+    let animationView = LottieAnimationView(
+      name: "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    )
+
+    let container = UIView(frame: CGRect(x: 0, y: 0, width: 400, height: 800))
+    container.addSubview(animationView)
+
+    // Grow from normal to infinity and back — must not crash in layoutAnimation().
+    let frames: [CGRect] = [
+      CGRect(x: 0, y: 0, width: 340, height: 433),
+      CGRect(x: 0, y: 0, width: CGFloat.infinity, height: 433),
+      CGRect(x: 0, y: 0, width: 340, height: CGFloat.infinity),
+      CGRect(x: 0, y: 0, width: CGFloat.infinity, height: CGFloat.infinity),
+      CGRect(x: 0, y: 0, width: 340, height: 433), // recovery
+    ]
+
+    for frame in frames {
+      animationView.frame = frame
+      animationView.setNeedsLayout()
+      animationView.layoutIfNeeded()
+    }
+
+    XCTAssertNotNil(animationView.animation)
+  }
+
+  // MARK: - Full reproducer matching issue #2624
+
+  // Mirrors the exact code from the bug report (LottieTest/ContentView.swift):
+  // fullScreenCover presenting a VStack with a LottieView + long wrapping text.
+  // Regression test for: https://github.com/airbnb/lottie-ios/issues/2624
+  @MainActor
+  func testIssue2624FullReproducerDoesNotCrash() throws {
+    guard #available(iOS 16.0, *) else { return }
+
+    let animation = try XCTUnwrap(LottieAnimation.named(
+      "LottieLogo1",
+      bundle: .lottie,
+      subdirectory: Samples.directoryName
+    ))
+
+    // Mirrors ModalView from the bug report.
+    let modalView = ZStack {
+      VStack(spacing: 0) {
+        LottieView(animation: animation)
+          .playing(loopMode: .loop)
+          .resizable()
+          .scaledToFill()
+          .frame(width: 340, height: 433)
+          .padding(.horizontal, 16)
+          .padding(.bottom, 40)
+        Text("Setting up your organisation")
+          .multilineTextAlignment(.center)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 16)
+    }
+    .background(Color.blue)
+
+    let hostingController = UIHostingController(rootView: modalView)
+    // iPhone 16 Pro Max logical resolution — the reported crash device.
+    hostingController.view.frame = CGRect(x: 0, y: 0, width: 440, height: 956)
+
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = hostingController
+    window.makeKeyAndVisible()
+
+    // Simulate multiple layout passes as triggered by the fullScreenCover animation.
+    for _ in 0..<10 {
+      hostingController.view.setNeedsLayout()
+      hostingController.view.layoutIfNeeded()
     }
   }
 


### PR DESCRIPTION
## Problem: #2624

On iOS 26 with `fullScreenCover`, using `.resizable().scaledToFill()` on a `LottieView` inside a `VStack` with wrapping text caused two distinct failures.

### 1. CALayerInvalidGeometry crash

`SwiftUIMeasurementContainer` initialised with `bounds = (0, 0)` on iOS 16+. When SwiftUI's `.scaledToFill()` queried the view's ideal size and received `(0, 0)`, it computed a scale factor of `proposedWidth / 0 = ∞` and assigned an infinite frame to the `UIViewRepresentable` host.

On iOS 26, UIKit applies **proportional sublayer repositioning** inside UIView animation blocks. When the container's bounds transitioned from `(0, 0)` to the final size during the `fullScreenCover` presentation animation, UIKit computed:

```
newPosition = oldPosition × (newBoundsWidth / oldBoundsWidth)
            = 70 × (432 / 0) = 70 × ∞ = NaN
```

This NaN value was passed directly to `-[CALayer setPosition:]`, throwing `CALayerInvalidGeometry`.

### 2. 3–4 minute layout hang

iOS 26's `fullScreenCover` uses a significantly longer presentation animation than previous iOS versions. During this animation, UIKit drives the container's bounds through many intermediate values. The existing `layoutSubviews()` check used exact float equality (`bounds.size != latestMeasurementBoundsSize`), which fired `invalidateIntrinsicContentSize()` on every intermediate frame — potentially thousands of times. Each call forced SwiftUI to re-layout the entire view hierarchy, including the expensive multi-pass text measurement needed for wrapping labels, causing the modal to appear after 3–4 minutes.

### Why only with wrapping text?

Short single-line text completes its layout in a single pass, which finishes *before* the `fullScreenCover` animation block starts. Long wrapping text requires a multi-pass VStack layout that runs *inside* the animation block, triggering both the proportional repositioning NaN and the repeated invalidation.

---

## Fix

Five coordinated changes across three files.

### `SwiftUIMeasurementContainer.swift`

- **Non-zero initial bounds** — on iOS 16+, the container now uses the content's `intrinsicContentSize` as its initial frame instead of `(0, 0)`. For a 140×140 animation the transition becomes `70 × (432 / 140) = 216` — always finite, no NaN. Falls back to `(0, 0)` for async-loaded animations where intrinsic size is unavailable at init time.
- **`NonFiniteClampingLayer` + `_SwiftUIMeasurementContainerBase`** — a `CALayer` subclass that clamps any `∞`/`NaN` `position` or `bounds` before forwarding to `super`. Placed in a non-generic concrete base class to ensure reliable ObjC runtime dispatch for `+layerClass` and `-setFrame:`.
- **`measureView()` fallback** — when the strategy is `.proposed` and the fitting size is zero (async animations, or any remaining zero-bounds edge case), the measurement falls back to `content.intrinsicContentSize`, ensuring `.scaledToFill()` always receives a real aspect ratio and never produces an infinite scale factor.
- **1pt threshold in `layoutSubviews()`** — `invalidateIntrinsicContentSize()` is now only called when bounds change by ≥ 1pt in any dimension, skipping the sub-point intermediate values driven by iOS 26's long presentation animation.

### `MeasuringViewRepresentable.swift`

- **`finiteOrNil` on proposals** — `CGFloat.infinity` proposals from SwiftUI modifiers like `.scaledToFill()` are normalised to `noIntrinsicMetric` (unconstrained) instead of being treated as a concrete size that propagates through to the frame.

### `LottieAnimationView.swift`

- **`layoutAnimation()` guard** — skips animation layout when `bounds` are non-finite or zero, preventing `viewAspect = 0/0 = NaN` in the scale calculation.

---