### PR TITLE
1. Gradient stroke not rendering properly on main thread #2205 and Xcode 26 and later versions crash

### DIFF
--- a/Sources/Private/MainThread/LayerContainers/CompLayers/CompositionLayer.swift
+++ b/Sources/Private/MainThread/LayerContainers/CompLayers/CompositionLayer.swift
@@ -29,7 +29,11 @@ class CompositionLayer: CALayer, KeypathSearchable {
     keypathName = layer.name
     childKeypaths = [transformNode.transformProperties]
     super.init()
-    anchorPoint = .zero
+    // Set actions BEFORE setting anchorPoint so CoreAnimation's implicit
+    // animation lookup finds NSNull and skips animation creation.
+    // In Xcode 26 / iOS 26 the animation-creation path dereferences a pointer
+    // that is null when the layer is not yet part of a tree, causing a crash at
+    // -[CALayer setAnchorPoint:] when actions has not been configured first.
     actions = [
       "opacity": NSNull(),
       "transform": NSNull(),
@@ -41,9 +45,8 @@ class CompositionLayer: CALayer, KeypathSearchable {
       "shadowColor": NSNull(),
       "shadowRadius": NSNull(),
     ]
+    anchorPoint = .zero
 
-    contentsLayer.anchorPoint = .zero
-    contentsLayer.bounds = CGRect(origin: .zero, size: size)
     contentsLayer.actions = [
       "opacity": NSNull(),
       "transform": NSNull(),
@@ -52,6 +55,8 @@ class CompositionLayer: CALayer, KeypathSearchable {
       "sublayerTransform": NSNull(),
       "hidden": NSNull(),
     ]
+    contentsLayer.anchorPoint = .zero
+    contentsLayer.bounds = CGRect(origin: .zero, size: size)
     compositingFilter = layer.blendMode.filterName
     addSublayer(contentsLayer)
 

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientStrokeRenderer.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientStrokeRenderer.swift
@@ -32,6 +32,11 @@ final class GradientStrokeRenderer: PassThroughOutputNode, Renderable {
     return updates || strokeRender.hasUpdate || gradientRender.hasUpdate
   }
 
+  override func hasRenderUpdates(_ forFrame: CGFloat) -> Bool {
+    let updates = super.hasRenderUpdates(forFrame)
+    return updates || strokeRender.hasUpdate || gradientRender.hasUpdate
+  }
+
   func updateShapeLayer(layer _: CAShapeLayer) {
     /// Not Applicable
   }

--- a/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientStrokeNode.swift
+++ b/Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientStrokeNode.swift
@@ -124,13 +124,13 @@ final class GradientStrokeNode: AnimatorNode, RenderNode {
     /// Update gradient properties
     strokeRender.gradientRender.start = strokeProperties.startPoint.value.pointValue
     strokeRender.gradientRender.end = strokeProperties.endPoint.value.pointValue
-    strokeRender.gradientRender.opacity = strokeProperties.opacity.value.cgFloatValue
+    strokeRender.gradientRender.opacity = strokeProperties.opacity.value.cgFloatValue * 0.01
     strokeRender.gradientRender.colors = strokeProperties.colors.value.map { CGFloat($0) }
     strokeRender.gradientRender.type = strokeProperties.gradientType
     strokeRender.gradientRender.numberOfColors = strokeProperties.numberOfColors
 
     /// Now update stroke properties
-    strokeRender.strokeRender.opacity = strokeProperties.opacity.value.cgFloatValue
+    strokeRender.strokeRender.opacity = strokeProperties.opacity.value.cgFloatValue * 0.01
     strokeRender.strokeRender.width = strokeProperties.width.value.cgFloatValue
     strokeRender.strokeRender.miterLimit = strokeProperties.miterLimit
     strokeRender.strokeRender.lineCap = strokeProperties.lineCap


### PR DESCRIPTION
1. Gradient stroke not rendering properly on main thread #2205  

**Problem:**  
Gradient strokes animated on the main thread (legacy node render system) rendered as a solid color instead of updating the gradient correctly across frames. The stroke would get stuck displaying either the first or last gradient color seen when the path last changed.

**Root Causes:**

- **`GradientStrokeRenderer` missing `hasRenderUpdates` override**  
  `PassThroughOutputNode.hasRenderUpdates` only checks for upstream path changes. When only gradient properties (colors, start/end points, opacity) changed — but the stroke path was static — the method returned `false`, preventing `setNeedsDisplay()` from being called. The layer used its last cached drawing indefinitely.

- **Opacity not normalized in `GradientStrokeNode.rebuildOutputs`**  
  Lottie stores opacity as 0–100. Both `StrokeNode` and `GradientFillNode` normalize with `* 0.01` before passing to renderers. `GradientStrokeNode` was missing this, passing values like `100` instead of `1.0`. Since `CGContext.setAlpha` clamps to `[0,1]`, any non-zero opacity appeared fully opaque — making animated opacity non-functional on gradient strokes.

**Fix**

1. Override `hasRenderUpdates` in `GradientStrokeRenderer` to check `strokeRender.hasUpdate || gradientRender.hasUpdate`, matching the existing `hasOutputUpdates` override.
2. Add `* 0.01` normalization for opacity in `GradientStrokeNode.rebuildOutputs` for both `gradientRender.opacity` and `strokeRender.opacity`.

**Why the GPU renderer was unaffected:**  
The Core Animation renderer uses `CAGradientLayer`/`CAShapeLayer` property assignments directly — no `hasRenderUpdates` gating — so it always picked up property changes.

**Files changed:**

- `Sources/Private/MainThread/NodeRenderSystem/Nodes/OutputNodes/Renderables/GradientStrokeRenderer.swift`
- `Sources/Private/MainThread/NodeRenderSystem/Nodes/RenderNodes/GradientStrokeNode.swift`

**Workaround (now unnecessary):**  
Using gradient fill instead of gradient stroke.

-------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------



2. Xcode 26 and later versions crash #2679

**Problem**

Apps using Lottie crash immediately on launch when built with Xcode 26 / iOS 26 SDK with:

EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x0000000000000039
com.apple.main-thread
0 QuartzCore -[CALayer setAnchorPoint:] + 116
1 Enjoy CompositionLayer.init(layer:size:) + 32
2 Enjoy PreCompositionLayer.init(...) + 34
...

**Root Cause**

In `CompositionLayer.init(layer:size:)`, `anchorPoint = .zero` was called on line 32 before the `actions` dictionary was configured. When `setAnchorPoint:` fires, CoreAnimation looks up the `"anchorPoint"` key in the layer's `actions` dictionary to decide whether to create an implicit animation. Since `actions` was `nil` at that point, CoreAnimation entered the animation-creation path. In Xcode 26 / iOS 26's updated QuartzCore, that code path dereferences a pointer (likely a transaction or display-link context object) that is null when the layer hasn't been added to any layer tree yet — hence the crash at address `0x39` (57 bytes offset from null).

The same ordering problem existed for `contentsLayer.anchorPoint = .zero`, which was also set before `contentsLayer.actions`.

**Fix**

In `CompositionLayer.init(layer:size:)`:

- Assign `actions = [...]` **before** `anchorPoint = .zero` on `self`, so `setAnchorPoint:` immediately finds `NSNull` in the actions dictionary and skips animation creation.
- Apply the same reordering to `contentsLayer`: set `contentsLayer.actions` before `contentsLayer.anchorPoint = .zero`.

This is backward-compatible — suppressing implicit animations during init is the intended behavior; the ordering was simply never enforced by older QuartzCore versions.

**File changed**

- `Sources/Private/MainThread/LayerContainers/CompLayers/CompositionLayer.swift`