### PR TITLE
ci: declare read-only permissions on CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build-package:
     name: "Build Package"


### PR DESCRIPTION
This adds a top-level `permissions: contents: read` block to the CI workflow (`main.yml`).

GitHub Actions tokens are granted broad read/write access by default. Declaring explicit permissions restricts the token scope to only what the workflow needs, reducing the blast radius if a dependency or action is compromised.

The CI workflow only checks out code and runs builds/tests, so `contents: read` is sufficient.

Reference: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token