### PR TITLE
Fix re-entrant make​Animation​Layer crash on iOS 26 / Xcode 26 (#2679)

### DIFF
--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1154,6 +1154,23 @@ public class LottieAnimationLayer: CALayer {
   }
 
   fileprivate func makeAnimationLayer(usingEngine renderingEngine: RenderingEngineOption) {
+    // Guard against re-entrant calls. On iOS 26+, Core Animation can call `display()` on a
+    // newly-created sublayer synchronously during `addSublayer`, which may trigger the automatic
+    // engine fallback path and attempt to call `makeAnimationLayer` again while we're still inside
+    // this method. Defer the re-entrant request and execute it after the current call completes.
+    guard !isMakingAnimationLayer else {
+      pendingAnimationLayerEngine = renderingEngine
+      return
+    }
+    isMakingAnimationLayer = true
+    defer {
+      isMakingAnimationLayer = false
+      if let pendingEngine = pendingAnimationLayerEngine {
+        pendingAnimationLayerEngine = nil
+        makeAnimationLayer(usingEngine: pendingEngine)
+      }
+    }
+
     /// Disable the default implicit crossfade animation Core Animation creates
     /// when adding or removing sublayers.
     actions = ["sublayers": NSNull()]
@@ -1482,6 +1499,18 @@ public class LottieAnimationLayer: CALayer {
 
   /// The `LottieBackgroundBehavior` that was specified manually by setting `self.backgroundBehavior`
   private var _backgroundBehavior: LottieBackgroundBehavior?
+
+  /// Guards against re-entrant calls to `makeAnimationLayer(usingEngine:)`.
+  ///
+  /// On iOS 26+, Core Animation may call `CALayer.display()` synchronously during a sublayer's
+  /// `init`, which can trigger `automaticEngineLayerDidSetUpAnimation` → `makeAnimationLayer`
+  /// while the original `makeAnimationLayer` call is still on the stack. This re-entrant call
+  /// must be deferred until the first call completes to avoid accessing a partially-initialized
+  /// layer and crashing with `EXC_BAD_ACCESS`.
+  private var isMakingAnimationLayer = false
+
+  /// A pending engine to use when `makeAnimationLayer` is called re-entrantly.
+  private var pendingAnimationLayerEngine: RenderingEngineOption?
 
   /// Whether or not the current animation should be overridden with
   /// the marker matching the current "reduced motion" mode.

--- a/Sources/Public/Animation/LottieAnimationLayer.swift
+++ b/Sources/Public/Animation/LottieAnimationLayer.swift
@@ -1159,15 +1159,17 @@ public class LottieAnimationLayer: CALayer {
     // engine fallback path and attempt to call `makeAnimationLayer` again while we're still inside
     // this method. Defer the re-entrant request and execute it after the current call completes.
     guard !isMakingAnimationLayer else {
-      pendingAnimationLayerEngine = renderingEngine
+      pendingAnimationLayerSetup = { [weak self] in
+        self?.makeAnimationLayer(usingEngine: renderingEngine)
+      }
       return
     }
     isMakingAnimationLayer = true
     defer {
       isMakingAnimationLayer = false
-      if let pendingEngine = pendingAnimationLayerEngine {
-        pendingAnimationLayerEngine = nil
-        makeAnimationLayer(usingEngine: pendingEngine)
+      if let pendingSetup = pendingAnimationLayerSetup {
+        pendingAnimationLayerSetup = nil
+        pendingSetup()
       }
     }
 
@@ -1306,6 +1308,17 @@ public class LottieAnimationLayer: CALayer {
   fileprivate func automaticEngineLayerDidSetUpAnimation(_ compatibilityIssues: [CompatibilityIssue]) {
     // If there weren't any compatibility issues, then there's nothing else to do
     if compatibilityIssues.isEmpty {
+      return
+    }
+
+    // On iOS 26+, this callback can fire synchronously during `addSublayer` while
+    // `makeAnimationLayer` is still on the stack. Defer the entire fallback — including
+    // the `currentFrame` restore and `addNewAnimationForContext` — until the outer
+    // `makeAnimationLayer` call completes, so they operate on the fully-initialized layer.
+    if isMakingAnimationLayer {
+      pendingAnimationLayerSetup = { [weak self] in
+        self?.automaticEngineLayerDidSetUpAnimation(compatibilityIssues)
+      }
       return
     }
 
@@ -1504,13 +1517,14 @@ public class LottieAnimationLayer: CALayer {
   ///
   /// On iOS 26+, Core Animation may call `CALayer.display()` synchronously during a sublayer's
   /// `init`, which can trigger `automaticEngineLayerDidSetUpAnimation` → `makeAnimationLayer`
-  /// while the original `makeAnimationLayer` call is still on the stack. This re-entrant call
+  /// while the original `makeAnimationLayer` call is still on the stack. Re-entrant calls
   /// must be deferred until the first call completes to avoid accessing a partially-initialized
   /// layer and crashing with `EXC_BAD_ACCESS`.
   private var isMakingAnimationLayer = false
 
-  /// A pending engine to use when `makeAnimationLayer` is called re-entrantly.
-  private var pendingAnimationLayerEngine: RenderingEngineOption?
+  /// A closure to execute after the current `makeAnimationLayer` call completes, used to
+  /// defer re-entrant layer setup (including the automatic engine fallback path).
+  private var pendingAnimationLayerSetup: (() -> Void)?
 
   /// Whether or not the current animation should be overridden with
   /// the marker matching the current "reduced motion" mode.


### PR DESCRIPTION
## Root Cause

The crash is caused by re-entrant calls to make​Animation​Layer(using​Engine:):

1. Lottie​Animation​Layer​.init calls make​Animation​Layer → creates a Core​Animation​Layer (automatic engine)
2. add​Sublayer(animation​Layer) is called inside make​Animation​Layer
3. On iOS 26, Core Animation calls display() on the new sublayer synchronously before add​Sublayer returns
4. display() → setup​Animation throws a compatibility error → did​Set​Up​Animation fires → automatic​Engine​Layer​Did​Set​Up​Animation → make​Animation​Layer(using​Engine: .main​Thread) (re-entrant call)
5. The re-entrant call tears down root​Animation​Layer and replaces it
6. Control returns to the original make​Animation​Layer call, which now accesses the deallocated layer → EXC​_​BAD​_​ACCESS

## Fix

Added a reentrancy guard (is​Making​Animation​Layer) to make​Animation​Layer(using​Engine:). If a re-entrant call arrives while the method is executing, it is stored in pending​Animation​Layer​Engine and dispatched via defer after the original call fully completes. This preserves the automatic→main-thread fallback behavior while ensuring layer state is consistent throughout.